### PR TITLE
Fix disappearing config options for door types

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/IConfigReader.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/IConfigReader.java
@@ -3,6 +3,8 @@ package nl.pim16aap2.bigdoors.api;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Set;
+
 /**
  * Represents an object that can read values from configs.
  *
@@ -21,4 +23,9 @@ public interface IConfigReader
      */
     @Contract("_, !null -> !null")
     @Nullable Object get(String path, @Nullable Object fallback);
+
+    /**
+     * Gets a set containing all keys.
+     */
+    Set<String> getKeys();
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DoorTypeManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DoorTypeManager.java
@@ -84,6 +84,7 @@ public final class DoorTypeManager extends Restartable implements IDebuggable
         for (final Map.Entry<DoorType, DoorRegistrationStatus> doorType : doorTypeStatus.entrySet())
             if (doorType.getValue().status == status)
                 enabledDoorTypes.add(doorType.getKey());
+        enabledDoorTypes.sort(Comparator.comparing(DoorType::getSimpleName));
         return enabledDoorTypes;
     }
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/util/Util.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/util/Util.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
@@ -918,5 +919,12 @@ public final class Util
         if ("ALL".equals(preparedLogLevelName))
             return Level.ALL;
         return null;
+    }
+
+    public static <T> void sortAlphabetically(List<T> list, Function<T, String> mapper)
+    {
+        if (list.isEmpty())
+            return;
+        list.sort(Comparator.comparing(mapper));
     }
 }

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsPlugin.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/BigDoorsPlugin.java
@@ -8,6 +8,7 @@ import nl.pim16aap2.bigdoors.api.IBigDoorsPlatformProvider;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.debugging.DebuggableRegistry;
 import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
+import nl.pim16aap2.bigdoors.spigot.config.ConfigLoaderSpigot;
 import nl.pim16aap2.bigdoors.spigot.listeners.BackupCommandListener;
 import nl.pim16aap2.bigdoors.spigot.listeners.LoginMessageListener;
 import nl.pim16aap2.bigdoors.spigot.logging.ConsoleAppender;
@@ -159,9 +160,12 @@ public final class BigDoorsPlugin extends JavaPlugin implements IBigDoorsPlatfor
         LOG_BACK_CONFIGURATOR.setLevel(bigDoorsSpigotPlatform.getBigDoorsConfig().logLevel()).apply();
         restartableHolder.initialize();
 
+        // Rewrite the config after everything has been loaded to ensure all
+        // extensions/addons have their hooks in.
+        ((ConfigLoaderSpigot) (bigDoorsSpigotPlatform.getBigDoorsConfig())).rewriteConfig();
+
         if (firstInit)
             initCommands(bigDoorsSpigotPlatform);
-
         // TODO: Remove this before any release.
         printDebug();
     }

--- a/bigdoors-spigot/spigot-util/src/main/java/nl/pim16aap2/bigdoors/spigot/util/implementations/ConfigReaderSpigot.java
+++ b/bigdoors-spigot/spigot-util/src/main/java/nl/pim16aap2/bigdoors/spigot/util/implementations/ConfigReaderSpigot.java
@@ -4,6 +4,8 @@ import nl.pim16aap2.bigdoors.api.IConfigReader;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Set;
+
 /**
  * Spigot implementation for {@link IConfigReader}.
  *
@@ -15,5 +17,11 @@ public record ConfigReaderSpigot(FileConfiguration config) implements IConfigRea
     public @Nullable Object get(String path, @Nullable Object fallback)
     {
         return config.get(path, fallback);
+    }
+
+    @Override
+    public Set<String> getKeys()
+    {
+        return config.getKeys(false);
     }
 }


### PR DESCRIPTION
- The DoorTypes are (currently) loaded after the first init of the config, which means that the config doesn't have a mapping on the first load, which caused them to be removed on the rewrite. This was fixed by also writing out all type-specific config options for unmapped types.
- The type-specific options are now sorted alphabetically.