### PR TITLE
Localization fixes

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationEntry.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationEntry.java
@@ -1,0 +1,13 @@
+package nl.pim16aap2.bigdoors.localization;
+
+/**
+ * Represents an entry in a localization file.
+ *
+ * @param key
+ *     The key of the localization entry. E.g. "start_menu.button.sleep.help".
+ * @param value
+ *     The value of the localization entry. E.g. "Press this button to make the computer go to sleep."
+ */
+record LocalizationEntry(String key, String value)
+{
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationGenerator.java
@@ -194,14 +194,14 @@ final class LocalizationGenerator implements ILocalizationGenerator
         final Set<String> usedPatches = new HashSet<>(patches.size());
         for (int idx = 0; idx < lines.size(); ++idx)
         {
-            final @Nullable String key = LocalizationUtil.getKeyFromLine(lines.get(idx));
-            if (key == null)
+            final @Nullable LocalizationEntry entry = LocalizationUtil.getEntryFromLine(lines.get(idx));
+            if (entry == null)
                 continue;
-            final @Nullable String newLine = patches.get(key);
+            final @Nullable String newLine = patches.get(entry.key());
             if (newLine == null)
                 continue;
             lines.set(idx, newLine);
-            usedPatches.add(key);
+            usedPatches.add(entry.key());
         }
 
         if (usedPatches.size() == patches.size())

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationManager.java
@@ -36,18 +36,25 @@ public final class LocalizationManager extends Restartable implements ILocalizat
     private final LocalizationGenerator baseGenerator;
     private @Nullable LocalizationGenerator patchGenerator;
 
-    @Inject
-    public LocalizationManager(
-        RestartableHolder restartableHolder, @Named("localizationBaseDir") Path baseDir,
-        @Named("localizationBaseName") String baseName, IConfigLoader configLoader)
+    LocalizationManager(
+        RestartableHolder restartableHolder, Path baseDir,
+        String baseName, IConfigLoader configLoader, boolean deleteBundleOnStart)
     {
         super(restartableHolder);
         this.baseDir = baseDir;
         this.baseName = baseName;
         this.configLoader = configLoader;
-        localizer = new Localizer(baseDir, baseName);
+        localizer = new Localizer(baseDir, baseName, deleteBundleOnStart);
         localizer.setDefaultLocale(configLoader.locale());
         baseGenerator = new LocalizationGenerator(baseDir, baseName);
+    }
+
+    @Inject
+    public LocalizationManager(
+        RestartableHolder restartableHolder, @Named("localizationBaseDir") Path baseDir,
+        @Named("localizationBaseName") String baseName, IConfigLoader configLoader)
+    {
+        this(restartableHolder, baseDir, baseName, configLoader, true);
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
@@ -430,6 +430,18 @@ public final class LocalizationUtil
         return String.format("%s%s.properties", outputBaseName, locale.length() == 0 ? "" : ("_" + locale));
     }
 
+    static void deleteFile(Path file)
+    {
+        try
+        {
+            Files.deleteIfExists(file);
+        }
+        catch (IOException e)
+        {
+            log.at(Level.SEVERE).withCause(e).log("Failed to delete file: '%s'", file);
+        }
+    }
+
     /**
      * Ensures a given zip file exists.
      */

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
@@ -557,11 +557,12 @@ public final class LocalizationUtil
         if (parts[0].isBlank())
             return Locale.ROOT;
 
-        if (parts.length == 1)
-            return new Locale(parts[0]);
-        if (parts.length == 2)
-            return new Locale(parts[0], parts[1]);
-        return new Locale(parts[0], parts[1], parts[2]);
+        final Locale.Builder builder = new Locale.Builder().setLanguage(parts[0]);
+        if (parts.length >= 2)
+            builder.setRegion(parts[1]);
+        if (parts.length >= 3)
+            builder.setVariant(parts[2]);
+        return builder.build();
     }
 
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/LocalizationUtil.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.stream.Stream;
@@ -115,8 +116,8 @@ public final class LocalizationUtil
 
         for (final String line : newLines)
         {
-            final @Nullable String key = getKeyFromLine(line);
-            if (key == null || keys.contains(key))
+            final @Nullable LocalizationEntry entry = getEntryFromLine(line);
+            if (entry == null || keys.contains(entry.key()))
                 continue;
             merged.add(line);
         }
