### PR TITLE
Invert DoorTypeManager - LocalizationManager control

### DIFF
--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/config/ConfigLoaderSpigot.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/config/ConfigLoaderSpigot.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.bigdoors.spigot.config;
 
+import dagger.Lazy;
 import lombok.ToString;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
@@ -51,7 +52,7 @@ public final class ConfigLoaderSpigot implements IConfigLoader, IDebuggable
     @ToString.Exclude
     private final JavaPlugin plugin;
     @ToString.Exclude
-    private final DoorTypeManager doorTypeManager;
+    private final Lazy<DoorTypeManager> doorTypeManager;
     private final Path baseDir;
 
     private static final List<String> DEFAULT_POWERBLOCK_TYPE = List.of("GOLD_BLOCK");
@@ -94,7 +95,7 @@ public final class ConfigLoaderSpigot implements IConfigLoader, IDebuggable
      */
     @Inject
     public ConfigLoaderSpigot(
-        RestartableHolder restartableHolder, JavaPlugin plugin, DoorTypeManager doorTypeManager,
+        RestartableHolder restartableHolder, JavaPlugin plugin, Lazy<DoorTypeManager> doorTypeManager,
         @Named("pluginBaseDirectory") Path baseDir, DebuggableRegistry debuggableRegistry)
     {
         this.plugin = plugin;
@@ -290,9 +291,11 @@ public final class ConfigLoaderSpigot implements IConfigLoader, IDebuggable
                                         "Math.min(0.3 * radius, 3) * Math.sin((counter / 4) * 3)", (String[]) null);
 
 
+        // TODO: The config is loaded before the DoorTypeManager, so we never see any config options for the
+        //       DoorTypes in the config.
         String @Nullable [] usedMultiplierComment = multiplierComment;
         String @Nullable [] usedPricesComment = pricesComment;
-        for (final DoorType type : doorTypeManager.getEnabledDoorTypes())
+        for (final DoorType type : doorTypeManager.get().getEnabledDoorTypes())
         {
             doorMultipliers.put(type, addNewConfigEntry(config, "multiplier_" + type, 0.0D, usedMultiplierComment));
             doorPrices.put(type, addNewConfigEntry(config, "price_" + type, "0", usedPricesComment));

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationManagerIntegrationTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationManagerIntegrationTest.java
@@ -4,7 +4,6 @@ import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
-import nl.pim16aap2.bigdoors.managers.DoorTypeManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +56,7 @@ class LocalizationManagerIntegrationTest
 
         final LocalizationManager localizationManager =
             new LocalizationManager(Mockito.mock(RestartableHolder.class), directoryOutput,
-                                    baseName, configLoader, Mockito.mock(DoorTypeManager.class));
+                                    baseName, configLoader);
 
         localizationManager.shutDown();
         localizationManager.initialize();
@@ -87,7 +86,7 @@ class LocalizationManagerIntegrationTest
 
         final LocalizationManager localizationManager =
             new LocalizationManager(Mockito.mock(RestartableHolder.class), directoryOutput,
-                                    baseName, configLoader, Mockito.mock(DoorTypeManager.class));
+                                    baseName, configLoader);
 
         Assertions.assertEquals("value0", localizationManager.getLocalizer().getMessage("key0"));
         Assertions.assertEquals("value3", localizationManager.getLocalizer().getMessage("key3"));

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/storage/SQLiteJDBCDriverConnectionTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/storage/SQLiteJDBCDriverConnectionTest.java
@@ -22,6 +22,7 @@ import nl.pim16aap2.bigdoors.doors.drawbridge.DoorTypeDrawbridge;
 import nl.pim16aap2.bigdoors.doors.drawbridge.Drawbridge;
 import nl.pim16aap2.bigdoors.doors.portcullis.DoorTypePortcullis;
 import nl.pim16aap2.bigdoors.doors.portcullis.Portcullis;
+import nl.pim16aap2.bigdoors.localization.LocalizationManager;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.DoorRegistry;
 import nl.pim16aap2.bigdoors.managers.DoorTypeManager;
@@ -112,6 +113,9 @@ public class SQLiteJDBCDriverConnectionTest
     @Mock
     private DebuggableRegistry debuggableRegistry;
 
+    @Mock
+    private LocalizationManager localizationManager;
+
     @BeforeEach
     void beforeEach()
         throws NoSuchMethodException
@@ -120,7 +124,7 @@ public class SQLiteJDBCDriverConnectionTest
 
         worldFactory = new TestPWorldFactory();
         doorRegistry = DoorRegistry.unCached(restartableHolder, debuggableRegistry);
-        doorTypeManager = new DoorTypeManager(restartableHolder, debuggableRegistry);
+        doorTypeManager = new DoorTypeManager(restartableHolder, debuggableRegistry, localizationManager);
 
         final AssistedFactoryMocker<DoorBase, DoorBase.IFactory> assistedFactoryMocker =
             new AssistedFactoryMocker<>(DoorBase.class, DoorBase.IFactory.class)


### PR DESCRIPTION
- Before, the LocalizationManager depended on the DoorTypeManager. The LocalizationManager would query all door types from its manager so it could parse the localization stuff. However, the DoorTypeManager would not have loaded the door types yet. Because the LocalizationManager had a higher priority than the DoorTypeManager, the DoorTypes would never be loaded for the LocalizationManager to be parsed. Inverting the control allows the DoorTypeManager to inform the LocalizationManager about any newly-loaded DoorTypes. This means all DoorTypes are parsed by the LocalizationManager.