### PR TITLE
Improve Attached Block Handling

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Alpha 0.1.8.38
 - Fixed bottom row of blocks sometimes lagging behind the rest of the door when dragging over other blocks (BigDoor, SlidingDoor).
+- Allow certain types of attached blocks (e.g. torches, rails, plants, redstone, etc) to be part of doors on 1.18+.
 
 Alpha 0.1.8.37
 - Add support for Minecraft 1.18.2. Massive thanks to Bonn2 for helping me test this!

--- a/core/src/main/java/nl/pim16aap2/bigDoors/Commander.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/Commander.java
@@ -487,7 +487,7 @@ public class Commander
     {
         private DummyMover()
         {
-            super(BigDoors.get(), null);
+            super(BigDoors.get(), null, false);
         }
 
         @Override

--- a/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/NMSBlockClassGenerator.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/NMSBlockClassGenerator.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Objects;
 import java.util.Set;
 
 import static net.bytebuddy.implementation.MethodCall.construct;
@@ -461,6 +462,8 @@ final class NMSBlockClassGenerator extends ClassGenerator
 
     public static class DeleteOriginalBlock
     {
+        private static final Material RESET_MATERIAL = Objects.requireNonNull(XMaterial.CAVE_AIR.parseMaterial());
+
         public static void deleteOriginalBlock(@This IGeneratedNMSBlock origin, boolean applyPhysics)
         {
             if (!applyPhysics)
@@ -469,7 +472,7 @@ final class NMSBlockClassGenerator extends ClassGenerator
             }
             else
             {
-                origin.generated$setBlockType(Material.BARRIER, false);
+                origin.generated$setBlockType(RESET_MATERIAL, false);
                 origin.generated$setBlockType(Material.AIR, true);
             }
         }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/NMSBlockClassGenerator.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/NMSBlockClassGenerator.java
@@ -78,7 +78,7 @@ final class NMSBlockClassGenerator extends ClassGenerator
     public static final Method METHOD_CAN_ROTATE =
         findMethod().inClass(NMSBlock.class).withName("canRotate").get();
     public static final Method METHOD_DELETE_ORIGINAL_BLOCK =
-        findMethod().inClass(NMSBlock.class).withName("deleteOriginalBlock").get();
+        findMethod().inClass(NMSBlock.class).withName("deleteOriginalBlock").withParameters(boolean.class).get();
     public static final Method METHOD_PUT_BLOCK =
         findMethod().inClass(NMSBlock.class).withName("putBlock").get();
 
@@ -331,7 +331,8 @@ final class NMSBlockClassGenerator extends ClassGenerator
             .define(METHOD_DELETE_ORIGINAL_BLOCK)
             .intercept(invoke(methodSetBlockType)
                            .onMethodCall(invoke(methodLocationGetBlock).onField(FIELD_LOCATION))
-                           .with(Material.AIR));
+                           .with(Material.AIR)
+                           .withArgument(0));
 
         return builder;
     }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/ReflectionRepository.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/codegeneration/ReflectionRepository.java
@@ -19,11 +19,7 @@ import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.List;
 