@@ -137,9 +138,9 @@ public final class LocalizationUtil
         final Set<String> ret = new LinkedHashSet<>();
         readFile(inputStream, line ->
         {
-            final @Nullable String key = getKeyFromLine(line);
-            if (key != null)
-                ret.add(key);
+            final @Nullable LocalizationEntry entry = getEntryFromLine(line);
+            if (entry != null)
+                ret.add(entry.key());
         });
         return ret;
     }
@@ -178,11 +179,52 @@ public final class LocalizationUtil
         final Set<String> ret = new LinkedHashSet<>(lines.size());
         for (final String line : lines)
         {
-            final @Nullable String key = getKeyFromLine(line);
-            if (key != null)
-                ret.add(key);
+            final @Nullable LocalizationEntry entry = getEntryFromLine(line);
+            if (entry != null)
+                ret.add(entry.key());
         }
         return ret;
+    }
+
+    /**
+     * Gets a set containing all the keys in an input stream.
+     *
+     * @param inputStream
+     *     The input stream to read lines of Strings from. These lines are expected to be of the format "key=value".
+     * @return A set with all the keys used in the input stream.
+     */
+    static Map<String, String> getEntryMap(InputStream inputStream)
+    {
+        final Map<String, String> ret = new TreeMap<>();
+        readFile(inputStream, line ->
+        {
+            final @Nullable LocalizationEntry key = getEntryFromLine(line);
+            if (key != null)
+                ret.put(key.key(), key.value());
+        });
+        return ret;
+    }
+
+    /**
+     * Gets a map containing all the key-value pairs in a file.
+     *
+     * @param path
+     *     The path to a file.
+     * @return A map with all the key-value pairs in the file.
+     */
+    static Map<String, String> getEntryMap(Path path)
+    {
+        if (!Files.isRegularFile(path))
+            return Collections.emptyMap();
+        try (InputStream inputStream = Files.newInputStream(path))
+        {
+            return getEntryMap(inputStream);
+        }
+        catch (IOException e)
+        {
+            log.at(Level.SEVERE).withCause(e).log("Failed to get entries from file: %s", path);
+            return Collections.emptyMap();
+        }
     }
 
     /**
@@ -192,14 +234,14 @@ public final class LocalizationUtil
      *     A string containing a key/value pair.
      * @return The key as used in the line.
      */
-    static @Nullable String getKeyFromLine(String line)
+    static @Nullable LocalizationEntry getEntryFromLine(String line)
     {
         final char[] chars = new char[line.length()];
         line.getChars(0, line.length(), chars, 0);
 
         for (int idx = 0; idx < line.length(); ++idx)
             if (chars[idx] == '=')
-                return line.substring(0, idx);
+                return new LocalizationEntry(line.substring(0, idx), line.substring(idx + 1));
         return null;
     }
 
@@ -521,4 +563,6 @@ public final class LocalizationUtil
             return new Locale(parts[0], parts[1]);
         return new Locale(parts[0], parts[1], parts[2]);
     }
+
+
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/localization/Localizer.java
@@ -33,8 +33,8 @@ final class Localizer implements ILocalizer
     private String bundleName;
 
     /**
-     * The default {@link Locale} to use when no locale is specified when requesting a translation. Defaults to {@link
-     * Locale#ROOT}.
+     * The default {@link Locale} to use when no locale is specified when requesting a translation. Defaults to
+     * {@link Locale#ROOT}.
      */
     @Setter
     private Locale defaultLocale;
