### PR TITLE
Improve thread safety

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/IPExecutor.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/IPExecutor.java
@@ -206,12 +206,25 @@ public interface IPExecutor
     /**
      * Asserts that this method was called from the main thread. See {@link #isMainThread()}.
      *
+     * @param message
+     *     The error message for the exception.
+     * @throws IllegalStateException
+     *     When called from any thread that is not that main thread.
+     */
+    default void assertMainThread(String message)
+    {
+        if (!isMainThread())
+            throw new IllegalThreadStateException(message);
+    }
+
+    /**
+     * Asserts that this method was called from the main thread. See {@link #isMainThread()}.
+     *
      * @throws IllegalStateException
      *     When called from any thread that is not that main thread.
      */
     default void assertMainThread()
     {
-        if (!isMainThread())
-            throw new IllegalThreadStateException();
+        assertMainThread("Assertion Failed: Not on main thread!");
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/AbstractDoor.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/AbstractDoor.java
@@ -51,7 +51,6 @@ public abstract class AbstractDoor implements IDoor
     protected final IConfigLoader config;
     protected final DoorOpeningHelper doorOpeningHelper;
 
-
     protected AbstractDoor(
         DoorBase doorBase, ILocalizer localizer, DoorRegistry doorRegistry,
         AutoCloseScheduler autoCloseScheduler, DoorOpeningHelper doorOpeningHelper)
@@ -298,9 +297,18 @@ public abstract class AbstractDoor implements IDoor
      *     The type of action.
      * @return The result of the attempt.
      */
-    // TODO: Simplify this method.
+    final DoorToggleResult toggle(
+        DoorActionCause cause, IMessageable messageReceiver, IPPlayer responsible, @Nullable Double targetTime,
+        boolean skipAnimation, DoorActionType actionType)
+    {
+        synchronized (getDoorBase())
+        {
+            return toggle0(cause, messageReceiver, responsible, targetTime, skipAnimation, actionType);
+        }
+    }
+
     @SuppressWarnings({"unused", "squid:S1172"}) // messageReceiver isn't used yet, but it will be.
-    final synchronized DoorToggleResult toggle(
+    private synchronized DoorToggleResult toggle0(
         DoorActionCause cause, IMessageable messageReceiver, IPPlayer responsible, @Nullable Double targetTime,
         boolean skipAnimation, DoorActionType actionType)
     {

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/AbstractDoor.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/AbstractDoor.java
@@ -312,13 +312,6 @@ public abstract class AbstractDoor implements IDoor
         DoorActionCause cause, IMessageable messageReceiver, IPPlayer responsible, @Nullable Double targetTime,
         boolean skipAnimation, DoorActionType actionType)
     {
-        if (!doorOpeningHelper.isMainThread())
-        {
-            log.at(Level.SEVERE).withCause(new IllegalStateException("Doors must be toggled on the main thread!"))
-               .log();
-            return DoorToggleResult.ERROR;
-        }
-
         if (getOpenDir() == RotateDirection.NONE)
         {
             log.at(Level.SEVERE).withCause(new IllegalStateException("OpenDir cannot be NONE!")).log();

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/DoorBase.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/DoorBase.java
@@ -7,7 +7,6 @@ import dagger.assisted.AssistedInject;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.IPExecutor;
@@ -31,6 +30,7 @@ import nl.pim16aap2.bigdoors.util.Util;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Provider;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 /**
@@ -57,38 +56,36 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
     @Getter
     private final IPWorld world;
 
-    @Getter
+    @GuardedBy("this")
     private Vector3Di rotationPoint;
 
-    @Getter
+    @GuardedBy("this")
     private Vector3Di powerBlock;
 
-    @Getter
-    @Setter
+    @GuardedBy("this")
     private String name;
 
+    @GuardedBy("this")
     private Cuboid cuboid;
 
-    @Getter
-    @Setter
+    @GuardedBy("this")
     private boolean isOpen;
 
-    @Getter
-    @Setter
+    @GuardedBy("this")
     private RotateDirection openDir;
 
     /**
      * Represents the locked status of this door. True = locked, False = unlocked.
      */
-    @Getter
-    @Setter
-    private volatile boolean isLocked;
-
-    @EqualsAndHashCode.Exclude
-    private final Map<UUID, DoorOwner> doorOwners;
+    @GuardedBy("this")
+    private boolean isLocked;
 
     @Getter
     private final DoorOwner primeOwner;
+
+    @EqualsAndHashCode.Exclude
+    @GuardedBy("this")
+    private final Map<UUID, DoorOwner> doorOwners;
 
     @EqualsAndHashCode.Exclude
     @Getter(AccessLevel.PACKAGE)
@@ -159,7 +156,7 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
         this.primeOwner = primeOwner;
 
         final int initSize = doorOwners == null ? 1 : doorOwners.size();
-        final Map<UUID, DoorOwner> doorOwnersTmp = new ConcurrentHashMap<>(initSize);
+        final Map<UUID, DoorOwner> doorOwnersTmp = new HashMap<>(initSize);
         if (doorOwners == null)
             doorOwnersTmp.put(primeOwner.pPlayerData().getUUID(), primeOwner);
         else
@@ -194,7 +191,7 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
         isLocked = other.isLocked;
         openDir = other.openDir;
         primeOwner = other.primeOwner;
-        this.doorOwners = doorOwners == null ? new ConcurrentHashMap<>(0) : doorOwners;
+        this.doorOwners = doorOwners == null ? new HashMap<>(0) : doorOwners;
 
         config = other.config;
         localizer = other.localizer;
@@ -219,6 +216,7 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
      *
      * @return A full copy of this {@link DoorBase}.
      */
+    @SuppressWarnings("unused")
     public synchronized DoorBase getFullSnapshot()
     {
         return new DoorBase(this, new HashMap<>(doorOwners));
@@ -243,7 +241,7 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
      *
      * @param typeData
      *     The type-specific data of an {@link AbstractDoor}.
-     * @return true if the synchronization was successful.
+     * @return Future true if the synchronization was successful.
      */
     synchronized CompletableFuture<Boolean> syncData(byte[] typeData)
     {
@@ -251,7 +249,7 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
     }
 
     @Override
-    protected void addOwner(UUID uuid, DoorOwner doorOwner)
+    protected synchronized void addOwner(UUID uuid, DoorOwner doorOwner)
     {
         if (doorOwner.permission() == PermissionLevel.CREATOR)
         {
@@ -277,7 +275,7 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
         return limitsManager.exceedsLimit(player, Limit.DOOR_SIZE, getBlockCount());
     }
 
-    void onRedstoneChange(AbstractDoor abstractDoor, int newCurrent)
+    synchronized void onRedstoneChange(AbstractDoor abstractDoor, int newCurrent)
     {
         final @Nullable DoorActionType doorActionType;
         if (newCurrent == 0 && isCloseable())
@@ -299,7 +297,7 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
     }
 
     @Override
-    protected boolean removeOwner(UUID uuid)
+    protected synchronized boolean removeOwner(UUID uuid)
     {
         if (primeOwner.pPlayerData().getUUID().equals(uuid))
         {
@@ -312,25 +310,19 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
     }
 
     @Override
-    public Cuboid getCuboid()
-    {
-        return cuboid;
-    }
-
-    @Override
-    public boolean isOpenable()
+    public synchronized boolean isOpenable()
     {
         return !isOpen;
     }
 
     @Override
-    public boolean isCloseable()
+    public synchronized boolean isCloseable()
     {
         return isOpen;
     }
 
     @Override
-    public List<DoorOwner> getDoorOwners()
+    public synchronized List<DoorOwner> getDoorOwners()
     {
         final List<DoorOwner> ret = new ArrayList<>(doorOwners.size());
         ret.addAll(doorOwners.values());
@@ -338,43 +330,43 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
     }
 
     @Override
-    public Optional<DoorOwner> getDoorOwner(UUID uuid)
+    public synchronized Optional<DoorOwner> getDoorOwner(UUID uuid)
     {
         return Optional.ofNullable(doorOwners.get(uuid));
     }
 
     @Override
-    public boolean isDoorOwner(UUID uuid)
+    public synchronized boolean isDoorOwner(UUID uuid)
     {
         return doorOwners.containsKey(uuid);
     }
 
     @Override
-    public void setCoordinates(Cuboid newCuboid)
+    public synchronized void setCoordinates(Cuboid newCuboid)
     {
         cuboid = newCuboid;
     }
 
     @Override
-    public void setCoordinates(Vector3Di posA, Vector3Di posB)
+    public synchronized void setCoordinates(Vector3Di posA, Vector3Di posB)
     {
         cuboid = new Cuboid(posA, posB);
     }
 
     @Override
-    public Vector3Di getMinimum()
+    public synchronized Vector3Di getMinimum()
     {
         return cuboid.getMin();
     }
 
     @Override
-    public Vector3Di getMaximum()
+    public synchronized Vector3Di getMaximum()
     {
         return cuboid.getMax();
     }
 
     @Override
-    public Vector3Di getDimensions()
+    public synchronized Vector3Di getDimensions()
     {
         return cuboid.getDimensions();
     }
@@ -386,13 +378,13 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
     }
 
     @Override
-    public void setPowerBlockPosition(Vector3Di pos)
+    public synchronized void setPowerBlockPosition(Vector3Di pos)
     {
         powerBlock = pos;
     }
 
     @Override
-    public int getBlockCount()
+    public synchronized int getBlockCount()
     {
         return cuboid.getVolume();
     }
@@ -473,10 +465,76 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
             + formatLine("OpenDir", openDir.name());
     }
 
-    private String formatLine(String name, @Nullable Object obj)
+    private synchronized String formatLine(String name, @Nullable Object obj)
     {
         final String objString = obj == null ? "NULL" : obj.toString();
         return name + ": " + objString + "\n";
+    }
+
+    @Override
+    public synchronized Vector3Di getRotationPoint()
+    {
+        return this.rotationPoint;
+    }
+
+    @Override
+    public synchronized Vector3Di getPowerBlock()
+    {
+        return this.powerBlock;
+    }
+
+    @Override
+    public synchronized String getName()
+    {
+        return this.name;
+    }
+
+    @Override
+    public synchronized Cuboid getCuboid()
+    {
+        return this.cuboid;
+    }
+
+    @Override
+    public synchronized boolean isOpen()
+    {
+        return this.isOpen;
+    }
+
+    @Override
+    public synchronized RotateDirection getOpenDir()
+    {
+        return this.openDir;
+    }
+
+    @Override
+    public synchronized boolean isLocked()
+    {
+        return this.isLocked;
+    }
+
+    @Override
+    public synchronized void setName(String name)
+    {
+        this.name = name;
+    }
+
+    @Override
+    public synchronized void setOpen(boolean isOpen)
+    {
+        this.isOpen = isOpen;
+    }
+
+    @Override
+    public synchronized void setOpenDir(RotateDirection openDir)
+    {
+        this.openDir = openDir;
+    }
+
+    @Override
+    public synchronized void setLocked(boolean isLocked)
+    {
+        this.isLocked = isLocked;
     }
 
     @AssistedFactory

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/DoorBase.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/DoorBase.java
@@ -419,7 +419,7 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
      * @return True when everything went all right, otherwise false.
      */
     // TODO: Move to DoorOpeningHelper.
-    synchronized boolean registerBlockMover(
+    boolean registerBlockMover(
         AbstractDoor abstractDoor, DoorActionCause cause, double time,
         boolean skipAnimation, Cuboid newCuboid, IPPlayer responsible,
         DoorActionType actionType)
@@ -435,8 +435,12 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
         try
         {
             final BlockMover.Context context = blockMoverContextProvider.get();
-            final BlockMover blockMover = abstractDoor.constructBlockMover(
-                context, cause, time, skipAnimation, newCuboid, responsible, actionType);
+            final BlockMover blockMover;
+            synchronized (this)
+            {
+                blockMover = abstractDoor.constructBlockMover(
+                    context, cause, time, skipAnimation, newCuboid, responsible, actionType);
+            }
             doorOpeningHelper.registerBlockMover(blockMover);
             blockMover.startAnimation();
         }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/DoorBase.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/DoorBase.java
@@ -424,14 +424,6 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
         boolean skipAnimation, Cuboid newCuboid, IPPlayer responsible,
         DoorActionType actionType)
     {
-        if (!executor.isMainThread(Thread.currentThread().threadId()))
-        {
-            doorActivityManager.setDoorAvailable(getDoorUID());
-            log.at(Level.SEVERE).withCause(
-                new IllegalThreadStateException("BlockMovers must be instantiated on the main thread!")).log();
-            return true;
-        }
-
         try
         {
             final BlockMover.Context context = blockMoverContextProvider.get();
@@ -441,7 +433,7 @@ public final class DoorBase extends DatabaseManager.FriendDoorAccessor implement
                 blockMover = abstractDoor.constructBlockMover(
                     context, cause, time, skipAnimation, newCuboid, responsible, actionType);
             }
-            doorOpeningHelper.registerBlockMover(blockMover);
+            doorActivityManager.addBlockMover(blockMover);
             blockMover.startAnimation();
         }
         catch (Exception e)

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/DoorOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/DoorOpeningHelper.java
@@ -177,17 +177,8 @@ public final class DoorOpeningHelper
         DoorBase doorBase, AbstractDoor abstractDoor, DoorActionCause cause, double time, boolean skipAnimation,
         Cuboid newCuboid, IPPlayer responsible, DoorActionType actionType)
     {
-        executor.assertMainThread();
         return doorBase.registerBlockMover(
             abstractDoor, cause, time, skipAnimation, newCuboid, responsible, actionType);
-    }
-
-    /**
-     * See {@link IPExecutor#isMainThread()}.
-     */
-    boolean isMainThread()
-    {
-        return executor.isMainThread();
     }
 
     /**
@@ -407,17 +398,6 @@ public final class DoorOpeningHelper
                 .map(newCuboid -> chunkLoader.checkChunks(door.getWorld(), newCuboid, mode))
                 .orElse(IChunkLoader.ChunkLoadResult.PASS);
         return newCoordsResult != IChunkLoader.ChunkLoadResult.FAIL;
-    }
-
-    /**
-     * Registers a BlockMover with the {@link DatabaseManager}
-     *
-     * @param blockMover
-     *     The {@link BlockMover}.
-     */
-    public void registerBlockMover(BlockMover blockMover)
-    {
-        doorActivityManager.addBlockMover(blockMover);
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/DoorOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/doors/DoorOpeningHelper.java
@@ -6,7 +6,6 @@ import nl.pim16aap2.bigdoors.api.IBlockAnalyzer;
 import nl.pim16aap2.bigdoors.api.IChunkLoader;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.IMessageable;
-import nl.pim16aap2.bigdoors.api.IPExecutor;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.api.IPWorld;
 import nl.pim16aap2.bigdoors.api.IProtectionCompatManager;
@@ -53,7 +52,6 @@ public final class DoorOpeningHelper
     private final IProtectionCompatManager protectionCompatManager;
     private final GlowingBlockSpawner glowingBlockSpawner;
     private final IBigDoorsEventFactory bigDoorsEventFactory;
-    private final IPExecutor executor;
     private final IChunkLoader chunkLoader;
     private final IDoorEventCaller doorEventCaller;
 
@@ -69,7 +67,6 @@ public final class DoorOpeningHelper
         IProtectionCompatManager protectionCompatManager,
         GlowingBlockSpawner glowingBlockSpawner,
         IBigDoorsEventFactory bigDoorsEventFactory,
-        IPExecutor executor,
         IChunkLoader chunkLoader,
         IDoorEventCaller doorEventCaller)
     {
@@ -83,7 +80,6 @@ public final class DoorOpeningHelper
         this.protectionCompatManager = protectionCompatManager;
         this.glowingBlockSpawner = glowingBlockSpawner;
         this.bigDoorsEventFactory = bigDoorsEventFactory;
-        this.executor = executor;
         this.chunkLoader = chunkLoader;
         this.doorEventCaller = doorEventCaller;
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/BlockMover.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/BlockMover.java
@@ -337,10 +337,7 @@ public abstract class BlockMover
         if (animationDuration < 0)
             throw new IllegalStateException("Trying to start an animation with invalid endCount value: " +
                                                 animationDuration);
-        if (executor.isMainThread())
-            startAnimation0();
-        else
-            executor.runSync(this::startAnimation);
+        executor.runOnMainThread(this::startAnimation0);
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/BlockMover.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/BlockMover.java
@@ -242,6 +242,9 @@ public abstract class BlockMover
         DoorActionCause cause, DoorActionType actionType)
         throws Exception
     {
+        if (!Thread.holdsLock(door.getDoorBase()))
+            throw new IllegalStateException("Trying to instantiate BlockMover without lock on door base!");
+
         executor = context.getExecutor();
         doorActivityManager = context.getDoorActivityManager();
         autoCloseScheduler = context.getAutoCloseScheduler();

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/BlockMover.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/BlockMover.java
@@ -262,8 +262,9 @@ public abstract class BlockMover
 
     public void abort()
     {
-        if (moverTask != null)
-            executor.cancel(moverTask, Objects.requireNonNull(moverTaskID));
+        final @Nullable TimerTask moverTask0 = moverTask;
+        if (moverTask0 != null)
+            executor.cancel(moverTask0, Objects.requireNonNull(moverTaskID));
         putBlocks(true);
     }
 
@@ -533,12 +534,14 @@ public abstract class BlockMover
         forEachHook("onAnimationEnding", IAnimationHook::onAnimationEnding);
 
         putBlocks(false);
-        if (moverTask == null)
+
+        final @Nullable TimerTask moverTask0 = moverTask;
+        if (moverTask0 == null)
         {
             log.at(Level.WARNING).log("MoverTask unexpectedly null for BlockMover:\n%s", this);
             return;
         }
-        executor.cancel(moverTask, Objects.requireNonNull(moverTaskID));
+        executor.cancel(moverTask0, Objects.requireNonNull(moverTaskID));
 
         animation.setState(AnimationState.COMPLETED);
         animation.setRegion(oldCuboid);
@@ -580,7 +583,7 @@ public abstract class BlockMover
 
         final int initialDelay = Math.round((float) START_DELAY / serverTickTime);
 
-        moverTask = new TimerTask()
+        final TimerTask moverTask0 = new TimerTask()
         {
             private int counter = 0;
             private @Nullable Long startTime = null; // Initialize on the first run.
@@ -609,7 +612,8 @@ public abstract class BlockMover
                 forEachHook("onPostAnimationStep", IAnimationHook::onPostAnimationStep);
             }
         };
-        moverTaskID = executor.runAsyncRepeated(moverTask, initialDelay, 1);
+        moverTask = moverTask0;
+        moverTaskID = executor.runAsyncRepeated(moverTask0, initialDelay, 1);
     }
 
     /**
@@ -755,10 +759,11 @@ public abstract class BlockMover
 
     private void forEachHook(String actionName, Consumer<IAnimationHook<IAnimatedBlock>> call)
     {
-        if (hooks == null)
+        final @Nullable var hooks0 = hooks;
+        if (hooks0 == null)
             return;
 
-        for (final IAnimationHook<IAnimatedBlock> hook : hooks)
+        for (final IAnimationHook<IAnimatedBlock> hook : hooks0)
         {
             log.at(Level.FINEST).log("Executing '%s' for hook '%s'!", actionName, hook.getName());
             try

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/BlockMover.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/BlockMover.java
@@ -352,8 +352,7 @@ public abstract class BlockMover
      */
     private synchronized void startAnimation0()
     {
-        if (!executor.isMainThread())
-            throw new IllegalStateException("Animations must be started on the main thread!");
+        executor.assertMainThread("Animations must be started on the main thread!");
 
         if (hasStarted.getAndSet(true))
             throw new IllegalStateException("Trying to start an animation again!");
@@ -421,8 +420,7 @@ public abstract class BlockMover
      */
     private boolean tryRemoveOriginalBlocks(boolean edgePass)
     {
-        if (!executor.isMainThread())
-            throw new IllegalStateException("Blocks must be removed on the main thread!");
+        executor.assertMainThread("Blocks must be removed on the main thread!");
 
         for (final IAnimatedBlock animatedBlock : privateAnimatedBlocks)
         {
@@ -570,8 +568,7 @@ public abstract class BlockMover
      */
     protected void prepareAnimation()
     {
-        if (!executor.isMainThread())
-            throw new IllegalStateException("Animated blocks must be spawned on the main thread!");
+        executor.assertMainThread("Animated blocks must be spawned on the main thread!");
         getAnimatedBlocks().forEach(IAnimatedBlock::spawn);
     }
 
@@ -580,8 +577,7 @@ public abstract class BlockMover
      */
     private synchronized void animateEntities(Animation<IAnimatedBlock> animation)
     {
-        if (!executor.isMainThread())
-            throw new IllegalStateException("Animation must be started on the main thread!");
+        executor.assertMainThread("Animation must be started on the main thread!");
 
         try
         {
@@ -667,8 +663,7 @@ public abstract class BlockMover
 
     private synchronized void putBlocks0(boolean onDisable)
     {
-        if (!executor.isMainThread())
-            throw new IllegalStateException("Attempting async block placement!");
+        executor.assertMainThread("Attempting async block placement!");
 
         for (final IAnimatedBlock animatedBlock : privateAnimatedBlocks)
         {

--- a/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/doors/bigdoor/BigDoorMover.java
+++ b/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/doors/bigdoor/BigDoorMover.java
@@ -35,7 +35,7 @@ public class BigDoorMover extends BlockMover
         if (angle == 0.0D)
             log.atSevere().log("Invalid open direction '%s' for door: %d", rotDirection.name(), getDoorUID());
 
-        rotationCenter = new Vector3Dd(rotationPoint.x() + 0.5, yMin, rotationPoint.z() + 0.5);
+        rotationCenter = new Vector3Dd(rotationPoint.x() + 0.5, oldCuboid.getMin().y(), rotationPoint.z() + 0.5);
 
         step = angle / super.animationDuration;
         halfEndCount = super.animationDuration / 2;

--- a/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/doors/bigdoor/BigDoorMover.java
+++ b/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/doors/bigdoor/BigDoorMover.java
@@ -35,7 +35,7 @@ public class BigDoorMover extends BlockMover
         if (angle == 0.0D)
             log.atSevere().log("Invalid open direction '%s' for door: %d", rotDirection.name(), getDoorUID());
 
-        rotationCenter = new Vector3Dd(door.getRotationPoint().x() + 0.5, yMin, door.getRotationPoint().z() + 0.5);
+        rotationCenter = new Vector3Dd(rotationPoint.x() + 0.5, yMin, rotationPoint.z() + 0.5);
 
         step = angle / super.animationDuration;
         halfEndCount = super.animationDuration / 2;
@@ -92,13 +92,12 @@ public class BigDoorMover extends BlockMover
     @Override
     protected float getRadius(int xAxis, int yAxis, int zAxis)
     {
-        return getRadius(door.getRotationPoint(), xAxis, zAxis);
+        return getRadius(rotationPoint, xAxis, zAxis);
     }
 
     @Override
     protected float getStartAngle(int xAxis, int yAxis, int zAxis)
     {
-        return (float) Math.atan2((double) door.getRotationPoint().x() - xAxis,
-                                  (double) door.getRotationPoint().z() - zAxis);
+        return (float) Math.atan2(rotationPoint.xD() - xAxis, rotationPoint.zD() - zAxis);
     }
 }

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/doors/clock/Clock.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/doors/clock/Clock.java
@@ -2,7 +2,6 @@ package nl.pim16aap2.bigdoors.doors.clock;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
@@ -55,10 +54,9 @@ public class Clock extends AbstractDoor implements IHorizontalAxisAligned
      *
      * @return The side of the hour arm relative to the minute arm.
      */
-    @Getter
-    @Setter
     @PersistentVariable
-    protected PBlockFace hourArmSide;
+    @Getter
+    protected final PBlockFace hourArmSide;
 
     public Clock(DoorBase doorData, boolean northSouthAligned, PBlockFace hourArmSide)
     {
@@ -86,7 +84,7 @@ public class Clock extends AbstractDoor implements IHorizontalAxisAligned
     }
 
     @Override
-    protected BlockMover constructBlockMover(
+    protected synchronized BlockMover constructBlockMover(
         BlockMover.Context context, DoorActionCause cause, double time, boolean skipAnimation, Cuboid newCuboid,
         IPPlayer responsible, DoorActionType actionType)
         throws Exception

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/doors/clock/ClockMover.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/doors/clock/ClockMover.java
@@ -71,7 +71,7 @@ public class ClockMover<T extends AbstractDoor & IHorizontalAxisAligned> extends
      */
     private boolean isHourArmNS(IAnimatedBlock animatedBlock)
     {
-        return ((int) animatedBlock.getPosition().z()) == door.getRotationPoint().z();
+        return ((int) animatedBlock.getPosition().z()) == rotationPoint.z();
     }
 
     /**
@@ -81,7 +81,7 @@ public class ClockMover<T extends AbstractDoor & IHorizontalAxisAligned> extends
      */
     private boolean isHourArmEW(IAnimatedBlock animatedBlock)
     {
-        return ((int) animatedBlock.getPosition().x()) == door.getRotationPoint().x();
+        return ((int) animatedBlock.getPosition().x()) == rotationPoint.x();
     }
 
     @Override

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/doors/clock/ClockMover.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/doors/clock/ClockMover.java
@@ -61,7 +61,6 @@ public class ClockMover<T extends AbstractDoor & IHorizontalAxisAligned> extends
         isHourArm = northSouth ? this::isHourArmNS : this::isHourArmEW;
         angleDirectionMultiplier =
             (rotateDirection == RotateDirection.EAST || rotateDirection == RotateDirection.SOUTH) ? -1 : 1;
-        super.animationDuration = 40_000;
     }
 
     /**

--- a/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/doors/drawbridge/BridgeMover.java
+++ b/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/doors/drawbridge/BridgeMover.java
@@ -79,7 +79,6 @@ public class BridgeMover<T extends AbstractDoor & IHorizontalAxisAligned> extend
                                                        " is not valid for this type!");
         }
 
-        super.animationDuration = (int) (20 * super.time);
         step = angle / super.animationDuration;
         halfEndCount = super.animationDuration / 2;
     }

--- a/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/doors/drawbridge/BridgeMover.java
+++ b/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/doors/drawbridge/BridgeMover.java
@@ -125,7 +125,7 @@ public class BridgeMover<T extends AbstractDoor & IHorizontalAxisAligned> extend
     @Override
     protected float getRadius(int xAxis, int yAxis, int zAxis)
     {
-        return getRadius(northSouth, door.getRotationPoint(), xAxis, yAxis, zAxis);
+        return getRadius(northSouth, rotationPoint, xAxis, yAxis, zAxis);
     }
 
     @Override
@@ -133,8 +133,8 @@ public class BridgeMover<T extends AbstractDoor & IHorizontalAxisAligned> extend
     {
         // Get the angle between the used axes (either x and y, or z and y).
         // When the rotation point is positioned along the NS axis, the Z values does not change.
-        final double deltaA = northSouth ? door.getRotationPoint().x() - xAxis : door.getRotationPoint().z() - zAxis;
-        final double deltaB = (double) door.getRotationPoint().y() - yAxis;
+        final double deltaA = northSouth ? rotationPoint.x() - xAxis : rotationPoint.z() - zAxis;
+        final double deltaB = rotationPoint.yD() - yAxis;
         return (float) Util.clampAngleRad(Math.atan2(deltaA, deltaB));
     }
 }

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/doors/flag/Flag.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/doors/flag/Flag.java
@@ -80,7 +80,7 @@ public class Flag extends AbstractDoor implements IHorizontalAxisAligned, IPerpe
     }
 
     @Override
-    protected BlockMover constructBlockMover(
+    protected synchronized BlockMover constructBlockMover(
         BlockMover.Context context, DoorActionCause cause, double time,
         boolean skipAnimation, Cuboid newCuboid, IPPlayer responsible,
         DoorActionType actionType)

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/doors/flag/FlagMover.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/doors/flag/FlagMover.java
@@ -8,6 +8,7 @@ import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
 import nl.pim16aap2.bigdoors.util.RotateDirection;
 import nl.pim16aap2.bigdoors.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
+import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
 
 import java.util.function.BiFunction;
 
@@ -32,19 +33,16 @@ public class FlagMover extends BlockMover
     {
         super(context, door, time, false, RotateDirection.NONE, player, door.getCuboid(), cause, actionType);
 
-        final int xLen = Math.abs(xMax - xMin) + 1;
-        final int zLen = Math.abs(zMax - zMin) + 1;
+        final Vector3Di dims = oldCuboid.getDimensions();
+
         NS = door.isNorthSouthAligned();
         getGoalPos = NS ? this::getGoalPosNS : this::getGoalPosEW;
 
-        final int length = NS ? zLen : xLen;
+        final int length = NS ? dims.z() : dims.x();
         period = length * 2.0f;
         amplitude = length / 4.0;
 
-        this.time = time;
         waveSpeed = 10.0f;
-
-        super.animationDuration = 200;
     }
 
     /**

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/doors/flag/FlagMover.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/doors/flag/FlagMover.java
@@ -117,7 +117,7 @@ public class FlagMover extends BlockMover
     protected float getRadius(int xAxis, int yAxis, int zAxis)
     {
         if (NS)
-            return Math.abs((float) zAxis - door.getRotationPoint().z());
-        return Math.abs((float) xAxis - door.getRotationPoint().x());
+            return Math.abs((float) zAxis - rotationPoint.z());
+        return Math.abs((float) xAxis - rotationPoint.x());
     }
 }

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/doors/garagedoor/GarageDoor.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/doors/garagedoor/GarageDoor.java
@@ -3,7 +3,6 @@ package nl.pim16aap2.bigdoors.doors.garagedoor;
 import com.google.common.flogger.StackSize;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
@@ -22,6 +21,7 @@ import nl.pim16aap2.bigdoors.util.RotateDirection;
 import nl.pim16aap2.bigdoors.util.Util;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
 
+import javax.annotation.concurrent.GuardedBy;
 import java.util.Optional;
 import java.util.logging.Level;
 
@@ -52,14 +52,12 @@ public class GarageDoor extends AbstractDoor implements IHorizontalAxisAligned, 
     @PersistentVariable
     protected final boolean northSouthAligned;
 
-    @Getter
-    @Setter
     @PersistentVariable
+    @GuardedBy("this")
     protected int autoCloseTime;
 
-    @Getter
-    @Setter
     @PersistentVariable
+    @GuardedBy("this")
     protected int autoOpenTime;
 
     public GarageDoor(DoorBase doorBase, int autoCloseTime, int autoOpenTime, boolean northSouthAligned)
@@ -103,12 +101,15 @@ public class GarageDoor extends AbstractDoor implements IHorizontalAxisAligned, 
     }
 
     @Override
-    public synchronized RotateDirection getCurrentToggleDir()
+    public RotateDirection getCurrentToggleDir()
     {
-        final RotateDirection rotDir = getOpenDir();
-        if (isOpen())
-            return RotateDirection.getOpposite(getOpenDir());
-        return rotDir;
+        synchronized (getDoorBase())
+        {
+            final RotateDirection rotDir = getOpenDir();
+            if (isOpen())
+                return RotateDirection.getOpposite(rotDir);
+            return rotDir;
+        }
     }
 
     @Override
@@ -120,10 +121,16 @@ public class GarageDoor extends AbstractDoor implements IHorizontalAxisAligned, 
     }
 
     @Override
-    public synchronized Optional<Cuboid> getPotentialNewCoordinates()
+    public Optional<Cuboid> getPotentialNewCoordinates()
     {
-        final RotateDirection rotateDirection = getCurrentToggleDir();
-        final Cuboid cuboid = getCuboid();
+        final RotateDirection rotateDirection;
+        final Cuboid cuboid;
+
+        synchronized (getDoorBase())
+        {
+            rotateDirection = getCurrentToggleDir();
+            cuboid = getCuboid();
+        }
 
         final Vector3Di dimensions = cuboid.getDimensions();
         final Vector3Di minimum = cuboid.getMin();
@@ -207,7 +214,7 @@ public class GarageDoor extends AbstractDoor implements IHorizontalAxisAligned, 
     }
 
     @Override
-    protected BlockMover constructBlockMover(
+    protected synchronized BlockMover constructBlockMover(
         BlockMover.Context context, DoorActionCause cause, double time,
         boolean skipAnimation, Cuboid newCuboid, IPPlayer responsible,
         DoorActionType actionType)
@@ -216,5 +223,29 @@ public class GarageDoor extends AbstractDoor implements IHorizontalAxisAligned, 
         return new GarageDoorMover(
             context, this, time, config.getAnimationSpeedMultiplier(getDoorType()), skipAnimation,
             getCurrentToggleDir(), responsible, newCuboid, cause, actionType);
+    }
+
+    @Override
+    public synchronized void setAutoCloseTime(int autoCloseTime)
+    {
+        this.autoCloseTime = autoCloseTime;
+    }
+
+    @Override
+    public synchronized void setAutoOpenTime(int autoOpenTime)
+    {
+        this.autoOpenTime = autoOpenTime;
+    }
+
+    @Override
+    public synchronized int getAutoCloseTime()
+    {
+        return this.autoCloseTime;
+    }
+
+    @Override
+    public synchronized int getAutoOpenTime()
+    {
+        return this.autoOpenTime;
     }
 }

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/doors/garagedoor/GarageDoorMover.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/doors/garagedoor/GarageDoorMover.java
@@ -28,9 +28,10 @@ public class GarageDoorMover extends BlockMover
     private final int yLen;
     private final int zLen;
     private final boolean northSouth;
-    protected int blocksToMove;
-
     private final double step;
+    private final boolean isOpen;
+
+    protected int blocksToMove;
 
     public GarageDoorMover(
         Context context, GarageDoor door, double time, double multiplier, boolean skipAnimation,
@@ -40,7 +41,9 @@ public class GarageDoorMover extends BlockMover
     {
         super(context, door, time, skipAnimation, rotateDirection, player, newCuboid, cause, actionType);
 
-        resultHeight = door.getMaximum().y() + 1.0D;
+        isOpen = door.isOpen();
+
+        resultHeight = oldCuboid.getMax().y() + 1.0D;
 
         BiFunction<IAnimatedBlock, Double, Vector3Dd> getVectorTmp;
         switch (rotateDirection)
@@ -99,7 +102,7 @@ public class GarageDoorMover extends BlockMover
         double yMod = stepSum;
         double zMod = 0;
 
-        if (currentHeight >= door.getMaximum().y())
+        if (currentHeight >= oldCuboid.getMax().y())
         {
             final double horizontal = Math.max(0, stepSum - animatedBlock.getRadius() - 0.5);
             xMod = directionVec.x() * horizontal;
@@ -112,7 +115,7 @@ public class GarageDoorMover extends BlockMover
 
     private Vector3Dd getVectorDownNorth(IAnimatedBlock animatedBlock, double stepSum)
     {
-        final double goalZ = door.getRotationPoint().z();
+        final double goalZ = rotationPoint.z();
         final double pivotZ = goalZ + 1.5;
         final double currentZ = Math.max(goalZ, animatedBlock.getStartZ() - stepSum);
 
@@ -132,7 +135,7 @@ public class GarageDoorMover extends BlockMover
 
     private Vector3Dd getVectorDownSouth(IAnimatedBlock animatedBlock, double stepSum)
     {
-        final double goalZ = door.getRotationPoint().z();
+        final double goalZ = rotationPoint.z();
         final double pivotZ = goalZ - 1.5;
         final double currentZ = Math.min(goalZ, animatedBlock.getStartZ() + stepSum);
 
@@ -151,7 +154,7 @@ public class GarageDoorMover extends BlockMover
 
     private Vector3Dd getVectorDownEast(IAnimatedBlock animatedBlock, double stepSum)
     {
-        final double goalX = door.getRotationPoint().x();
+        final double goalX = rotationPoint.x();
         final double pivotX = goalX - 1.5;
         final double currentX = Math.min(goalX, animatedBlock.getStartX() + stepSum);
 
@@ -170,7 +173,7 @@ public class GarageDoorMover extends BlockMover
 
     private Vector3Dd getVectorDownWest(IAnimatedBlock animatedBlock, double stepSum)
     {
-        final double goalX = door.getRotationPoint().x();
+        final double goalX = rotationPoint.x();
         final double pivotX = goalX + 1.5;
         final double currentX = Math.max(goalX, animatedBlock.getStartX() - stepSum);
 
@@ -195,7 +198,7 @@ public class GarageDoorMover extends BlockMover
         double newY;
         double newZ;
 
-        if (!door.isOpen())
+        if (!isOpen)
         {
             newX = startLocation.xD() + (1 + yLen - radius) * directionVec.x();
             newY = resultHeight;
@@ -206,13 +209,13 @@ public class GarageDoorMover extends BlockMover
             if (directionVec.x() == 0)
             {
                 newX = startLocation.xD();
-                newY = door.getMaximum().y() - (zLen - radius);
-                newZ = door.getRotationPoint().z();
+                newY = oldCuboid.getMax().y() - (zLen - radius);
+                newZ = rotationPoint.z();
             }
             else
             {
-                newX = door.getRotationPoint().x();
-                newY = door.getMaximum().y() - (xLen - radius);
+                newX = rotationPoint.x();
+                newY = oldCuboid.getMax().y() - (xLen - radius);
                 newZ = startLocation.zD();
             }
             newY -= 2;
@@ -234,14 +237,14 @@ public class GarageDoorMover extends BlockMover
     @Override
     protected float getRadius(int xAxis, int yAxis, int zAxis)
     {
-        if (!door.isOpen())
+        if (!isOpen)
         {
-            final float height = door.getMaximum().y();
+            final float height = oldCuboid.getMax().y();
             return height - yAxis;
         }
 
-        final int dX = Math.abs(xAxis - door.getRotationPoint().x());
-        final int dZ = Math.abs(zAxis - door.getRotationPoint().z());
+        final int dX = Math.abs(xAxis - rotationPoint.x());
+        final int dZ = Math.abs(zAxis - rotationPoint.z());
         return Math.abs(dX * directionVec.x() + dZ * directionVec.z());
     }
 }

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/doors/garagedoor/GarageDoorMover.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/doors/garagedoor/GarageDoorMover.java
@@ -24,14 +24,9 @@ public class GarageDoorMover extends BlockMover
     private final double resultHeight;
     private final Vector3Di directionVec;
     private final BiFunction<IAnimatedBlock, Double, Vector3Dd> getVector;
-    private final int xLen;
-    private final int yLen;
-    private final int zLen;
     private final boolean northSouth;
     private final double step;
     private final boolean isOpen;
-
-    protected int blocksToMove;
 
     public GarageDoorMover(
         Context context, GarageDoor door, double time, double multiplier, boolean skipAnimation,
@@ -74,24 +69,21 @@ public class GarageDoorMover extends BlockMover
                                                     rotateDirection + "\"");
         }
 
-        xLen = xMax - xMin;
-        yLen = yMax - yMin;
-        zLen = zMax - zMin;
-
+        final Vector3Di dims = oldCuboid.getDimensions();
+        int blocksToMove;
         if (!door.isOpen())
         {
-            blocksToMove = yLen + 1;
+            blocksToMove = dims.y();
             getVector = this::getVectorUp;
         }
         else
         {
-            blocksToMove = Math.abs((xLen + 1) * directionVec.x()
-                                        + (yLen + 1) * directionVec.y()
-                                        + (zLen + 1) * directionVec.z());
+            blocksToMove = Math.abs(dims.x() * directionVec.x()
+                                        + dims.y() * directionVec.y()
+                                        + dims.z() * directionVec.z());
             getVector = getVectorTmp;
         }
 
-        super.animationDuration = (int) (20 * super.time);
         step = (blocksToMove + 0.5f) / super.animationDuration;
     }
 
@@ -198,24 +190,26 @@ public class GarageDoorMover extends BlockMover
         double newY;
         double newZ;
 
+        final Vector3Di dims = oldCuboid.getDimensions();
+
         if (!isOpen)
         {
-            newX = startLocation.xD() + (1 + yLen - radius) * directionVec.x();
+            newX = startLocation.xD() + (dims.y() - radius) * directionVec.x();
             newY = resultHeight;
-            newZ = startLocation.zD() + (1 + yLen - radius) * directionVec.z();
+            newZ = startLocation.zD() + (dims.y() - radius) * directionVec.z();
         }
         else
         {
             if (directionVec.x() == 0)
             {
                 newX = startLocation.xD();
-                newY = oldCuboid.getMax().y() - (zLen - radius);
+                newY = oldCuboid.getMax().y() - (dims.z() - radius);
                 newZ = rotationPoint.z();
             }
             else
             {
                 newX = rotationPoint.x();
-                newY = oldCuboid.getMax().y() - (xLen - radius);
+                newY = oldCuboid.getMax().y() - (dims.x() - radius);
                 newZ = startLocation.zD();
             }
             newY -= 2;

--- a/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/doors/portcullis/VerticalMover.java
+++ b/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/doors/portcullis/VerticalMover.java
@@ -29,27 +29,6 @@ public class VerticalMover extends BlockMover
         super(context, door, time, skipAnimation, RotateDirection.NONE, player, newCuboid, cause, actionType);
         this.blocksToMove = blocksToMove;
 
-        double speed = 1;
-        double pcMultiplier = multiplier;
-        pcMultiplier = pcMultiplier == 0.0 ? 1.0 : pcMultiplier;
-        final int maxSpeed = 6;
-
-        // If the time isn't default, calculate speed.
-        if (time != 0.0)
-        {
-            speed = Math.abs(blocksToMove) / time;
-            super.time = time;
-        }
-
-        // If the non-default exceeds the max-speed or isn't set, calculate default speed.
-        if (time == 0.0 || speed > maxSpeed)
-        {
-            speed = (blocksToMove < 0 ? 1.7 : 0.8) * pcMultiplier;
-            speed = speed > maxSpeed ? maxSpeed : speed;
-            super.time = Math.abs(blocksToMove) / speed;
-        }
-
-        super.animationDuration = (int) (20 * super.time);
         step = ((double) blocksToMove) / ((double) super.animationDuration);
     }
 

--- a/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/doors/revolvingdoor/RevolvingDoorMover.java
+++ b/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/doors/revolvingdoor/RevolvingDoorMover.java
@@ -46,7 +46,6 @@ public class RevolvingDoorMover extends BlockMover
                                   getDoorUID(), rotateDirection.name()));
         }
 
-        super.animationDuration = (int) (20.0 * super.time * quarterCircles);
         step = (Math.PI / 2.0 * quarterCircles) / super.animationDuration * -1.0;
         endStepSum = super.animationDuration * step;
     }

--- a/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/doors/revolvingdoor/RevolvingDoorMover.java
+++ b/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/doors/revolvingdoor/RevolvingDoorMover.java
@@ -21,7 +21,6 @@ import java.util.function.BiFunction;
 public class RevolvingDoorMover extends BlockMover
 {
     private final BiFunction<IAnimatedBlock, Double, Vector3Dd> getGoalPos;
-
     private final double step;
     private final double endStepSum;
 
@@ -54,8 +53,8 @@ public class RevolvingDoorMover extends BlockMover
 
     private Vector3Dd getGoalPosClockwise(double radius, double startAngle, double startY, double stepSum)
     {
-        final double posX = 0.5 + door.getRotationPoint().x() - radius * Math.sin(startAngle + stepSum);
-        final double posZ = 0.5 + door.getRotationPoint().z() - radius * Math.cos(startAngle + stepSum);
+        final double posX = 0.5 + rotationPoint.xD() - radius * Math.sin(startAngle + stepSum);
+        final double posZ = 0.5 + rotationPoint.zD() - radius * Math.cos(startAngle + stepSum);
         return new Vector3Dd(posX, startY, posZ);
     }
 
@@ -68,8 +67,8 @@ public class RevolvingDoorMover extends BlockMover
 
     private Vector3Dd getGoalPosCounterClockwise(double radius, double startAngle, double startY, double stepSum)
     {
-        final double posX = 0.5 + door.getRotationPoint().x() - radius * Math.sin(startAngle - stepSum);
-        final double posZ = 0.5 + door.getRotationPoint().z() - radius * Math.cos(startAngle - stepSum);
+        final double posX = 0.5 + rotationPoint.xD() - radius * Math.sin(startAngle - stepSum);
+        final double posZ = 0.5 + rotationPoint.zD() - radius * Math.cos(startAngle - stepSum);
         return new Vector3Dd(posX, startY, posZ);
     }
 
@@ -104,15 +103,14 @@ public class RevolvingDoorMover extends BlockMover
     @Override
     protected float getRadius(int xAxis, int yAxis, int zAxis)
     {
-        final double deltaA = (double) door.getRotationPoint().x() - xAxis;
-        final double deltaB = (double) door.getRotationPoint().z() - zAxis;
+        final double deltaA = rotationPoint.xD() - xAxis;
+        final double deltaB = rotationPoint.zD() - zAxis;
         return (float) Math.sqrt(Math.pow(deltaA, 2) + Math.pow(deltaB, 2));
     }
 
     @Override
     protected float getStartAngle(int xAxis, int yAxis, int zAxis)
     {
-        return (float) Math.atan2((double) door.getRotationPoint().x() - xAxis,
-                                  (double) door.getRotationPoint().z() - zAxis);
+        return (float) Math.atan2(rotationPoint.xD() - xAxis, rotationPoint.zD() - zAxis);
     }
 }

--- a/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/doors/slidingdoor/SlidingMover.java
+++ b/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/doors/slidingdoor/SlidingMover.java
@@ -25,7 +25,7 @@ public class SlidingMover extends BlockMover
 
     private final double step;
 
-    private @Nullable IAnimatedBlock firstBlockData = null;
+    private volatile @Nullable IAnimatedBlock firstBlockData = null;
 
     protected final int blocksToMove;
 
@@ -43,27 +43,6 @@ public class SlidingMover extends BlockMover
         moveX = northSouth ? 0 : blocksToMove;
         moveZ = northSouth ? blocksToMove : 0;
 
-        double speed = 1;
-        double pcMult = multiplier;
-        pcMult = pcMult == 0.0 ? 1.0 : pcMult;
-        final int maxSpeed = 6;
-
-        // If the time isn't default, calculate speed.
-        if (time != 0.0)
-        {
-            speed = Math.abs(blocksToMove) / time;
-            super.time = time;
-        }
-
-        // If the non-default exceeds the max-speed or isn't set, calculate default speed.
-        if (time == 0.0 || speed > maxSpeed)
-        {
-            speed = 1.4 * pcMult;
-            speed = speed > maxSpeed ? maxSpeed : speed;
-            super.time = Math.abs(blocksToMove) / speed;
-        }
-
-        super.animationDuration = (int) (20 * super.time);
         step = ((double) blocksToMove) / ((double) super.animationDuration);
     }
 

--- a/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/doors/windmill/WindmillMover.java
+++ b/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/doors/windmill/WindmillMover.java
@@ -55,9 +55,8 @@ public class WindmillMover<T extends AbstractDoor & IHorizontalAxisAligned> exte
     {
         // Get the current radius of a block between used axis (either x and y, or z and y).
         // When the rotation point is positioned along the NS axis, the X values does not change for this type.
-        final double deltaA = (double) door.getRotationPoint().y() - yAxis;
-        final double deltaB =
-            northSouth ? (door.getRotationPoint().z() - zAxis) : (door.getRotationPoint().x() - xAxis);
+        final double deltaA = rotationPoint.yD() - yAxis;
+        final double deltaB = northSouth ? (rotationPoint.z() - zAxis) : (rotationPoint.x() - xAxis);
         return (float) Math.sqrt(Math.pow(deltaA, 2) + Math.pow(deltaB, 2));
     }
 
@@ -66,8 +65,8 @@ public class WindmillMover<T extends AbstractDoor & IHorizontalAxisAligned> exte
     {
         // Get the angle between the used axes (either x and y, or z and y).
         // When the rotation point is positioned along the NS axis, the X values does not change for this type.
-        final double deltaA = northSouth ? door.getRotationPoint().z() - zAxis : door.getRotationPoint().x() - xAxis;
-        final double deltaB = (double) door.getRotationPoint().y() - yAxis;
+        final double deltaA = northSouth ? rotationPoint.z() - zAxis : rotationPoint.x() - xAxis;
+        final double deltaB = rotationPoint.yD() - yAxis;
 
         return (float) Util.clampAngleRad(Math.atan2(deltaA, deltaB));
     }

--- a/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/doors/windmill/WindmillMover.java
+++ b/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/doors/windmill/WindmillMover.java
@@ -30,9 +30,8 @@ public class WindmillMover<T extends AbstractDoor & IHorizontalAxisAligned> exte
         throws Exception
     {
         super(context, time, door, rotateDirection, false, multiplier, player, door.getCuboid(), cause, actionType);
-
         super.perpetualMovement = true;
-        super.animationDuration = (int) (20 * 20 * super.time);
+
         step = (Math.PI / 2.0) / (20.0f * super.time * 2.0f);
     }
 

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/events/DoorEventCallerSpigot.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/events/DoorEventCallerSpigot.java
@@ -39,7 +39,7 @@ public class DoorEventCallerSpigot implements IDoorEventCaller
         }
 
         // Async events can only be called asynchronously and Sync events can only be called from the main thread.
-        final boolean isMainThread = executor.isMainThread(Thread.currentThread().getId());
+        final boolean isMainThread = executor.isMainThread();
         if (isMainThread && bigDoorsEvent.isAsynchronous())
             executor.runAsync(() -> Bukkit.getPluginManager().callEvent((BigDoorsSpigotEvent) bigDoorsEvent));
         else if ((!isMainThread) && (!bigDoorsEvent.isAsynchronous()))


### PR DESCRIPTION
- Synchronize access to DoorBase properties where appropriate.
- Replace the ConcurrentHashMap in the DoorBase class with a regular HashMap. All accesses to it are now synchronized, so no need for the additional overhead.
- For AbstractDoor (sub)classes: Synchronize on DoorBase when accessing more than one property at a time to ensure consistency.
- Update BlockMover instantiation requirements: No longer required (or recommended) to do on the main thread, but you _do_ need a lock on the DoorBase object being toggled. This ensures all reads from the DoorBase class are consistent.
- Restrict AbstractDoor access in BlockMover classes. To ensure they do not access data that has been changed after the movement was initiated, they copy all required data in the constructor. The visibility of the door variable has been restricted to private to enforce this for subclasses.
- Added synchronization to some of the fields in the 1.19.3 module that may be accessed asynchronously.