### PR TITLE
Publish Javadoc in GH actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,11 @@ jobs:
           name: BigDoors-Spigot
           path: bigdoors-spigot/spigot-core/target/BigDoors-Spigot.jar
 
-
+      # Publish java doc page when a commit/PR is pushed/merged to master
       - name: Deploy Javadoc
         uses: JamesIves/github-pages-deploy-action@v4.2.5
         with:
           branch: gh-pages
           folder: target/site/apidocs
           target-folder: javadoc
-        #if: github.ref == 'refs/heads/master'
-
+        if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           cache: 'maven'
 
       - name: Build the project and run static analysis tools.
-        run: mvn --batch-mode clean -P=errorprone test package checkstyle:checkstyle pmd:check
+        run: mvn --batch-mode clean -P=errorprone test package checkstyle:checkstyle pmd:check site
 
       - name: Upload doortypes
         uses: actions/upload-artifact@v3
@@ -49,3 +49,13 @@ jobs:
         with:
           name: BigDoors-Spigot
           path: bigdoors-spigot/spigot-core/target/BigDoors-Spigot.jar
+
+
+      - name: Deploy Javadoc
+        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        with:
+          branch: gh-pages
+          folder: target/site/apidocs
+          target-folder: javadoc
+        #if: github.ref == 'refs/heads/master'
+

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DoorTypeManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DoorTypeManager.java
@@ -10,7 +10,6 @@ import nl.pim16aap2.bigdoors.api.restartable.Restartable;
 import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.doortypes.DoorType;
 import nl.pim16aap2.util.SafeStringBuilder;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
@@ -50,7 +49,7 @@ public final class DoorTypeManager extends Restartable implements IDebuggable
     /**
      * Gets all registered AND enabled {@link DoorType}s.
      */