@@ -50,22 +50,27 @@ final class Localizer implements ILocalizer
      * @param defaultLocale
      *     The default {@link Locale} to use when no locale is specified when requesting a translation. Defaults to
      *     {@link Locale#ROOT}.
+     * @param deleteBundleOnStart
+     *     Delete the existing bundle on startup to ensure it will be regenerated. Should be true for usual operation,
+     *     but special situations (e.g. testing) might require it to be false.
      */
-    Localizer(Path directory, String baseName, Locale defaultLocale)
+    Localizer(Path directory, String baseName, Locale defaultLocale, boolean deleteBundleOnStart)
     {
         this.baseName = baseName;
         this.directory = directory;
         this.defaultLocale = defaultLocale;
         bundleName = baseName + ".bundle";
+        if (deleteBundleOnStart)
+            LocalizationUtil.deleteFile(directory.resolve(bundleName));
         init();
     }
 
     /**
-     * See {@link #Localizer(Path, String, Locale)}.
+     * See {@link #Localizer(Path, String, Locale, boolean)}.
      */
-    Localizer(Path directory, String baseName)
+    Localizer(Path directory, String baseName, boolean deleteBundleOnStart)
     {
-        this(directory, baseName, Locale.ROOT);
+        this(directory, baseName, Locale.ROOT, deleteBundleOnStart);
     }
 
     /**
@@ -113,7 +118,7 @@ final class Localizer implements ILocalizer
         return getMessage(key, defaultLocale, args);
     }
 
-    @Override @SuppressWarnings("unused")
+    @Override
     public List<Locale> getAvailableLocales()
     {
         return localeList;

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherTest.java
@@ -8,10 +8,8 @@ class LocalizationPatcherTest
     @Test
     void isValidPatch()
     {
-        Assertions.assertFalse(LocalizationPatcher.isValidPatch("key", "key="));
-        //noinspection ConstantConditions
-        Assertions.assertFalse(LocalizationPatcher.isValidPatch(null, "key="));
-        Assertions.assertTrue(LocalizationPatcher.isValidPatch("key", "key= "));
-        Assertions.assertTrue(LocalizationPatcher.isValidPatch("key", "key=value"));
+        Assertions.assertFalse(LocalizationPatcher.isValidPatch(new LocalizationEntry("key", "")));
+        Assertions.assertTrue(LocalizationPatcher.isValidPatch(new LocalizationEntry("key", " ")));
+        Assertions.assertTrue(LocalizationPatcher.isValidPatch(new LocalizationEntry("key", "value")));
     }
 }

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationUtilTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationUtilTest.java
@@ -55,12 +55,13 @@ class LocalizationUtilTest
     }
 
     @Test
-    void testGetKeyFromLine()
+    void testGetEntryFromLine()
     {
-        Assertions.assertEquals("key", getKeyFromLine("key=value"));
-        Assertions.assertEquals("key", getKeyFromLine("key=value=another_value"));
-        Assertions.assertNull(getKeyFromLine("key"));
-        Assertions.assertNull(getKeyFromLine(""));
+        Assertions.assertEquals(new LocalizationEntry("key", "value"), getEntryFromLine("key=value"));
+        Assertions.assertEquals(
+            new LocalizationEntry("key", "value=another_value"), getEntryFromLine("key=value=another_value"));
+        Assertions.assertNull(getEntryFromLine("key"));
+        Assertions.assertNull(getEntryFromLine(""));
     }
 
     @Test

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationManagerIntegrationTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationManagerIntegrationTest.java
@@ -56,7 +56,7 @@ class LocalizationManagerIntegrationTest
 
         final LocalizationManager localizationManager =
             new LocalizationManager(Mockito.mock(RestartableHolder.class), directoryOutput,
-                                    baseName, configLoader);
+                                    baseName, configLoader, false);
 
         localizationManager.shutDown();
         localizationManager.initialize();
@@ -86,7 +86,7 @@ class LocalizationManagerIntegrationTest
 
         final LocalizationManager localizationManager =
             new LocalizationManager(Mockito.mock(RestartableHolder.class), directoryOutput,
-                                    baseName, configLoader);
+                                    baseName, configLoader, false);
 
         Assertions.assertEquals("value0", localizationManager.getLocalizer().getMessage("key0"));
         Assertions.assertEquals("value3", localizationManager.getLocalizer().getMessage("key3"));

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherIntegrationTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationPatcherIntegrationTest.java
@@ -39,18 +39,18 @@ class LocalizationPatcherIntegrationTest
         throws IOException
     {
         final Path file0 = LocalizationUtil.ensureFileExists(directoryOutput.resolve("patch.properties"));
-        LocalizationUtil.appendToFile(file0, List.of("key0=aaa", "key1=aba", "key2=aab", "key3=baa"));
+        LocalizationUtil.appendToFile(file0, List.of("key0=aaa", "key3=baa", "key1=aba", "key2=aab"));
 
         final Path file1 = LocalizationUtil.ensureFileExists(directoryOutput.resolve("patch_en_US.properties"));
-        LocalizationUtil.appendToFile(file1, List.of("key10=aaa", "key11=aba", "key12=aab", "key13=baa"));
+        LocalizationUtil.appendToFile(file1, List.of("key10=aaa", "key13=baa", "key12=aab", "key11=aba"));
 
         final LocalizationPatcher patcher = new LocalizationPatcher(directoryOutput, "patch");
-        patcher.updatePatchKeys(List.of("key1", "key4", "key5"));
+        patcher.updatePatchKeys(List.of("key1", "key5", "key4"));
 
         Assertions.assertArrayEquals(new Object[]{"key0", "key1", "key2", "key3", "key4", "key5"},
                                      LocalizationUtil.getKeySet(file0).toArray());
 
-        Assertions.assertArrayEquals(new Object[]{"key10", "key11", "key12", "key13", "key1", "key4", "key5"},
+        Assertions.assertArrayEquals(new Object[]{"key1", "key10", "key11", "key12", "key13", "key4", "key5"},
                                      LocalizationUtil.getKeySet(file1).toArray());
     }
 

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationUtilIntegrationTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizationUtilIntegrationTest.java
@@ -42,7 +42,7 @@ class LocalizationUtilIntegrationTest
         addFilesToZip(zipFile,
                       base + ".properties",
                       base + "_en_us.properties",
-                      base + "_en_us_some_random_variation.properties",
+                      base + "_en_us_random.properties",
                       base + "_nl.properties",
                       base + "_nl_NL.properties");
 
@@ -50,8 +50,9 @@ class LocalizationUtilIntegrationTest
         Assertions.assertEquals(5, locales.size());
         Assertions.assertTrue(locales.contains(Locale.ROOT));
         Assertions.assertTrue(locales.contains(Locale.US));
-        Assertions.assertTrue(locales.contains(new Locale("en", "US", "some_random_variation")));
-        Assertions.assertTrue(locales.contains(new Locale("nl")));
-        Assertions.assertTrue(locales.contains(new Locale("nl", "NL")));
+        Assertions.assertTrue(locales.contains(
+            new Locale.Builder().setLanguage("en").setRegion("US").setVariant("random").build()));
+        Assertions.assertTrue(locales.contains(new Locale.Builder().setLanguage("nl").build()));
+        Assertions.assertTrue(locales.contains(new Locale.Builder().setLanguage("nl").setRegion("NL").build()));
     }
 }

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
@@ -67,7 +67,7 @@ class LocalizerIntegrationTest
     @Test
     void testGetMessage()
     {
-        final Localizer localizer = new Localizer(directory, BASE_NAME);
+        final Localizer localizer = new Localizer(directory, BASE_NAME, false);
         Assertions.assertEquals("waarde0", localizer.getMessage("key0", LOCALE_DUTCH));
         final String input = "A_B_C_D_E";
         Assertions.assertEquals(input, localizer.getMessage("key1", LOCALE_DUTCH, input));
@@ -79,7 +79,7 @@ class LocalizerIntegrationTest
     void testAppendingMessages()
         throws IOException, URISyntaxException
     {
-        final Localizer localizer = new Localizer(directory, BASE_NAME);
+        final Localizer localizer = new Localizer(directory, BASE_NAME, false);
         // Just ensure that it's loaded properly.
         Assertions.assertEquals("value0", localizer.getMessage("key0"));
         // Ensure that the key doesn't exist (yet!).

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/localization/LocalizerIntegrationTest.java
@@ -21,7 +21,7 @@ import static nl.pim16aap2.bigdoors.localization.LocalizationTestingUtilities.wr
 
 class LocalizerIntegrationTest
 {
-    private static final Locale LOCALE_DUTCH = new Locale("nl", "NL");
+    private static final Locale LOCALE_DUTCH = new Locale.Builder().setLanguage("nl").setRegion("NL").build();
     private static final String BASE_NAME = "Translation";
 
     private FileSystem fs;


### PR DESCRIPTION
- Sort patch-file alphabetically so it's easier to use.
- Delete the existing bundle on startup so it is regenerated as intended.
- Replace the use of the deprecated Locale constructors with the new Locale.Builder method.