### PR TITLE
Fix scoreboard initialization

### DIFF
--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsPlugin.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsPlugin.java
@@ -145,9 +145,6 @@ public final class BigDoorsPlugin extends JavaPlugin implements IBigDoorsPlatfor
             bigDoorsSpigotPlatform = initPlatform();
         initialized = true;
 
-        // TODO: Remove this before any release.
-        printDebug();
-
         if (bigDoorsSpigotPlatform == null)
         {
             log.at(Level.SEVERE).log("Failed to enable BigDoors: Platform could not be initialized!");
@@ -156,6 +153,9 @@ public final class BigDoorsPlugin extends JavaPlugin implements IBigDoorsPlatfor
 
         LOG_BACK_CONFIGURATOR.setLevel(bigDoorsSpigotPlatform.getBigDoorsConfig().logLevel()).apply();
         restartableHolder.initialize();
+
+        // TODO: Remove this before any release.
+        printDebug();
     }
 
     @Override


### PR DESCRIPTION
- The scoreboard's initialization was not handled properly in the GlowingBlockSpawner class; The scoreboard would not get (re)initialized in the initialization function which resulted in an NPE. Additionally, the whole method of initialization could be simplified a bit by just doing it in the initialize method.
- Fixed some flogger statements logging new exceptions instead of stacktraces.