-    @Getter(onMethod = @__({@NotNull}))
+    @Getter
     private final List<DoorType> sortedDoorTypes = new CopyOnWriteArrayList<>()
     {
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,6 @@
         <lombok.encoding>UTF-8</lombok.encoding>
         <maven.compiler.release>17</maven.compiler.release>
 
-        <lombok.inputDir>${project.basedir}</lombok.inputDir>
-        <lombok.outputDir>${project.build.directory}/generated-sources/delombok</lombok.outputDir>
-        <src.dir>${basedir}/src/main/java</src.dir>
-
         <dependency.version.jcalculator>1.8</dependency.version.jcalculator>
         <dependency.version.flogger>0.7.4</dependency.version.flogger>
         <dependency.version.slf4j>1.7.36</dependency.version.slf4j>
@@ -34,10 +30,12 @@
         <dependency.version.junit>5.8.2</dependency.version.junit>
         <dependency.version.surefire>3.0.0-M6</dependency.version.surefire>
         <dependency.version.jacoco>0.8.8</dependency.version.jacoco>
+        <dependency.version.maven-build-helper>3.3.0</dependency.version.maven-build-helper>
         <dependency.version.maven-compiler>3.10.1</dependency.version.maven-compiler>
         <dependency.version.maven-shade>3.3.0</dependency.version.maven-shade>
         <dependency.version.maven-jar>3.2.2</dependency.version.maven-jar>
         <dependency.version.maven-clean>3.2.0</dependency.version.maven-clean>
+        <dependency.version.maven-javadoc>3.3.2</dependency.version.maven-javadoc>
         <dependency.version.maven-dependency>3.3.0</dependency.version.maven-dependency>
         <dependency.version.maven-resources>3.2.0</dependency.version.maven-resources>
         <dependency.version.maven-install>3.0.0-M1</dependency.version.maven-install>
@@ -217,9 +215,64 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>${src.dir}</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
+                <!-- Set up the delombok directory property-->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${dependency.version.maven-build-helper}</version>
+                    <executions>
+                        <execution>
+                            <phase>initialize</phase>
+                            <id>regex-property</id>
+                            <goals>
+                                <goal>regex-property</goal>
+                            </goals>
+                            <configuration>
+                                <name>delombok_dir</name>
+                                <value>${project.basedir}</value>
+                                <!--suppress MavenModelInspection -->
+                                <regex>^${maven.multiModuleProjectDirectory}</regex>
+                                <!--suppress MavenModelInspection -->
+                                <replacement>${maven.multiModuleProjectDirectory}/delombok</replacement>
+                                <failIfNoMatch>true</failIfNoMatch>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok-maven-plugin</artifactId>
+                    <version>${dependency.version.lombok-plugin}</version>
+                    <executions>
+                        <execution>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>delombok</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
+                        <outputDirectory>${delombok_dir}/src/main/java</outputDirectory>
+                        <formatPreferences>
+                            <generateDelombokComment>skip</generateDelombokComment>
+                            <javaLangAsFQN>skip</javaLangAsFQN>
+                            <suppressWarnings>skip</suppressWarnings>
+                        </formatPreferences>
+                    </configuration>
+                </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
@@ -372,6 +425,7 @@
                     <version>${dependency.version.jacoco}</version>
                     <executions>
                         <execution>
+                            <id>prepare-agent</id>
                             <goals>
                                 <goal>prepare-agent</goal>
                             </goals>
@@ -384,27 +438,16 @@
                             </goals>
                         </execution>
                     </executions>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.projectlombok</groupId>
-                    <artifactId>lombok-maven-plugin</artifactId>
-                    <version>${dependency.version.lombok-plugin}</version>
-                    <executions>
-                        <execution>
-                            <phase>generate-sources</phase>
-                            <goals>
-                                <goal>delombok</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
-                        <sourceDirectory>src/main/java</sourceDirectory>
-                        <formatPreferences>
-                            <generateDelombokComment>skip</generateDelombokComment>
-                            <javaLangAsFQN>skip</javaLangAsFQN>
-                            <suppressWarnings>skip</suppressWarnings>
-                        </formatPreferences>
+                        <excludes>
+                            <exclude>**/*_MembersInjector.class</exclude>
+                            <exclude>**/Dagger*Component.class</exclude>
+                            <exclude>**/Dagger*Component$Builder.class</exclude>
+                            <exclude>**/*Module_*.class</exclude>
+                            <exclude>**/*Factory.class</exclude>
+                            <exclude>**/*_Factory.java</exclude>
+                            <exclude>**/*_Impl.class</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
 
@@ -476,6 +519,75 @@
         </profile>
 
         <profile>
+            <id>delombok</id>
+            <build>
+                <plugins>
+                    <!-- Set up the delombok directory property-->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>${dependency.version.maven-build-helper}</version>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok-maven-plugin</artifactId>
+                        <version>${dependency.version.lombok-plugin}</version>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${dependency.version.maven-compiler}</version>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <skipMain>true</skipMain>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${dependency.version.maven-javadoc}</version>
+                        <reportSets>
+                            <reportSet>
+                                <id>aggregate</id>
+                                <inherited>false</inherited>
+                                <reports>
+                                    <report>aggregate</report>
+                                </reports>
+                            </reportSet>
+                            <reportSet>
+                                <id>default</id>
+                                <reports>
+                                    <report>javadoc</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                        <configuration>
+                            <!--suppress MavenModelInspection -->
+                            <sourcepath>${delombok_dir}</sourcepath>
+                            <failOnError>false</failOnError>
+                            <additionalOptions>-Xdoclint:none</additionalOptions>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
+
+        <profile>
             <id>errorprone</id>
             <build>
                 <pluginManagement>
@@ -541,6 +653,40 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
                 <version>${dependency.version.maven-jxr}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${dependency.version.maven-javadoc}</version>
+                <reportSets>
+                    <reportSet>
+                        <id>aggregate</id>
+                        <inherited>false</inherited>
+                        <reports>
+                            <report>aggregate</report>
+                        </reports>
+                    </reportSet>
+                    <reportSet>
+                        <id>default</id>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <additionalOptions>-Xdoclint:none</additionalOptions>
+                    <excludes>
+                        <!-- Exclude Dagger2 files -->
+                        <exclude>**/*_MembersInjector.java</exclude>
+                        <exclude>**/Dagger*Component.java</exclude>
+                        <exclude>**/Dagger*Component$Builder.java</exclude>
+                        <exclude>**/*Module_*.java</exclude>
+                        <exclude>**/*_Factory.java</exclude>
+                        <exclude>**/*_Impl.java</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,13 @@
         <dependency.version.jacoco>0.8.8</dependency.version.jacoco>
         <dependency.version.maven-build-helper>3.3.0</dependency.version.maven-build-helper>
         <dependency.version.maven-compiler>3.10.1</dependency.version.maven-compiler>
+        <dependency.version.maven-shade>3.3.0-SNAPSHOT</dependency.version.maven-shade>
         <dependency.version.maven-source>3.2.1</dependency.version.maven-source>
-        <dependency.version.maven-shade>3.3.0</dependency.version.maven-shade>
         <dependency.version.maven-jar>3.2.2</dependency.version.maven-jar>
         <dependency.version.maven-clean>3.2.0</dependency.version.maven-clean>
         <dependency.version.maven-javadoc>3.3.2</dependency.version.maven-javadoc>
+        <dependency.version.maven-build-helper>3.3.0</dependency.version.maven-build-helper>
+        <dependency.version.maven-source>3.2.1</dependency.version.maven-source>
         <dependency.version.maven-dependency>3.3.0</dependency.version.maven-dependency>
         <dependency.version.maven-resources>3.2.0</dependency.version.maven-resources>
         <dependency.version.maven-install>3.0.0-M1</dependency.version.maven-install>
@@ -221,7 +223,47 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${dependency.version.maven-clean}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>${dependency.version.maven-site}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${dependency.version.maven-javadoc}</version>
+                <executions>
+                    <execution>
+                        <id>generate-javadoc</id>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <additionalOptions>-Xdoclint:none</additionalOptions>
+                    <sourceFileExcludes>
+                        <!-- Exclude Dagger2 files -->
+                        <exclude>**/*_Impl.java</exclude>
+                        <exclude>**/*_MembersInjector.java</exclude>
+                        <exclude>**/*Dagger*Component.java</exclude>
+                        <exclude>**/*Dagger*Component$Builder.java</exclude>
+                        <exclude>**/*Module_*.java</exclude>
+                        <exclude>**/*_Factory.java</exclude>
+                    </sourceFileExcludes>
+                </configuration>
             </plugin>
 
             <plugin>
@@ -237,12 +279,6 @@
                         <configuration>
                             <attach>false</attach>
                         </configuration>
-                    </execution>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -264,9 +300,6 @@
                             <goal>prepare-agent</goal>
                         </goals>
                         <phase>pre-integration-test</phase>
-                        <configuration>
-                            <propertyName>itCoverageAgent</propertyName>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -274,60 +307,6 @@
 
         <pluginManagement>
             <plugins>
-                <!-- Set up the delombok directory property-->
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>${dependency.version.maven-build-helper}</version>
-                    <executions>
-                        <execution>
-                            <phase>initialize</phase>
-                            <id>regex-property</id>
-                            <goals>
-                                <goal>regex-property</goal>
-                            </goals>
-                            <configuration>
-                                <name>delombok_dir</name>
-                                <value>${project.basedir}</value>
-                                <!--suppress MavenModelInspection -->
-                                <regex>^${maven.multiModuleProjectDirectory}</regex>
-                                <!--suppress MavenModelInspection -->
-                                <replacement>${maven.multiModuleProjectDirectory}/delombok</replacement>
-                                <failIfNoMatch>true</failIfNoMatch>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.projectlombok</groupId>
-                    <artifactId>lombok-maven-plugin</artifactId>
-                    <version>${dependency.version.lombok-plugin}</version>
-                    <executions>
-                        <execution>
-                            <phase>generate-sources</phase>
-                            <goals>
-                                <goal>delombok</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
-                        <outputDirectory>${delombok_dir}/src/main/java</outputDirectory>
-                        <formatPreferences>
-                            <generateDelombokComment>skip</generateDelombokComment>
-                            <javaLangAsFQN>skip</javaLangAsFQN>
-                            <suppressWarnings>skip</suppressWarnings>
-                        </formatPreferences>
-                    </configuration>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>${dependency.version.maven-site}</version>
-                </plugin>
-
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
@@ -489,6 +468,7 @@
                     </executions>
                     <configuration>
                         <excludes>
+                            <!-- Exclude Dagger2 files -->
                             <exclude>**/*_MembersInjector.class</exclude>
                             <exclude>**/Dagger*Component.class</exclude>
                             <exclude>**/Dagger*Component$Builder.class</exclude>
@@ -568,75 +548,6 @@
         </profile>
 
         <profile>
-            <id>delombok</id>
-            <build>
-                <plugins>
-                    <!-- Set up the delombok directory property-->
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>${dependency.version.maven-build-helper}</version>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.projectlombok</groupId>
-                        <artifactId>lombok-maven-plugin</artifactId>
-                        <version>${dependency.version.lombok-plugin}</version>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${dependency.version.maven-compiler}</version>
-                        <executions>
-                            <execution>
-                                <id>default-compile</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
-                                <configuration>
-                                    <skipMain>true</skipMain>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-
-            <reporting>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${dependency.version.maven-javadoc}</version>
-                        <reportSets>
-                            <reportSet>
-                                <id>aggregate</id>
-                                <inherited>false</inherited>
-                                <reports>
-                                    <report>aggregate</report>
-                                </reports>
-                            </reportSet>
-                            <reportSet>
-                                <id>default</id>
-                                <reports>
-                                    <report>javadoc</report>
-                                </reports>
-                            </reportSet>
-                        </reportSets>
-                        <configuration>
-                            <!--suppress MavenModelInspection -->
-                            <sourcepath>${delombok_dir}</sourcepath>
-                            <failOnError>false</failOnError>
-                            <additionalOptions>-Xdoclint:none</additionalOptions>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </reporting>
-        </profile>
-
-        <profile>
             <id>errorprone</id>
             <build>
                 <pluginManagement>
@@ -696,58 +607,47 @@
         </profile>
     </profiles>
 
-    <!--    <reporting>-->
-    <!--        <plugins>-->
-    <!--            <plugin>-->
-    <!--                <groupId>org.apache.maven.plugins</groupId>-->
-    <!--                <artifactId>maven-jxr-plugin</artifactId>-->
-    <!--                <version>${dependency.version.maven-jxr}</version>-->
-    <!--            </plugin>-->
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>${dependency.version.maven-jxr}</version>
+            </plugin>
 
-
-    <!--            <plugin>-->
-    <!--                <groupId>org.apache.maven.plugins</groupId>-->
-    <!--                <artifactId>maven-javadoc-plugin</artifactId>-->
-    <!--                <version>${dependency.version.maven-javadoc}</version>-->
-    <!--                <reportSets>-->
-    <!--                    <reportSet>-->
-    <!--                        <id>aggregate</id>-->
-    <!--                        <inherited>false</inherited>-->
-    <!--                        <reports>-->
-    <!--                            <report>aggregate</report>-->
-    <!--                        </reports>-->
-    <!--                    </reportSet>-->
-    <!--                    <reportSet>-->
-    <!--                        <id>default</id>-->
-    <!--                        <reports>-->
-    <!--                            <report>javadoc</report>-->
-    <!--                        </reports>-->
-    <!--                    </reportSet>-->
-    <!--                </reportSets>-->
-    <!--                <configuration>-->
-    <!--                    <failOnError>false</failOnError>-->
-    <!--                    <additionalOptions>-Xdoclint:none</additionalOptions>-->
-    <!--                    <excludes>-->
-    <!--                        &lt;!&ndash; Exclude Dagger2 files &ndash;&gt;-->
-    <!--                        <exclude>**/*_MembersInjector.java</exclude>-->
-    <!--                        <exclude>**/Dagger*Component.java</exclude>-->
-    <!--                        <exclude>**/Dagger*Component$Builder.java</exclude>-->
-    <!--                        <exclude>**/*Module_*.java</exclude>-->
-    <!--                        <exclude>**/*_Factory.java</exclude>-->
-    <!--                        <exclude>**/*_Impl.java</exclude>-->
-    <!--                    </excludes>-->
-    <!--                </configuration>-->
-    <!--            </plugin>-->
-
-    <!--            <plugin>-->
-    <!--                <groupId>org.apache.maven.plugins</groupId>-->
-    <!--                <artifactId>maven-project-info-reports-plugin</artifactId>-->
-    <!--                <version>3.2.2</version>-->
-    <!--                <configuration>-->
-    <!--                    <dependencyDetailsEnabled>false</dependencyDetailsEnabled>-->
-    <!--                    <offline>true</offline>-->
-    <!--                </configuration>-->
-    <!--            </plugin>-->
-    <!--        </plugins>-->
-    <!--    </reporting>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${dependency.version.maven-javadoc}</version>
+                <reportSets>
+                    <reportSet>
+                        <id>aggregate</id>
+                        <inherited>false</inherited>
+                        <reports>
+                            <report>aggregate</report>
+                        </reports>
+                    </reportSet>
+                    <reportSet>
+                        <id>default</id>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <additionalOptions>-Xdoclint:none</additionalOptions>
+                    <sourceFileExcludes>
+                        <!-- Exclude Dagger2 files -->
+                        <exclude>**/*_Impl.java</exclude>
+                        <exclude>**/*_MembersInjector.java</exclude>
+                        <exclude>**/*Dagger*Component.java</exclude>
+                        <exclude>**/*Dagger*Component$Builder.java</exclude>
+                        <exclude>**/*Module_*.java</exclude>
+                        <exclude>**/*_Factory.java</exclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <dependency.version.jacoco>0.8.8</dependency.version.jacoco>
         <dependency.version.maven-build-helper>3.3.0</dependency.version.maven-build-helper>
         <dependency.version.maven-compiler>3.10.1</dependency.version.maven-compiler>
+        <dependency.version.maven-source>3.2.1</dependency.version.maven-source>
         <dependency.version.maven-shade>3.3.0</dependency.version.maven-shade>
         <dependency.version.maven-jar>3.2.2</dependency.version.maven-jar>
         <dependency.version.maven-clean>3.2.0</dependency.version.maven-clean>
@@ -221,6 +222,29 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>3.1.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${dependency.version.maven-source}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <attach>false</attach>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <module>bigdoors-doors</module>
         <module>bigdoors-integration-test</module>
         <module>utilities</module>
+        <module>report-aggregate</module>
     </modules>
 
     <repositories>
@@ -220,6 +221,30 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>3.1.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${dependency.version.jacoco}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-unit-tests</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <propertyName>itCoverageAgent</propertyName>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
 
@@ -647,47 +672,58 @@
         </profile>
     </profiles>
 
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <version>${dependency.version.maven-jxr}</version>
-            </plugin>
+    <!--    <reporting>-->
+    <!--        <plugins>-->
+    <!--            <plugin>-->
+    <!--                <groupId>org.apache.maven.plugins</groupId>-->
+    <!--                <artifactId>maven-jxr-plugin</artifactId>-->
+    <!--                <version>${dependency.version.maven-jxr}</version>-->
+    <!--            </plugin>-->
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${dependency.version.maven-javadoc}</version>
-                <reportSets>
-                    <reportSet>
-                        <id>aggregate</id>
-                        <inherited>false</inherited>
-                        <reports>
-                            <report>aggregate</report>
-                        </reports>
-                    </reportSet>
-                    <reportSet>
-                        <id>default</id>
-                        <reports>
-                            <report>javadoc</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-                <configuration>
-                    <failOnError>false</failOnError>
-                    <additionalOptions>-Xdoclint:none</additionalOptions>
-                    <excludes>
-                        <!-- Exclude Dagger2 files -->
-                        <exclude>**/*_MembersInjector.java</exclude>
-                        <exclude>**/Dagger*Component.java</exclude>
-                        <exclude>**/Dagger*Component$Builder.java</exclude>
-                        <exclude>**/*Module_*.java</exclude>
-                        <exclude>**/*_Factory.java</exclude>
-                        <exclude>**/*_Impl.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
+
+    <!--            <plugin>-->
+    <!--                <groupId>org.apache.maven.plugins</groupId>-->
+    <!--                <artifactId>maven-javadoc-plugin</artifactId>-->
+    <!--                <version>${dependency.version.maven-javadoc}</version>-->
+    <!--                <reportSets>-->
+    <!--                    <reportSet>-->
+    <!--                        <id>aggregate</id>-->
+    <!--                        <inherited>false</inherited>-->
+    <!--                        <reports>-->
+    <!--                            <report>aggregate</report>-->
+    <!--                        </reports>-->
+    <!--                    </reportSet>-->
+    <!--                    <reportSet>-->
+    <!--                        <id>default</id>-->
+    <!--                        <reports>-->
+    <!--                            <report>javadoc</report>-->
+    <!--                        </reports>-->
+    <!--                    </reportSet>-->
+    <!--                </reportSets>-->
+    <!--                <configuration>-->
+    <!--                    <failOnError>false</failOnError>-->
+    <!--                    <additionalOptions>-Xdoclint:none</additionalOptions>-->
+    <!--                    <excludes>-->
+    <!--                        &lt;!&ndash; Exclude Dagger2 files &ndash;&gt;-->
+    <!--                        <exclude>**/*_MembersInjector.java</exclude>-->
+    <!--                        <exclude>**/Dagger*Component.java</exclude>-->
+    <!--                        <exclude>**/Dagger*Component$Builder.java</exclude>-->
+    <!--                        <exclude>**/*Module_*.java</exclude>-->
+    <!--                        <exclude>**/*_Factory.java</exclude>-->
+    <!--                        <exclude>**/*_Impl.java</exclude>-->
+    <!--                    </excludes>-->
+    <!--                </configuration>-->
+    <!--            </plugin>-->
+
+    <!--            <plugin>-->
+    <!--                <groupId>org.apache.maven.plugins</groupId>-->
+    <!--                <artifactId>maven-project-info-reports-plugin</artifactId>-->
+    <!--                <version>3.2.2</version>-->
+    <!--                <configuration>-->
+    <!--                    <dependencyDetailsEnabled>false</dependencyDetailsEnabled>-->
+    <!--                    <offline>true</offline>-->
+    <!--                </configuration>-->
+    <!--            </plugin>-->
+    <!--        </plugins>-->
+    <!--    </reporting>-->
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,11 @@
         <dependency.version.jacoco>0.8.8</dependency.version.jacoco>
         <dependency.version.maven-build-helper>3.3.0</dependency.version.maven-build-helper>
         <dependency.version.maven-compiler>3.10.1</dependency.version.maven-compiler>
-        <dependency.version.maven-shade>3.3.0-SNAPSHOT</dependency.version.maven-shade>
+        <dependency.version.maven-shade>3.3.0</dependency.version.maven-shade>
         <dependency.version.maven-source>3.2.1</dependency.version.maven-source>
         <dependency.version.maven-jar>3.2.2</dependency.version.maven-jar>
         <dependency.version.maven-clean>3.2.0</dependency.version.maven-clean>
         <dependency.version.maven-javadoc>3.3.2</dependency.version.maven-javadoc>
-        <dependency.version.maven-build-helper>3.3.0</dependency.version.maven-build-helper>
         <dependency.version.maven-source>3.2.1</dependency.version.maven-source>
         <dependency.version.maven-dependency>3.3.0</dependency.version.maven-dependency>
         <dependency.version.maven-resources>3.2.0</dependency.version.maven-resources>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -4,6 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>report-aggregate</artifactId>
+    <description>Simple module used for aggregating test reports across all other modules.</description>
     <packaging>jar</packaging>
     <version>1</version>
 
@@ -112,6 +113,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${dependency.version.jacoco}</version>
                 <executions>
                     <execution>
                         <id>report-aggregate</id>
@@ -139,36 +141,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${dependency.version.maven-javadoc}</version>
-
-                <executions>
-                    <execution>
-                        <id>merge-docs</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>aggregate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
-                <configuration>
-                    <failOnError>false</failOnError>
-                    <additionalOptions>-Xdoclint:none</additionalOptions>
-                    <excludes>
-                        <!-- Exclude Dagger2 files -->
-                        <exclude>**/*_MembersInjector.java</exclude>
-                        <exclude>**/Dagger*Component.java</exclude>
-                        <exclude>**/Dagger*Component$Builder.java</exclude>
-                        <exclude>**/*Module_*.java</exclude>
-                        <exclude>**/*_Factory.java</exclude>
-                        <exclude>**/*_Impl.java</exclude>
-                    </excludes>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/report-aggregate/pom.xml
+++ b/report-aggregate/pom.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>report-aggregate</artifactId>
+    <packaging>jar</packaging>
+    <version>1</version>
+
+    <parent>
+        <artifactId>bigdoors-parent</artifactId>
+        <groupId>nl.pim16aap2.bigdoors</groupId>
+        <version>1</version>
+    </parent>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>bigdoors-core</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>doors-bigdoor</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>doors-clock</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>doors-drawbridge</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>doors-elevator</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>doors-flag</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>doors-garagedoor</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>doors-portcullis</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>doors-revolvingdoor</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>doors-slidingdoor</artifactId>
+            <version>1</version>
+        </dependency>
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>doors-windmill</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>spigot-core</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>spigot-util</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2</groupId>
+            <artifactId>util</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2</groupId>
+            <artifactId>test-util</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.bigdoors</groupId>
+            <artifactId>bigdoors-integration-test</artifactId>
+            <version>1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>merge-results</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>merge</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <directory>${project.build.directory}</directory>
+                                    <includes>
+                                        <include>*.exec</include>
+                                    </includes>
+                                </fileSet>
+                            </fileSets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${dependency.version.maven-javadoc}</version>
+
+                <executions>
+                    <execution>
+                        <id>merge-docs</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <additionalOptions>-Xdoclint:none</additionalOptions>
+                    <excludes>
+                        <!-- Exclude Dagger2 files -->
+                        <exclude>**/*_MembersInjector.java</exclude>
+                        <exclude>**/Dagger*Component.java</exclude>
+                        <exclude>**/Dagger*Component$Builder.java</exclude>
+                        <exclude>**/*Module_*.java</exclude>
+                        <exclude>**/*_Factory.java</exclude>
+                        <exclude>**/*_Impl.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
- This PR adds a step to the GitHub actions workflow to publish the generated javadocs.
- When building the project you now also get the sources and javadoc jars.