### PR TITLE
Fix/type init

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doortypes/DoorType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doortypes/DoorType.java
@@ -102,7 +102,7 @@ public abstract class DoorType
      * @return The {@link DoorSerializer}.
      */
     @SuppressWarnings("ConstantConditions")
-    public DoorSerializer<?> getDoorSerializer()
+    public final DoorSerializer<?> getDoorSerializer()
     {
         if (doorSerializer != null)
             return doorSerializer;

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/extensions/DoorTypeInitializer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/extensions/DoorTypeInitializer.java
@@ -201,8 +201,10 @@ final class DoorTypeInitializer
             final Class<?> typeClass = doorTypeClassLoader.loadClass(typeInfo.mainClass);
             final Method getter = typeClass.getDeclaredMethod("get");
             doorType = (DoorType) getter.invoke(null);
+            // Retrieve the serializer to ensure that it could be initialized successfully.
+            doorType.getDoorSerializer();
         }
-        catch (Exception e)
+        catch (Exception | Error e)
         {
             log.at(Level.SEVERE).withCause(e).log("Failed to load extension: %s", typeInfo.getTypeName());
             return Optional.empty();


### PR DESCRIPTION
A quick fix for DoorType initialization for issues related to loading failures. 

1) When loading a new DoorType from a jar, the DoorSerializer is now retrieved to ensure it is initialized during the loading process so we can handle failures gracefully. Before, it wouldn't be initialized until it was needed, potentially causing all kinds of issues later on. 
2) When a DoorType fails to load (e.g. because the DoorSerializer throws an error during initialization), all door types that depend on this one will not be loaded either (with an accompanying message in the log).