-import static nl.pim16aap2.bigDoors.reflection.ReflectionBuilder.findClass;
-import static nl.pim16aap2.bigDoors.reflection.ReflectionBuilder.findConstructor;
-import static nl.pim16aap2.bigDoors.reflection.ReflectionBuilder.findField;
-import static nl.pim16aap2.bigDoors.reflection.ReflectionBuilder.findMethod;
-import static nl.pim16aap2.bigDoors.reflection.ReflectionBuilder.parameterBuilder;
+import static nl.pim16aap2.bigDoors.reflection.ReflectionBuilder.*;
 
 final class ReflectionRepository
 {
@@ -307,8 +303,8 @@ final class ReflectionRepository
             .inClass(classCraftEntity).withName("setCustomNameVisible").withParameters(boolean.class).get();
         methodIsAssignableFrom = findMethod().inClass(Class.class).withName("isAssignableFrom")
                                              .withParameters(Class.class).get();
-        methodSetBlockType = findMethod().inClass(Block.class).withName("setType").withParameters(Material.class)
-                                         .get();
+        methodSetBlockType = findMethod().inClass(Block.class).withName("setType")
+                                         .withParameters(Material.class, boolean.class).get();
         methodEnumOrdinal = findMethod().inClass(Enum.class).withName("ordinal").get();
         methodArrayGetIdx = findMethod().inClass(Array.class).withName("get")
                                         .withParameters(Object.class, int.class).get();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BlockMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BlockMover.java
@@ -3,27 +3,43 @@ package nl.pim16aap2.bigDoors.moveBlocks;
 import com.cryptomorin.xseries.XMaterial;
 import nl.pim16aap2.bigDoors.BigDoors;
 import nl.pim16aap2.bigDoors.Door;
+import nl.pim16aap2.bigDoors.events.DoorEventToggle;
+import nl.pim16aap2.bigDoors.events.DoorEventToggleEnd;
+import nl.pim16aap2.bigDoors.util.MyBlockData;
 import nl.pim16aap2.bigDoors.util.MyBlockFace;
 import nl.pim16aap2.bigDoors.util.Util;
 import nl.pim16aap2.bigDoors.util.Vector3D;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemFrame;
+import org.bukkit.material.MaterialData;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class BlockMover
 {
     private final BigDoors plugin;
     private final @Nullable Door door;
 
-    protected BlockMover(BigDoors plugin, @Nullable Door door)
+    protected final AtomicBoolean blocksPlaced = new AtomicBoolean(false);
+    protected final ArrayList<MyBlockData> savedBlocks = new ArrayList<>();
+    protected final boolean instantOpen;
+
+    protected BlockMover(BigDoors plugin, @Nullable Door door, boolean instantOpen)
     {
         this.plugin = plugin;
         this.door = door;
+        this.instantOpen = instantOpen;
         if (door == null)
             return;
 
@@ -89,5 +105,81 @@ public abstract class BlockMover
     public int buttonDelay(final int endCount)
     {
         return Math.max(0, 17 - endCount);
+    }
+
+    protected synchronized void putBlocks(
+        boolean onDisable, double time, int endCount, LocationFinder locationUpdater, Runnable coordinateUpdater)
+    {
+        if (blocksPlaced.getAndSet(true))
+            return;
+
+        final World world = Objects.requireNonNull(door).getWorld();
+
+        for (MyBlockData savedBlock : savedBlocks)
+        {
+            Material mat = savedBlock.getMat();
+            byte matByte = savedBlock.getBlockByte();
+            Location newPos = locationUpdater.apply(savedBlock.getRadius(), savedBlock.getStartX(),
+                                                    savedBlock.getStartY(), savedBlock.getStartZ());
+
+            if (!instantOpen)
+                savedBlock.getFBlock().remove();
+
+            if (!savedBlock.getMat().equals(Material.AIR))
+            {
+                if (BigDoors.isOnFlattenedVersion())
+                {
+                    savedBlock.getBlock().putBlock(newPos);
+                    Block b = world.getBlockAt(newPos);
+                    BlockState bs = b.getState();
+                    bs.update();
+                }
+                else
+                {
+                    Block b = world.getBlockAt(newPos);
+                    MaterialData matData = savedBlock.getMatData();
+                    matData.setData(matByte);
+
+                    b.setType(mat);
+                    BlockState bs = b.getState();
+                    bs.setData(matData);
+                    bs.update();
+                }
+            }
+        }
+
+        coordinateUpdater.run();
+        toggleOpen(door);
+
+        if (!onDisable)
+        {
+            int delay = buttonDelay(endCount)
+                + Math.min(plugin.getMinimumDoorDelay(), plugin.getConfigLoader().coolDown() * 20);
+            new BukkitRunnable()
+            {
+                @Override
+                public void run()
+                {
+                    plugin.getCommander().setDoorAvailable(door.getDoorUID());
+                    Bukkit.getPluginManager()
+                          .callEvent(new DoorEventToggleEnd(door, (door.isOpen() ? DoorEventToggle.ToggleType.OPEN : DoorEventToggle.ToggleType.CLOSE),
+                                                            instantOpen));
+
+                    if (door.isOpen())
+                        plugin.getAutoCloseScheduler().scheduleAutoClose(door, time, instantOpen);
+                }
+            }.runTaskLater(plugin, delay);
+        }
+    }
+
+    protected void toggleOpen(Door door)
+    {
+        door.setOpenStatus(!door.isOpen());
+    }
+
+    @FunctionalInterface
+    public interface LocationFinder
+    {
+        Location apply(double radius, double startX, double startY, double startZ);
     }
 }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Bridge/getNewLocation/GetNewLocation.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Bridge/getNewLocation/GetNewLocation.java
@@ -4,5 +4,5 @@ import org.bukkit.Location;
 
 public interface GetNewLocation
 {
-    public Location getNewLocation(double radius, double xPos, double yPos, double zPos, int index);
+    public Location getNewLocation(double radius, double xPos, double yPos, double zPos);
 }

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Bridge/getNewLocation/GetNewLocationEast.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Bridge/getNewLocation/GetNewLocationEast.java
@@ -1,10 +1,9 @@
 package nl.pim16aap2.bigDoors.moveBlocks.Bridge.getNewLocation;
 
-import org.bukkit.Location;
-import org.bukkit.World;
-
 import nl.pim16aap2.bigDoors.util.DoorDirection;
 import nl.pim16aap2.bigDoors.util.RotateDirection;
+import org.bukkit.Location;
+import org.bukkit.World;
 
 @SuppressWarnings("unused")
 public class GetNewLocationEast implements GetNewLocation
@@ -32,7 +31,7 @@ public class GetNewLocationEast implements GetNewLocation
     {}
 
     @Override
-    public Location getNewLocation(double radius, double xPos, double yPos, double zPos, int index)
+    public Location getNewLocation(double radius, double xPos, double yPos, double zPos)
     {
         Location newPos = null;
 

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Bridge/getNewLocation/GetNewLocationNorth.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Bridge/getNewLocation/GetNewLocationNorth.java
@@ -1,10 +1,9 @@
 package nl.pim16aap2.bigDoors.moveBlocks.Bridge.getNewLocation;
 
-import org.bukkit.Location;
-import org.bukkit.World;
-
 import nl.pim16aap2.bigDoors.util.DoorDirection;
 import nl.pim16aap2.bigDoors.util.RotateDirection;
+import org.bukkit.Location;
+import org.bukkit.World;
 
 @SuppressWarnings("unused")
 public class GetNewLocationNorth implements GetNewLocation
@@ -32,7 +31,7 @@ public class GetNewLocationNorth implements GetNewLocation
     {}
 
     @Override
-    public Location getNewLocation(double radius, double xPos, double yPos, double zPos, int index)
+    public Location getNewLocation(double radius, double xPos, double yPos, double zPos)
     {
         Location newPos = null;
 

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Bridge/getNewLocation/GetNewLocationSouth.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Bridge/getNewLocation/GetNewLocationSouth.java
@@ -1,10 +1,9 @@
 package nl.pim16aap2.bigDoors.moveBlocks.Bridge.getNewLocation;
 
-import org.bukkit.Location;
-import org.bukkit.World;
-
 import nl.pim16aap2.bigDoors.util.DoorDirection;
 import nl.pim16aap2.bigDoors.util.RotateDirection;
+import org.bukkit.Location;
+import org.bukkit.World;
 
 @SuppressWarnings("unused")
 public class GetNewLocationSouth implements GetNewLocation
@@ -32,7 +31,7 @@ public class GetNewLocationSouth implements GetNewLocation
     {}
 
     @Override
-    public Location getNewLocation(double radius, double xPos, double yPos, double zPos, int index)
+    public Location getNewLocation(double radius, double xPos, double yPos, double zPos)
     {
         Location newPos = null;
 

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Bridge/getNewLocation/GetNewLocationWest.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/Bridge/getNewLocation/GetNewLocationWest.java
@@ -1,10 +1,9 @@
 package nl.pim16aap2.bigDoors.moveBlocks.Bridge.getNewLocation;
 
-import org.bukkit.Location;
-import org.bukkit.World;
-
 import nl.pim16aap2.bigDoors.util.DoorDirection;
 import nl.pim16aap2.bigDoors.util.RotateDirection;
+import org.bukkit.Location;
+import org.bukkit.World;
 
 @SuppressWarnings("unused")
 public class GetNewLocationWest implements GetNewLocation
@@ -32,7 +31,7 @@ public class GetNewLocationWest implements GetNewLocation
     {}
 
     @Override
-    public Location getNewLocation(double radius, double xPos, double yPos, double zPos, int index)
+    public Location getNewLocation(double radius, double xPos, double yPos, double zPos)
     {
         Location newPos = null;
 

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeMover.java
@@ -311,7 +311,7 @@ public class BridgeMover extends BlockMover
             {
                 NMSBlock block = mbd.getBlock();
                 if (block != null && Util.isAllowedBlock(mbd.getMat()))
-                    block.deleteOriginalBlock();
+                    block.deleteOriginalBlock(false);
             }
 
         savedBlocks.trimToSize();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeMover.java
@@ -5,8 +5,6 @@ import nl.pim16aap2.bigDoors.Door;
 import nl.pim16aap2.bigDoors.NMS.CustomCraftFallingBlock;
 import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory;
 import nl.pim16aap2.bigDoors.NMS.NMSBlock;
-import nl.pim16aap2.bigDoors.events.DoorEventToggle.ToggleType;
-import nl.pim16aap2.bigDoors.events.DoorEventToggleEnd;
 import nl.pim16aap2.bigDoors.moveBlocks.Bridge.getNewLocation.GetNewLocation;
 import nl.pim16aap2.bigDoors.moveBlocks.Bridge.getNewLocation.GetNewLocationEast;
 import nl.pim16aap2.bigDoors.moveBlocks.Bridge.getNewLocation.GetNewLocationNorth;
@@ -26,9 +24,6 @@ import org.bukkit.material.MaterialData;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 public class BridgeMover extends BlockMover
 {
     private final World world;
@@ -44,7 +39,6 @@ public class BridgeMover extends BlockMover
     private final RotateDirection upDown;
     private final DoorDirection engineSide;
     private final double endStepSum;
-    private final boolean instantOpen;
     private Location turningPoint;
     private double startStepSum;
     private final DoorDirection openDirection;
@@ -52,8 +46,6 @@ public class BridgeMover extends BlockMover
     private int stepMultiplier;
     private final int xMin, yMin, zMin;
     private final int xMax, yMax, zMax;
-    private final ArrayList<MyBlockData> savedBlocks = new ArrayList<>();
-    private final AtomicBoolean blocksPlaced = new AtomicBoolean(false);
     private int endCount;
     private BukkitRunnable animationRunnable;
 
@@ -61,7 +53,7 @@ public class BridgeMover extends BlockMover
     public BridgeMover(BigDoors plugin, World world, double time, Door door, RotateDirection upDown,
         DoorDirection openDirection, boolean instantOpen, double multiplier)
     {
-        super(plugin, door);
+        super(plugin, door, instantOpen);
         fabf = plugin.getFABF();
         engineSide = door.getEngSide();
         NS = engineSide == DoorDirection.NORTH || engineSide == DoorDirection.SOUTH;
@@ -69,7 +61,6 @@ public class BridgeMover extends BlockMover
         this.world = world;
         this.plugin = plugin;
         this.upDown = upDown;
-        this.instantOpen = instantOpen;
         this.openDirection = openDirection;
 
         xMin = door.getMinimum().getBlockX();
@@ -307,12 +298,9 @@ public class BridgeMover extends BlockMover
 
         // This is only supported on 1.13
         if (BigDoors.isOnFlattenedVersion())
-            for (MyBlockData mbd : savedBlocks)
-            {
-                NMSBlock block = mbd.getBlock();
-                if (block != null && Util.isAllowedBlock(mbd.getMat()))
-                    block.deleteOriginalBlock(false);
-            }
+        {
+            savedBlocks.forEach(myBlockData -> myBlockData.getBlock().deleteOriginalBlock(false));
+        }
 
         savedBlocks.trimToSize();
 
@@ -331,95 +319,12 @@ public class BridgeMover extends BlockMover
         this.putBlocks(onDisable);
     }
 
-    // Put the door blocks back, but change their state now.
-    @SuppressWarnings("deprecation")
     @Override
     public synchronized void putBlocks(boolean onDisable)
     {
-        if (blocksPlaced.getAndSet(true))
-            return;
-
-        int index = 0;
-        double xAxis = turningPoint.getX();
-        do
-        {
-            double zAxis = turningPoint.getZ();
-            do
-            {
-                for (double yAxis = yMin; yAxis <= yMax; yAxis++)
-                {
-                    /*
-                     * 0-3: Vertical oak, spruce, birch, then jungle 4-7: East/west oak, spruce,
-                     * birch, jungle 8-11: North/south oak, spruce, birch, jungle 12-15: Uses oak,
-                     * spruce, birch, jungle bark texture on all six faces
-                     */
-
-                    Material mat = savedBlocks.get(index).getMat();
-
-                    if (!mat.equals(Material.AIR))
-                    {
-                        byte matByte = savedBlocks.get(index).getBlockByte();
-                        Location newPos = gnl.getNewLocation(savedBlocks.get(index).getRadius(), xAxis, yAxis, zAxis,
-                                                             index);
-
-                        if (!instantOpen)
-                            savedBlocks.get(index).getFBlock().remove();
-
-                        if (!savedBlocks.get(index).getMat().equals(Material.AIR))
-                        {
-                            if (BigDoors.isOnFlattenedVersion())
-                            {
-                                savedBlocks.get(index).getBlock().putBlock(newPos);
-                                Block b = world.getBlockAt(newPos);
-                                BlockState bs = b.getState();
-                                bs.update();
-                            }
-                            else
-                            {
-                                Block b = world.getBlockAt(newPos);
-                                MaterialData matData = savedBlocks.get(index).getMatData();
-                                matData.setData(matByte);
-
-                                b.setType(mat);
-                                BlockState bs = b.getState();
-                                bs.setData(matData);
-                                bs.update();
-                            }
-                        }
-                    }
-                    index++;
-                }
-                zAxis += dz;
-            }
-            while (zAxis >= pointOpposite.getBlockZ() && dz == -1 || zAxis <= pointOpposite.getBlockZ() && dz == 1);
-            xAxis += dx;
-        }
-        while (xAxis >= pointOpposite.getBlockX() && dx == -1 || xAxis <= pointOpposite.getBlockX() && dx == 1);
-        savedBlocks.clear();
-
-        // Tell the door object it has been opened and what its new coordinates are.
-        updateCoords(door, openDirection, upDown, -1, false);
-        toggleOpen(door);
-
-        if (!onDisable)
-        {
-            int delay = buttonDelay(endCount)
-                + Math.min(plugin.getMinimumDoorDelay(), plugin.getConfigLoader().coolDown() * 20);
-            new BukkitRunnable()
-            {
-                @Override
-                public void run()
-                {
-                    plugin.getCommander().setDoorAvailable(door.getDoorUID());
-                    Bukkit.getPluginManager()
-                        .callEvent(new DoorEventToggleEnd(door, (door.isOpen() ? ToggleType.OPEN : ToggleType.CLOSE),
-                                                          instantOpen));
-
-                    if (door.isOpen())
-                        plugin.getAutoCloseScheduler().scheduleAutoClose(door, time, instantOpen);
-                }
-            }.runTaskLater(plugin, delay);
-        }
+        super.putBlocks(onDisable, time, endCount,
+                        gnl::getNewLocation,
+                        () -> updateCoords(door, openDirection, upDown, -1, false));
     }
 
     // Method that takes care of the rotation aspect.
@@ -589,12 +494,6 @@ public class BridgeMover extends BlockMover
         if (matData == 3)
             return (byte) (openDirection.equals(DoorDirection.NORTH) ? 1 : 0);
         return matData;
-    }
-
-    // Toggle the open status of a drawbridge.
-    private void toggleOpen(Door door)
-    {
-        door.setOpenStatus(!door.isOpen());
     }
 
     // Update the coordinates of a door based on its location, direction it's

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/BridgeMover.java
@@ -24,6 +24,9 @@ import org.bukkit.material.MaterialData;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class BridgeMover extends BlockMover
 {
     private final World world;
@@ -190,6 +193,11 @@ public class BridgeMover extends BlockMover
     {
         savedBlocks.ensureCapacity(door.getBlockCount());
 
+        // This will reserve a bit too much memory, but not enough to worry about.
+        final List<NMSBlock> edges =
+            new ArrayList<>(Math.min(door.getBlockCount(),
+                                     (xMax - xMin + 1) * 2 + (yMax - yMin + 1) * 2 + (zMax - zMin + 1) * 2));
+
         int xAxis = turningPoint.getBlockX();
         do
         {
@@ -271,6 +279,11 @@ public class BridgeMover extends BlockMover
 
                         savedBlocks.add(new MyBlockData(mat, matByte, fBlock, radius, materialData,
                                                         block2 == null ? block : block2, canRotate, startLocation));
+
+                        if (xAxis == xMin || xAxis == xMax ||
+                            yAxis == yMin || yAxis == yMax ||
+                            zAxis == zMin || zAxis == zMax)
+                            edges.add(block);
                     }
                 }
                 zAxis += dz;
@@ -300,6 +313,8 @@ public class BridgeMover extends BlockMover
         if (BigDoors.isOnFlattenedVersion())
         {
             savedBlocks.forEach(myBlockData -> myBlockData.getBlock().deleteOriginalBlock(false));
+            // Update the physics around the edges after we've removed all our blocks.
+            edges.forEach(block -> block.deleteOriginalBlock(true));
         }
 
         savedBlocks.trimToSize();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/CylindricalMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/CylindricalMover.java
@@ -24,6 +24,9 @@ import org.bukkit.material.MaterialData;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class CylindricalMover extends BlockMover
 {
     private GetNewLocation gnl;
@@ -85,6 +88,11 @@ public class CylindricalMover extends BlockMover
     private void createAnimatedBlocks()
     {
         savedBlocks.ensureCapacity(door.getBlockCount());
+
+        // This will reserve a bit too much memory, but not enough to worry about.
+        final List<NMSBlock> edges =
+            new ArrayList<>(Math.min(door.getBlockCount(),
+                                     (xMax - xMin + 1) * 2 + (yMax - yMin + 1) * 2 + (zMax - zMin + 1) * 2));
 
         int xAxis = turningPoint.getBlockX();
         do
@@ -160,6 +168,11 @@ public class CylindricalMover extends BlockMover
 
                         savedBlocks.add(new MyBlockData(mat, matByte, fBlock, radius, materialData,
                                                         block2 == null ? block : block2, canRotate, startLocation));
+
+                        if (xAxis == xMin || xAxis == xMax ||
+                            yAxis == yMin || yAxis == yMax ||
+                            zAxis == zMin || zAxis == zMax)
+                            edges.add(block);
                     }
                 }
                 zAxis += dz;
@@ -197,6 +210,8 @@ public class CylindricalMover extends BlockMover
         if (BigDoors.isOnFlattenedVersion())
         {
             savedBlocks.forEach(myBlockData -> myBlockData.getBlock().deleteOriginalBlock(false));
+            // Update the physics around the edges after we've removed all our blocks.
+            edges.forEach(block -> block.deleteOriginalBlock(true));
         }
 
         savedBlocks.trimToSize();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/CylindricalMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/CylindricalMover.java
@@ -5,8 +5,6 @@ import nl.pim16aap2.bigDoors.Door;
 import nl.pim16aap2.bigDoors.NMS.CustomCraftFallingBlock;
 import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory;
 import nl.pim16aap2.bigDoors.NMS.NMSBlock;
-import nl.pim16aap2.bigDoors.events.DoorEventToggle.ToggleType;
-import nl.pim16aap2.bigDoors.events.DoorEventToggleEnd;
 import nl.pim16aap2.bigDoors.moveBlocks.Cylindrical.getNewLocation.GetNewLocation;
 import nl.pim16aap2.bigDoors.moveBlocks.Cylindrical.getNewLocation.GetNewLocationEast;
 import nl.pim16aap2.bigDoors.moveBlocks.Cylindrical.getNewLocation.GetNewLocationNorth;
@@ -26,9 +24,6 @@ import org.bukkit.material.MaterialData;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 public class CylindricalMover extends BlockMover
 {
     private GetNewLocation gnl;
@@ -41,7 +36,6 @@ public class CylindricalMover extends BlockMover
     private final int tickRate;
     private double endStepSum;
     private double multiplier;
-    private final boolean instantOpen;
     private double startStepSum;
     private final RotateDirection rotDirection;
     private final Location pointOpposite;
@@ -50,8 +44,6 @@ public class CylindricalMover extends BlockMover
     private final int yMax, zMin, zMax;
     private final DoorDirection currentDirection;
     private final Location turningPoint;
-    private final ArrayList<MyBlockData> savedBlocks = new ArrayList<>();
-    private final AtomicBoolean blocksPlaced = new AtomicBoolean(false);
     private int endCount = 0;
     private BukkitRunnable animationRunnable;
 
@@ -59,7 +51,7 @@ public class CylindricalMover extends BlockMover
     public CylindricalMover(BigDoors plugin, World world, int qCircleLimit, RotateDirection rotDirection, double time,
         Location pointOpposite, DoorDirection currentDirection, Door door, boolean instantOpen, double multiplier)
     {
-        super(plugin, door);
+        super(plugin, door, instantOpen);
         this.rotDirection = rotDirection;
         this.currentDirection = currentDirection;
         this.plugin = plugin;
@@ -68,7 +60,6 @@ public class CylindricalMover extends BlockMover
         this.pointOpposite = pointOpposite;
         turningPoint = door.getEngine();
         fabf = plugin.getFABF();
-        this.instantOpen = instantOpen;
         stepMultiplier = rotDirection == RotateDirection.CLOCKWISE ? -1 : 1;
 
         xMin = Math.min(turningPoint.getBlockX(), pointOpposite.getBlockX());
@@ -170,8 +161,6 @@ public class CylindricalMover extends BlockMover
                         savedBlocks.add(new MyBlockData(mat, matByte, fBlock, radius, materialData,
                                                         block2 == null ? block : block2, canRotate, startLocation));
                     }
-                    else
-                        savedBlocks.add(new MyBlockData(Material.AIR));
                 }
                 zAxis += dz;
             }
@@ -206,12 +195,9 @@ public class CylindricalMover extends BlockMover
 
         // This is only supported on 1.13
         if (BigDoors.isOnFlattenedVersion())
-            for (MyBlockData mbd : savedBlocks)
-            {
-                NMSBlock block = mbd.getBlock();
-                if (block != null && Util.isAllowedBlock(mbd.getMat()))
-                    block.deleteOriginalBlock(false);
-            }
+        {
+            savedBlocks.forEach(myBlockData -> myBlockData.getBlock().deleteOriginalBlock(false));
+        }
 
         savedBlocks.trimToSize();
 
@@ -230,81 +216,12 @@ public class CylindricalMover extends BlockMover
         this.putBlocks(onDisable);
     }
 
-    // Put the door blocks back, but change their state now.
-    @SuppressWarnings("deprecation")
     @Override
     public synchronized void putBlocks(boolean onDisable)
     {
-        if (blocksPlaced.getAndSet(true))
-            return;
-
-        for (MyBlockData savedBlock : savedBlocks)
-        {
-            /*
-             * 0-3: Vertical oak, spruce, birch, then jungle 4-7: East/west oak, spruce,
-             * birch, jungle 8-11: North/south oak, spruce, birch, jungle 12-15: Uses oak,
-             * spruce, birch, jungle bark texture on all six faces
-             */
-
-            Material mat = savedBlock.getMat();
-
-            if (!mat.equals(Material.AIR))
-            {
-                byte matByte = savedBlock.getBlockByte();
-
-                Location newPos = gnl.getNewLocation(savedBlock.getRadius(), savedBlock.getStartX(),
-                                                     savedBlock.getStartY(), savedBlock.getStartZ());
-
-                if (!instantOpen)
-                    savedBlock.getFBlock().remove();
-
-                if (!savedBlock.getMat().equals(Material.AIR))
-                {
-                    if (BigDoors.isOnFlattenedVersion())
-                    {
-                        savedBlock.getBlock().putBlock(newPos);
-                        Block b = world.getBlockAt(newPos);
-                        BlockState bs = b.getState();
-                        bs.update();
-                    }
-                    else
-                    {
-                        Block b = world.getBlockAt(newPos);
-                        MaterialData matData = savedBlock.getMatData();
-                        matData.setData(matByte);
-
-                        b.setType(mat);
-                        BlockState bs = b.getState();
-                        bs.setData(matData);
-                        bs.update();
-                    }
-                }
-            }
-        }
-
-        // Tell the door object it has been opened and what its new coordinates are.
-        updateCoords(door, currentDirection, rotDirection, -1, false);
-        toggleOpen(door);
-
-        if (!onDisable)
-        {
-            int delay = buttonDelay(endCount)
-                + Math.min(plugin.getMinimumDoorDelay(), plugin.getConfigLoader().coolDown() * 20);
-            new BukkitRunnable()
-            {
-                @Override
-                public void run()
-                {
-                    plugin.getCommander().setDoorAvailable(door.getDoorUID());
-                    Bukkit.getPluginManager()
-                        .callEvent(new DoorEventToggleEnd(door, (door.isOpen() ? ToggleType.OPEN : ToggleType.CLOSE),
-                                                          instantOpen));
-
-                    if (door.isOpen())
-                        plugin.getAutoCloseScheduler().scheduleAutoClose(door, time, instantOpen);
-                }
-            }.runTaskLater(plugin, delay);
-        }
+        super.putBlocks(onDisable, time, endCount,
+                        gnl::getNewLocation,
+                        () -> updateCoords(door, currentDirection, rotDirection, -1, false));
     }
 
     // Method that takes care of the rotation aspect.
@@ -507,12 +424,6 @@ public class CylindricalMover extends BlockMover
         else if (matData == 3 || matData == 7)
             matData = (byte) (matData - 2);
         return matData;
-    }
-
-    // Toggle the open status of a drawbridge.
-    private void toggleOpen(Door door)
-    {
-        door.setOpenStatus(!door.isOpen());
     }
 
     // Update the coordinates of a door based on its location, direction it's

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/CylindricalMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/CylindricalMover.java
@@ -210,7 +210,7 @@ public class CylindricalMover extends BlockMover
             {
                 NMSBlock block = mbd.getBlock();
                 if (block != null && Util.isAllowedBlock(mbd.getMat()))
-                    block.deleteOriginalBlock();
+                    block.deleteOriginalBlock(false);
             }
 
         savedBlocks.trimToSize();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingMover.java
@@ -141,7 +141,7 @@ public class SlidingMover extends BlockMover
             {
                 NMSBlock block = mbd.getBlock();
                 if (block != null && Util.isAllowedBlock(mbd.getMat()))
-                    block.deleteOriginalBlock();
+                    block.deleteOriginalBlock(false);
             }
 
         savedBlocks.trimToSize();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingMover.java
@@ -5,8 +5,6 @@ import nl.pim16aap2.bigDoors.Door;
 import nl.pim16aap2.bigDoors.NMS.CustomCraftFallingBlock;
 import nl.pim16aap2.bigDoors.NMS.FallingBlockFactory;
 import nl.pim16aap2.bigDoors.NMS.NMSBlock;
-import nl.pim16aap2.bigDoors.events.DoorEventToggle.ToggleType;
-import nl.pim16aap2.bigDoors.events.DoorEventToggleEnd;
 import nl.pim16aap2.bigDoors.util.DoorDirection;
 import nl.pim16aap2.bigDoors.util.MyBlockData;
 import nl.pim16aap2.bigDoors.util.RotateDirection;
@@ -21,9 +19,6 @@ import org.bukkit.material.MaterialData;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
-import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 public class SlidingMover extends BlockMover
 {
     private FallingBlockFactory fabf;
@@ -33,14 +28,11 @@ public class SlidingMover extends BlockMover
     private World world;
     private BigDoors plugin;
     private int tickRate;
-    private boolean instantOpen;
     private int moveX, moveZ;
     private int blocksToMove;
     private RotateDirection openDirection;
     private int xMin, xMax, yMin;
     private int yMax, zMin, zMax;
-    private ArrayList<MyBlockData> savedBlocks = new ArrayList<>();
-    private final AtomicBoolean blocksPlaced = new AtomicBoolean(false);
     private int endCount;
     private BukkitRunnable animationRunnable;
 
@@ -48,12 +40,11 @@ public class SlidingMover extends BlockMover
     public SlidingMover(BigDoors plugin, World world, double time, Door door, boolean instantOpen, int blocksToMove,
         RotateDirection openDirection, double multiplier)
     {
-        super(plugin, door);
+        super(plugin, door, instantOpen);
         this.plugin = plugin;
         this.world = world;
         this.door = door;
         fabf = plugin.getFABF();
-        this.instantOpen = instantOpen;
 
         // North and West direction move negatively along the Z/X axis.
         this.blocksToMove = (openDirection.equals(RotateDirection.NORTH) ||
@@ -137,12 +128,9 @@ public class SlidingMover extends BlockMover
 
         // This is only supported on 1.13
         if (BigDoors.isOnFlattenedVersion())
-            for (MyBlockData mbd : savedBlocks)
-            {
-                NMSBlock block = mbd.getBlock();
-                if (block != null && Util.isAllowedBlock(mbd.getMat()))
-                    block.deleteOriginalBlock(false);
-            }
+        {
+            savedBlocks.forEach(myBlockData -> myBlockData.getBlock().deleteOriginalBlock(false));
+        }
 
         savedBlocks.trimToSize();
 
@@ -161,86 +149,12 @@ public class SlidingMover extends BlockMover
         this.putBlocks(onDisable);
     }
 
-    // Put the door blocks back, but change their state now.
-    @SuppressWarnings("deprecation")
     @Override
     public synchronized void putBlocks(boolean onDisable)
     {
-        if (blocksPlaced.getAndSet(true))
-            return;
-
-        int index = 0;
-        double yAxis = yMin;
-        do
-        {
-            double zAxis = zMin;
-            do
-            {
-                for (int xAxis = xMin; xAxis <= xMax; ++xAxis)
-                {
-                    Material mat = savedBlocks.get(index).getMat();
-                    if (!mat.equals(Material.AIR))
-                    {
-                        byte matByte = savedBlocks.get(index).getBlockByte();
-                        Location newPos = getNewLocation(xAxis, yAxis, zAxis);
-
-                        if (!instantOpen)
-                            savedBlocks.get(index).getFBlock().remove();
-
-                        if (!savedBlocks.get(index).getMat().equals(Material.AIR))
-                            if (plugin.isOnFlattenedVersion())
-                            {
-                                savedBlocks.get(index).getBlock().putBlock(newPos);
-
-                                Block b = world.getBlockAt(newPos);
-                                BlockState bs = b.getState();
-                                bs.update();
-                            }
-                            else
-                            {
-                                Block b = world.getBlockAt(newPos);
-                                MaterialData matData = savedBlocks.get(index).getMatData();
-                                matData.setData(matByte);
-
-                                b.setType(mat);
-                                BlockState bs = b.getState();
-                                bs.setData(matData);
-                                bs.update();
-                            }
-                    }
-                    ++index;
-                }
-                ++zAxis;
-            }
-            while (zAxis <= zMax);
-            ++yAxis;
-        }
-        while (yAxis <= yMax);
-        savedBlocks.clear();
-
-        // Tell the door object it has been opened and what its new coordinates are.
-        updateCoords(door, null, openDirection, blocksToMove, NS, false);
-        toggleOpen(door);
-
-        if (!onDisable)
-        {
-            int delay = buttonDelay(endCount)
-                + Math.min(plugin.getMinimumDoorDelay(), plugin.getConfigLoader().coolDown() * 20);
-            new BukkitRunnable()
-            {
-                @Override
-                public void run()
-                {
-                    plugin.getCommander().setDoorAvailable(door.getDoorUID());
-                    Bukkit.getPluginManager()
-                        .callEvent(new DoorEventToggleEnd(door, (door.isOpen() ? ToggleType.OPEN : ToggleType.CLOSE),
-                                                          instantOpen));
-
-                    if (door.isOpen())
-                        plugin.getAutoCloseScheduler().scheduleAutoClose(door, time, instantOpen);
-                }
-            }.runTaskLater(plugin, delay);
-        }
+        super.putBlocks(onDisable, time, endCount,
+                        (__, x, y, z) -> getNewLocation(x, y, z),
+                        () -> updateCoords(door, null, openDirection, blocksToMove, NS, false));
     }
 
     private Location getNewLocation(double xAxis, double yAxis, double zAxis)
@@ -287,9 +201,9 @@ public class SlidingMover extends BlockMover
                 if (!plugin.getCommander().canGo() || counter > totalTicks || firstBlockData == null)
                 {
                     Util.playSound(door.getEngine(), "bd.thud", 2f, 0.15f);
-                    for (int idx = 0; idx < savedBlocks.size(); ++idx)
-                        if (!savedBlocks.get(idx).getMat().equals(Material.AIR))
-                            savedBlocks.get(idx).getFBlock().setVelocity(new Vector(0D, 0D, 0D));
+                    for (MyBlockData savedBlock : savedBlocks)
+                        if (!savedBlock.getMat().equals(Material.AIR))
+                            savedBlock.getFBlock().setVelocity(new Vector(0D, 0D, 0D));
                     Bukkit.getScheduler().callSyncMethod(plugin, () ->
                     {
                         putBlocks(false);
@@ -316,12 +230,6 @@ public class SlidingMover extends BlockMover
             }
         };
         animationRunnable.runTaskTimerAsynchronously(plugin, 14, tickRate);
-    }
-
-    // Toggle the open status of a drawbridge.
-    private void toggleOpen(Door door)
-    {
-        door.setOpenStatus(!door.isOpen());
     }
 
     // Update the coordinates of a door based on its location, direction it's

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/SlidingMover.java
@@ -19,6 +19,9 @@ import org.bukkit.material.MaterialData;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class SlidingMover extends BlockMover
 {
     private FallingBlockFactory fabf;
@@ -90,6 +93,11 @@ public class SlidingMover extends BlockMover
     {
         savedBlocks.ensureCapacity(door.getBlockCount());
 
+        // This will reserve a bit too much memory, but not enough to worry about.
+        final List<NMSBlock> edges =
+            new ArrayList<>(Math.min(door.getBlockCount(),
+                                     (xMax - xMin + 1) * 2 + (yMax - yMin + 1) * 2 + (zMax - zMin + 1) * 2));
+
         int yAxis = yMin;
         do
         {
@@ -117,6 +125,11 @@ public class SlidingMover extends BlockMover
                             fBlock = fabf.fallingBlockFactory(newFBlockLocation, block, matData, mat);
                         savedBlocks
                             .add(new MyBlockData(mat, matData, fBlock, 0, materialData, block, 0, startLocation));
+
+                        if (xAxis == xMin || xAxis == xMax ||
+                            yAxis == yMin || yAxis == yMax ||
+                            zAxis == zMin || zAxis == zMax)
+                            edges.add(block);
                     }
                 }
                 ++zAxis;
@@ -130,6 +143,8 @@ public class SlidingMover extends BlockMover
         if (BigDoors.isOnFlattenedVersion())
         {
             savedBlocks.forEach(myBlockData -> myBlockData.getBlock().deleteOriginalBlock(false));
+            // Update the physics around the edges after we've removed all our blocks.
+            edges.forEach(block -> block.deleteOriginalBlock(true));
         }
 
         savedBlocks.trimToSize();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/VerticalMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/VerticalMover.java
@@ -130,7 +130,7 @@ public class VerticalMover extends BlockMover
             {
                 NMSBlock block = mbd.getBlock();
                 if (block != null && Util.isAllowedBlock(mbd.getMat()))
-                    block.deleteOriginalBlock();
+                    block.deleteOriginalBlock(false);
             }
 
         savedBlocks.trimToSize();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/VerticalMover.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/moveBlocks/VerticalMover.java
@@ -19,6 +19,9 @@ import org.bukkit.material.MaterialData;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class VerticalMover extends BlockMover
 {
     private FallingBlockFactory fabf;
@@ -79,6 +82,11 @@ public class VerticalMover extends BlockMover
     {
         savedBlocks.ensureCapacity(door.getBlockCount());
 
+        // This will reserve a bit too much memory, but not enough to worry about.
+        final List<NMSBlock> edges =
+            new ArrayList<>(Math.min(door.getBlockCount(),
+                                     (xMax - xMin + 1) * 2 + (yMax - yMin + 1) * 2 + (zMax - zMin + 1) * 2));
+
         int yAxis = yMin;
         do
         {
@@ -106,6 +114,11 @@ public class VerticalMover extends BlockMover
                             fBlock = fabf.fallingBlockFactory(newFBlockLocation, block, matData, mat);
                         savedBlocks
                             .add(new MyBlockData(mat, matData, fBlock, 0, materialData, block, 0, startLocation));
+
+                        if (xAxis == xMin || xAxis == xMax ||
+                            yAxis == yMin || yAxis == yMax ||
+                            zAxis == zMin || zAxis == zMax)
+                            edges.add(block);
                     }
                 }
                 ++zAxis;
@@ -119,6 +132,8 @@ public class VerticalMover extends BlockMover
         if (BigDoors.isOnFlattenedVersion())
         {
             savedBlocks.forEach(myBlockData -> myBlockData.getBlock().deleteOriginalBlock(false));
+            // Update the physics around the edges after we've removed all our blocks.
+            edges.forEach(block -> block.deleteOriginalBlock(true));
         }
 
         savedBlocks.trimToSize();

--- a/core/src/main/java/nl/pim16aap2/bigDoors/util/Util.java
+++ b/core/src/main/java/nl/pim16aap2/bigDoors/util/Util.java
@@ -533,18 +533,11 @@ public final class Util
             return 2;
         // Panes only have to rotate on 1.13+.
         // On versions before, rotating it only changes its color...
-        if ((BigDoors.get().isOnFlattenedVersion()) &&
-            (xmat.equals(XMaterial.WHITE_STAINED_GLASS_PANE) || xmat.equals(XMaterial.YELLOW_STAINED_GLASS_PANE) ||
-             xmat.equals(XMaterial.PURPLE_STAINED_GLASS_PANE) || xmat.equals(XMaterial.LIGHT_BLUE_STAINED_GLASS_PANE) ||
-             xmat.equals(XMaterial.GRAY_STAINED_GLASS_PANE) || xmat.equals(XMaterial.GREEN_STAINED_GLASS_PANE) ||
-             xmat.equals(XMaterial.BLACK_STAINED_GLASS_PANE) || xmat.equals(XMaterial.LIME_STAINED_GLASS_PANE) ||
-             xmat.equals(XMaterial.BLUE_STAINED_GLASS_PANE) || xmat.equals(XMaterial.BROWN_STAINED_GLASS_PANE) ||
-             xmat.equals(XMaterial.CYAN_STAINED_GLASS_PANE) || xmat.equals(XMaterial.RED_STAINED_GLASS_PANE) ||
-             xmat.equals(XMaterial.MAGENTA_STAINED_GLASS_PANE)))
+        if ((BigDoors.isOnFlattenedVersion()) && (mat.toString().endsWith("GLASS_PANE")))
             return 3;
         if (xmat.equals(XMaterial.ANVIL))
             return 4;
-        if (xmat.equals(XMaterial.COBBLESTONE_WALL))
+        if (mat.toString().endsWith("_WALL"))
             return 5;
         if (xmat.equals(XMaterial.STRIPPED_ACACIA_LOG) || xmat.equals(XMaterial.STRIPPED_BIRCH_LOG) ||
             xmat.equals(XMaterial.STRIPPED_SPRUCE_LOG) || xmat.equals(XMaterial.STRIPPED_DARK_OAK_LOG) ||
@@ -553,7 +546,16 @@ public final class Util
             return 6;
         if (xmat.equals(XMaterial.END_ROD))
             return 7;
-        if (xmat.equals(XMaterial.LIGHTNING_ROD))
+        if (xmat.equals(XMaterial.LIGHTNING_ROD) || xmat.equals(XMaterial.REDSTONE_WIRE) ||
+            mat.toString().endsWith("BUTTON") || xmat.equals(XMaterial.REPEATER) ||
+            mat.toString().endsWith("RAIL") || xmat.equals(XMaterial.TRIPWIRE_HOOK) ||
+            mat.toString().endsWith("_DOOR") || mat.toString().endsWith("_HEAD") ||
+            mat.toString().endsWith("_SIGN") || mat.toString().endsWith("_BANNER") ||
+            xmat.equals(XMaterial.WALL_TORCH) || xmat.equals(XMaterial.SOUL_WALL_TORCH) ||
+            xmat.equals(XMaterial.REDSTONE_WALL_TORCH) || xmat.equals(XMaterial.VINE) ||
+            xmat.equals(XMaterial.COMPARATOR) || xmat.equals(XMaterial.LADDER) ||
+            xmat.equals(XMaterial.LEVER) || xmat.equals(XMaterial.BIG_DRIPLEAF) ||
+            xmat.equals(XMaterial.BIG_DRIPLEAF_STEM) || xmat.equals(XMaterial.SMALL_DRIPLEAF))
             return 8;
         return 0;
     }
@@ -586,11 +588,12 @@ public final class Util
             return true;
 
         if (name.endsWith("BANNER") || name.endsWith("SHULKER_BOX") || name.endsWith("DOOR") ||
-            name.endsWith("CARPET") || name.endsWith("BUTTON") || name.endsWith("BED") ||
-            name.endsWith("PRESSURE_PLATE") || name.endsWith("SIGN") || name.endsWith("SAPLING") ||
-            name.endsWith("TORCH") || name.endsWith("HEAD") || name.endsWith("SKULL") || name.endsWith("RAIL") ||
-            name.endsWith("TULIP"))
+            name.endsWith("BED") || name.endsWith("SIGN") || name.endsWith("HEAD") || name.endsWith("SKULL"))
             return false;
+
+        if (name.endsWith("CARPET") || name.endsWith("BUTTON") || name.endsWith("PRESSURE_PLATE") ||
+            name.endsWith("SAPLING") || name.endsWith("TORCH") || name.endsWith("RAIL") || name.endsWith("TULIP"))
+            return BigDoors.getMCVersion().isAtLeast(BigDoors.MCVersion.v1_18);
 
         XMaterial xmat = XMaterial.matchXMaterial(name).orElse(null);
         if (xmat == null)
@@ -601,9 +604,69 @@ public final class Util
 
         switch (xmat)
         {
+        case CAKE:
+        case LEVER:
+        case REDSTONE_WIRE:
+        case TRIPWIRE:
+        case TRIPWIRE_HOOK:
+        case BROWN_MUSHROOM:
+        case RED_MUSHROOM:
+        case DEAD_BUSH:
+        case FERN:
+        case LARGE_FERN:
+        case ROSE_BUSH:
+        case ATTACHED_MELON_STEM:
+        case ATTACHED_PUMPKIN_STEM:
+        case WHITE_TULIP:
+        case LILY_PAD:
+        case SUGAR_CANE:
+        case PUMPKIN_STEM:
+        case NETHER_WART:
+        case NETHER_WART_BLOCK:
+        case VINE:
+        case CHORUS_FLOWER:
+        case CHORUS_FRUIT:
+        case CHORUS_PLANT:
+        case SUNFLOWER:
+        case REPEATER:
+        case COMPARATOR:
+        case SEA_PICKLE:
+        case POPPY:
+        case BLUE_ORCHID:
+        case ALLIUM:
+        case AZURE_BLUET:
+        case OXEYE_DAISY:
+        case LILAC:
+        case PEONY:
+        case GRASS:
+        case TALL_GRASS:
+        case SEAGRASS:
+        case TALL_SEAGRASS:
+        case LADDER:
+        case DANDELION:
+        case CORNFLOWER:
+        case LILY_OF_THE_VALLEY:
+        case WITHER_ROSE:
+        case SWEET_BERRY_BUSH:
+        case LANTERN:
+        case BELL:
+        case CAVE_VINES:
+        case CAVE_VINES_PLANT:
+        case GLOW_LICHEN:
+        case MOSS_CARPET:
+        case AMETHYST_CLUSTER:
+        case BIG_DRIPLEAF:
+        case BIG_DRIPLEAF_STEM:
+            return BigDoors.getMCVersion().isAtLeast(BigDoors.MCVersion.v1_18);
+
+
+
         case AIR:
         case WATER:
         case LAVA:
+
+        case GLOW_ITEM_FRAME:
+        case ITEM_FRAME:
 
         case ARMOR_STAND:
         case BREWING_STAND:
@@ -619,67 +682,17 @@ public final class Util
         case SPAWNER:
         case FURNACE:
         case FURNACE_MINECART:
-        case CAKE:
-
-        case LEVER:
 
         case REDSTONE:
-        case REDSTONE_WIRE:
         case TRAPPED_CHEST:
-        case TRIPWIRE:
-        case TRIPWIRE_HOOK:
 
-        case BROWN_MUSHROOM:
-        case RED_MUSHROOM:
-        case DEAD_BUSH:
-        case FERN:
-        case LARGE_FERN:
-        case CONDUIT:
-
-        case ROSE_BUSH:
-        case ATTACHED_MELON_STEM:
-        case ATTACHED_PUMPKIN_STEM:
-        case WHITE_TULIP:
-        case LILY_PAD:
-        case SUGAR_CANE:
-        case PUMPKIN_STEM:
-        case NETHER_WART:
-        case NETHER_WART_BLOCK:
-        case VINE:
-        case CHORUS_FLOWER:
-        case CHORUS_FRUIT:
-        case CHORUS_PLANT:
-        case SUNFLOWER:
-
-        case REPEATER:
         case COMMAND_BLOCK:
         case COMMAND_BLOCK_MINECART:
-        case COMPARATOR:
-        case SEA_PICKLE:
-
-        case POPPY:
-        case BLUE_ORCHID:
-        case ALLIUM:
-        case AZURE_BLUET:
-        case OXEYE_DAISY:
-        case LILAC:
-        case PEONY:
-        case GRASS:
-        case TALL_GRASS:
-        case SEAGRASS:
-        case TALL_SEAGRASS:
-
-        case LADDER:
 
         case STRUCTURE_BLOCK:
         case STRUCTURE_VOID:
 
             /* 1.14 start */
-
-        case DANDELION:
-        case CORNFLOWER:
-        case LILY_OF_THE_VALLEY:
-        case WITHER_ROSE:
         case BARREL:
 
         case BLAST_FURNACE:
@@ -692,28 +705,13 @@ public final class Util
         case LECTERN:
         case LOOM:
         case SMITHING_TABLE:
-//        case SMOKER:
         case STONECUTTER:
-        case SWEET_BERRY_BUSH:
-        case LANTERN:
-        case BELL:
             /* 1.14 end */
 
             /* 1.15 start */
         case BEEHIVE:
         case BEE_NEST:
             /* 1.15 end */
-
-            /* 1.17 start */
-        case CAVE_VINES:
-        case CAVE_VINES_PLANT:
-        case GLOW_ITEM_FRAME:
-        case GLOW_LICHEN:
-        case MOSS_CARPET:
-        case AMETHYST_CLUSTER:
-        case BIG_DRIPLEAF:
-        case BIG_DRIPLEAF_STEM:
-            /* 1.17 end */
 
             return false;
         default:

--- a/nms/nms-api/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock.java
+++ b/nms/nms-api/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock.java
@@ -17,7 +17,7 @@ public interface NMSBlock
     void rotateCylindrical(RotateDirection rotDir);
     boolean canRotate();
 
-    void deleteOriginalBlock();
+    void deleteOriginalBlock(boolean applyPhysics);
     @Override
     String toString();
 }

--- a/nms/v1_13_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R1.java
+++ b/nms/v1_13_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R1.java
@@ -153,6 +153,14 @@ public class NMSBlock_V1_13_R1 extends net.minecraft.server.v1_13_R1.Block imple
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 }

--- a/nms/v1_13_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R1.java
+++ b/nms/v1_13_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R1.java
@@ -1,8 +1,12 @@
 package nl.pim16aap2.bigDoors.NMS;
 
-import java.util.Set;
-
 import com.cryptomorin.xseries.XMaterial;
+import net.minecraft.server.v1_13_R1.BlockPosition;
+import net.minecraft.server.v1_13_R1.BlockRotatable;
+import net.minecraft.server.v1_13_R1.EnumBlockRotation;
+import net.minecraft.server.v1_13_R1.EnumDirection.EnumAxis;
+import net.minecraft.server.v1_13_R1.IBlockData;
+import nl.pim16aap2.bigDoors.util.RotateDirection;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -13,12 +17,7 @@ import org.bukkit.craftbukkit.v1_13_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_13_R1.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_13_R1.block.data.CraftBlockData;
 
-import net.minecraft.server.v1_13_R1.BlockPosition;
-import net.minecraft.server.v1_13_R1.BlockRotatable;
-import net.minecraft.server.v1_13_R1.EnumBlockRotation;
-import net.minecraft.server.v1_13_R1.EnumDirection.EnumAxis;
-import net.minecraft.server.v1_13_R1.IBlockData;
-import nl.pim16aap2.bigDoors.util.RotateDirection;
+import java.util.Set;
 
 public class NMSBlock_V1_13_R1 extends net.minecraft.server.v1_13_R1.Block implements NMSBlock
 {
@@ -152,8 +151,8 @@ public class NMSBlock_V1_13_R1 extends net.minecraft.server.v1_13_R1.Block imple
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 }

--- a/nms/v1_13_R1_5/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R1_5.java
+++ b/nms/v1_13_R1_5/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R1_5.java
@@ -1,7 +1,12 @@
 package nl.pim16aap2.bigDoors.NMS;
 
-import java.util.Set;
-
+import com.cryptomorin.xseries.XMaterial;
+import net.minecraft.server.v1_13_R2.BlockPosition;
+import net.minecraft.server.v1_13_R2.BlockRotatable;
+import net.minecraft.server.v1_13_R2.EnumBlockRotation;
+import net.minecraft.server.v1_13_R2.EnumDirection.EnumAxis;
+import net.minecraft.server.v1_13_R2.IBlockData;
+import nl.pim16aap2.bigDoors.util.RotateDirection;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -12,13 +17,7 @@ import org.bukkit.craftbukkit.v1_13_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_13_R2.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_13_R2.block.data.CraftBlockData;
 
-import net.minecraft.server.v1_13_R2.BlockPosition;
-import net.minecraft.server.v1_13_R2.BlockRotatable;
-import net.minecraft.server.v1_13_R2.EnumBlockRotation;
-import net.minecraft.server.v1_13_R2.EnumDirection.EnumAxis;
-import net.minecraft.server.v1_13_R2.IBlockData;
-import nl.pim16aap2.bigDoors.util.RotateDirection;
-import com.cryptomorin.xseries.XMaterial;
+import java.util.Set;
 
 public class NMSBlock_V1_13_R1_5 extends net.minecraft.server.v1_13_R2.Block implements NMSBlock
 {
@@ -152,8 +151,8 @@ public class NMSBlock_V1_13_R1_5 extends net.minecraft.server.v1_13_R2.Block imp
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 }

--- a/nms/v1_13_R1_5/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R1_5.java
+++ b/nms/v1_13_R1_5/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R1_5.java
@@ -153,6 +153,14 @@ public class NMSBlock_V1_13_R1_5 extends net.minecraft.server.v1_13_R2.Block imp
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 }

--- a/nms/v1_13_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R2.java
+++ b/nms/v1_13_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R2.java
@@ -1,7 +1,12 @@
 package nl.pim16aap2.bigDoors.NMS;
 
-import java.util.Set;
-
+import com.cryptomorin.xseries.XMaterial;
+import net.minecraft.server.v1_13_R2.BlockPosition;
+import net.minecraft.server.v1_13_R2.BlockRotatable;
+import net.minecraft.server.v1_13_R2.EnumBlockRotation;
+import net.minecraft.server.v1_13_R2.EnumDirection.EnumAxis;
+import net.minecraft.server.v1_13_R2.IBlockData;
+import nl.pim16aap2.bigDoors.util.RotateDirection;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -12,13 +17,7 @@ import org.bukkit.craftbukkit.v1_13_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_13_R2.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_13_R2.block.data.CraftBlockData;
 
-import net.minecraft.server.v1_13_R2.BlockPosition;
-import net.minecraft.server.v1_13_R2.BlockRotatable;
-import net.minecraft.server.v1_13_R2.EnumBlockRotation;
-import net.minecraft.server.v1_13_R2.EnumDirection.EnumAxis;
-import net.minecraft.server.v1_13_R2.IBlockData;
-import nl.pim16aap2.bigDoors.util.RotateDirection;
-import com.cryptomorin.xseries.XMaterial;
+import java.util.Set;
 
 public class NMSBlock_V1_13_R2 extends net.minecraft.server.v1_13_R2.Block implements NMSBlock
 {
@@ -152,8 +151,8 @@ public class NMSBlock_V1_13_R2 extends net.minecraft.server.v1_13_R2.Block imple
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 }

--- a/nms/v1_13_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R2.java
+++ b/nms/v1_13_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_13_R2.java
@@ -153,6 +153,14 @@ public class NMSBlock_V1_13_R2 extends net.minecraft.server.v1_13_R2.Block imple
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 }

--- a/nms/v1_14_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_14_R1.java
+++ b/nms/v1_14_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_14_R1.java
@@ -1,7 +1,12 @@
 package nl.pim16aap2.bigDoors.NMS;
 
-import java.util.Set;
-
+import com.cryptomorin.xseries.XMaterial;
+import net.minecraft.server.v1_14_R1.BlockPosition;
+import net.minecraft.server.v1_14_R1.BlockRotatable;
+import net.minecraft.server.v1_14_R1.EnumBlockRotation;
+import net.minecraft.server.v1_14_R1.EnumDirection.EnumAxis;
+import net.minecraft.server.v1_14_R1.IBlockData;
+import nl.pim16aap2.bigDoors.util.RotateDirection;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -12,13 +17,7 @@ import org.bukkit.craftbukkit.v1_14_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_14_R1.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_14_R1.block.data.CraftBlockData;
 
-import net.minecraft.server.v1_14_R1.BlockPosition;
-import net.minecraft.server.v1_14_R1.BlockRotatable;
-import net.minecraft.server.v1_14_R1.EnumBlockRotation;
-import net.minecraft.server.v1_14_R1.EnumDirection.EnumAxis;
-import net.minecraft.server.v1_14_R1.IBlockData;
-import nl.pim16aap2.bigDoors.util.RotateDirection;
-import com.cryptomorin.xseries.XMaterial;
+import java.util.Set;
 
 public class NMSBlock_V1_14_R1 extends net.minecraft.server.v1_14_R1.Block implements NMSBlock
 {
@@ -152,8 +151,8 @@ public class NMSBlock_V1_14_R1 extends net.minecraft.server.v1_14_R1.Block imple
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 }

--- a/nms/v1_14_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_14_R1.java
+++ b/nms/v1_14_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_14_R1.java
@@ -153,6 +153,14 @@ public class NMSBlock_V1_14_R1 extends net.minecraft.server.v1_14_R1.Block imple
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 }

--- a/nms/v1_15_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_15_R1.java
+++ b/nms/v1_15_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_15_R1.java
@@ -1,7 +1,12 @@
 package nl.pim16aap2.bigDoors.NMS;
 
-import java.util.Set;
-
+import com.cryptomorin.xseries.XMaterial;
+import net.minecraft.server.v1_15_R1.BlockPosition;
+import net.minecraft.server.v1_15_R1.BlockRotatable;
+import net.minecraft.server.v1_15_R1.EnumBlockRotation;
+import net.minecraft.server.v1_15_R1.EnumDirection.EnumAxis;
+import net.minecraft.server.v1_15_R1.IBlockData;
+import nl.pim16aap2.bigDoors.util.RotateDirection;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -12,13 +17,7 @@ import org.bukkit.craftbukkit.v1_15_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_15_R1.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_15_R1.block.data.CraftBlockData;
 
-import net.minecraft.server.v1_15_R1.BlockPosition;
-import net.minecraft.server.v1_15_R1.BlockRotatable;
-import net.minecraft.server.v1_15_R1.EnumBlockRotation;
-import net.minecraft.server.v1_15_R1.EnumDirection.EnumAxis;
-import net.minecraft.server.v1_15_R1.IBlockData;
-import nl.pim16aap2.bigDoors.util.RotateDirection;
-import com.cryptomorin.xseries.XMaterial;
+import java.util.Set;
 
 public class NMSBlock_V1_15_R1 extends net.minecraft.server.v1_15_R1.Block implements NMSBlock
 {
@@ -162,8 +161,8 @@ public class NMSBlock_V1_15_R1 extends net.minecraft.server.v1_15_R1.Block imple
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 }

--- a/nms/v1_15_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_15_R1.java
+++ b/nms/v1_15_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_15_R1.java
@@ -163,6 +163,14 @@ public class NMSBlock_V1_15_R1 extends net.minecraft.server.v1_15_R1.Block imple
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 }

--- a/nms/v1_16_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R1.java
+++ b/nms/v1_16_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R1.java
@@ -1,7 +1,14 @@
 package nl.pim16aap2.bigDoors.NMS;
 
-import java.util.Set;
-
+import com.cryptomorin.xseries.XMaterial;
+import net.minecraft.server.v1_16_R1.Block;
+import net.minecraft.server.v1_16_R1.BlockPosition;
+import net.minecraft.server.v1_16_R1.BlockRotatable;
+import net.minecraft.server.v1_16_R1.EnumBlockRotation;
+import net.minecraft.server.v1_16_R1.EnumDirection.EnumAxis;
+import net.minecraft.server.v1_16_R1.IBlockData;
+import net.minecraft.server.v1_16_R1.Item;
+import nl.pim16aap2.bigDoors.util.RotateDirection;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -12,15 +19,7 @@ import org.bukkit.craftbukkit.v1_16_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R1.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_16_R1.block.data.CraftBlockData;
 
-import net.minecraft.server.v1_16_R1.Block;
-import net.minecraft.server.v1_16_R1.BlockPosition;
-import net.minecraft.server.v1_16_R1.BlockRotatable;
-import net.minecraft.server.v1_16_R1.EnumBlockRotation;
-import net.minecraft.server.v1_16_R1.EnumDirection.EnumAxis;
-import net.minecraft.server.v1_16_R1.IBlockData;
-import net.minecraft.server.v1_16_R1.Item;
-import nl.pim16aap2.bigDoors.util.RotateDirection;
-import com.cryptomorin.xseries.XMaterial;
+import java.util.Set;
 
 public class NMSBlock_V1_16_R1 extends net.minecraft.server.v1_16_R1.BlockBase implements NMSBlock
 {
@@ -161,9 +160,9 @@ public class NMSBlock_V1_16_R1 extends net.minecraft.server.v1_16_R1.BlockBase i
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 
     @Override

--- a/nms/v1_16_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R1.java
+++ b/nms/v1_16_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R1.java
@@ -162,7 +162,15 @@ public class NMSBlock_V1_16_R1 extends net.minecraft.server.v1_16_R1.BlockBase i
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 
     @Override

--- a/nms/v1_16_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R2.java
+++ b/nms/v1_16_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R2.java
@@ -1,7 +1,14 @@
 package nl.pim16aap2.bigDoors.NMS;
 
-import java.util.Set;
-
+import com.cryptomorin.xseries.XMaterial;
+import net.minecraft.server.v1_16_R2.Block;
+import net.minecraft.server.v1_16_R2.BlockPosition;
+import net.minecraft.server.v1_16_R2.BlockRotatable;
+import net.minecraft.server.v1_16_R2.EnumBlockRotation;
+import net.minecraft.server.v1_16_R2.EnumDirection.EnumAxis;
+import net.minecraft.server.v1_16_R2.IBlockData;
+import net.minecraft.server.v1_16_R2.Item;
+import nl.pim16aap2.bigDoors.util.RotateDirection;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -12,15 +19,7 @@ import org.bukkit.craftbukkit.v1_16_R2.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R2.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_16_R2.block.data.CraftBlockData;
 
-import net.minecraft.server.v1_16_R2.Block;
-import net.minecraft.server.v1_16_R2.BlockPosition;
-import net.minecraft.server.v1_16_R2.BlockRotatable;
-import net.minecraft.server.v1_16_R2.EnumBlockRotation;
-import net.minecraft.server.v1_16_R2.EnumDirection.EnumAxis;
-import net.minecraft.server.v1_16_R2.IBlockData;
-import net.minecraft.server.v1_16_R2.Item;
-import nl.pim16aap2.bigDoors.util.RotateDirection;
-import com.cryptomorin.xseries.XMaterial;
+import java.util.Set;
 
 public class NMSBlock_V1_16_R2 extends net.minecraft.server.v1_16_R2.BlockBase implements NMSBlock
 {
@@ -161,9 +160,9 @@ public class NMSBlock_V1_16_R2 extends net.minecraft.server.v1_16_R2.BlockBase i
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 
     @Override

--- a/nms/v1_16_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R2.java
+++ b/nms/v1_16_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R2.java
@@ -162,7 +162,15 @@ public class NMSBlock_V1_16_R2 extends net.minecraft.server.v1_16_R2.BlockBase i
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 
     @Override

--- a/nms/v1_16_R3/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R3.java
+++ b/nms/v1_16_R3/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R3.java
@@ -1,7 +1,14 @@
 package nl.pim16aap2.bigDoors.NMS;
 
-import java.util.Set;
-
+import com.cryptomorin.xseries.XMaterial;
+import net.minecraft.server.v1_16_R3.Block;
+import net.minecraft.server.v1_16_R3.BlockPosition;
+import net.minecraft.server.v1_16_R3.BlockRotatable;
+import net.minecraft.server.v1_16_R3.EnumBlockRotation;
+import net.minecraft.server.v1_16_R3.EnumDirection.EnumAxis;
+import net.minecraft.server.v1_16_R3.IBlockData;
+import net.minecraft.server.v1_16_R3.Item;
+import nl.pim16aap2.bigDoors.util.RotateDirection;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -12,15 +19,7 @@ import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R3.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_16_R3.block.data.CraftBlockData;
 
-import net.minecraft.server.v1_16_R3.Block;
-import net.minecraft.server.v1_16_R3.BlockPosition;
-import net.minecraft.server.v1_16_R3.BlockRotatable;
-import net.minecraft.server.v1_16_R3.EnumBlockRotation;
-import net.minecraft.server.v1_16_R3.EnumDirection.EnumAxis;
-import net.minecraft.server.v1_16_R3.IBlockData;
-import net.minecraft.server.v1_16_R3.Item;
-import nl.pim16aap2.bigDoors.util.RotateDirection;
-import com.cryptomorin.xseries.XMaterial;
+import java.util.Set;
 
 public class NMSBlock_V1_16_R3 extends net.minecraft.server.v1_16_R3.BlockBase implements NMSBlock
 {
@@ -161,9 +160,9 @@ public class NMSBlock_V1_16_R3 extends net.minecraft.server.v1_16_R3.BlockBase i
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 
     @Override

--- a/nms/v1_16_R3/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R3.java
+++ b/nms/v1_16_R3/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_16_R3.java
@@ -162,7 +162,15 @@ public class NMSBlock_V1_16_R3 extends net.minecraft.server.v1_16_R3.BlockBase i
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 
     @Override

--- a/nms/v1_17_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_17_R1.java
+++ b/nms/v1_17_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_17_R1.java
@@ -186,9 +186,9 @@ public class NMSBlock_V1_17_R1 extends BlockBase implements NMSBlock
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 
     @Override

--- a/nms/v1_17_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_17_R1.java
+++ b/nms/v1_17_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_17_R1.java
@@ -188,7 +188,15 @@ public class NMSBlock_V1_17_R1 extends BlockBase implements NMSBlock
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 
     @Override

--- a/nms/v1_18_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_18_R1.java
+++ b/nms/v1_18_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_18_R1.java
@@ -185,9 +185,9 @@ public class NMSBlock_V1_18_R1 extends BlockBase implements NMSBlock
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 
     @Override

--- a/nms/v1_18_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_18_R1.java
+++ b/nms/v1_18_R1/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_18_R1.java
@@ -187,7 +187,15 @@ public class NMSBlock_V1_18_R1 extends BlockBase implements NMSBlock
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 
     @Override

--- a/nms/v1_18_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_18_R2.java
+++ b/nms/v1_18_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_18_R2.java
@@ -187,7 +187,15 @@ public class NMSBlock_V1_18_R2 extends BlockBase implements NMSBlock
     @Override
     public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        if (!applyPhysics)
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
+        }
+        else
+        {
+            loc.getWorld().getBlockAt(loc).setType(Material.CAVE_AIR, false);
+            loc.getWorld().getBlockAt(loc).setType(Material.AIR, true);
+        }
     }
 
     @Override

--- a/nms/v1_18_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_18_R2.java
+++ b/nms/v1_18_R2/src/main/java/nl/pim16aap2/bigDoors/NMS/NMSBlock_V1_18_R2.java
@@ -185,9 +185,9 @@ public class NMSBlock_V1_18_R2 extends BlockBase implements NMSBlock
     }
 
     @Override
-    public void deleteOriginalBlock()
+    public void deleteOriginalBlock(boolean applyPhysics)
     {
-        loc.getWorld().getBlockAt(loc).setType(Material.AIR);
+        loc.getWorld().getBlockAt(loc).setType(Material.AIR, applyPhysics);
     }
 
     @Override


### PR DESCRIPTION
Closes #88

This PR ensures that blocks that are attached to soon-to-be animated blocks (e.g. torches, rails, etc) do not get duplicated when they are part of a door. 

This is achieved by not applying physics when creating an animated block. To ensure that attached blocks that are not part of the door but attached to some block that is still get broken as intended, all blocks along the edges of the door are refreshed to ensure a physics update is applied. The refresh happens by first setting the block to CAVE_AIR without applying a physics update and then back to regular AIR, but this time _with_ a request for a physics update. Setting it to AIR with a physics update immediately won't work, as a physics update won't happen if a block doesn't change state.