### PR TITLE
Handle movable deletion through central system

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
@@ -224,13 +224,14 @@ public final class DatabaseManager extends Restartable implements IDebuggable
                 if (event.isCancelled())
                     return ActionResult.CANCELLED;
 
-                final boolean result = db.removeMovable(movable.getUid());
+                final MovableSnapshot snapshot = movable.getSnapshot();
+                movableRegistry.onMovableDeletion(snapshot);
+                final boolean result = db.removeMovable(snapshot.getUid());
                 if (!result)
                 {
                     log.atSevere().withStackTrace(StackSize.FULL).log("Failed to process event: %s", event);
                     return ActionResult.FAIL;
                 }
-                movableRegistry.deregisterMovable(movable.getUid());
 
                 powerBlockManager.get().onMovableAddOrRemove(movable.getWorld().worldName(),
                                                              new Vector3Di(movable.getPowerBlock().x(),

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
@@ -62,8 +62,8 @@ public final class DatabaseManager extends Restartable implements IDebuggable
 
     private final IStorage db;
 
+    private final MovableDeletionManager movableDeletionManager;
     private final IBigDoorsEventCaller bigDoorsEventCaller;
-    private final MovableRegistry movableRegistry;
     private final Lazy<PowerBlockManager> powerBlockManager;
     private final IBigDoorsEventFactory bigDoorsEventFactory;
 
@@ -77,14 +77,14 @@ public final class DatabaseManager extends Restartable implements IDebuggable
      */
     @Inject
     public DatabaseManager(
-        RestartableHolder restartableHolder, IStorage storage, MovableRegistry movableRegistry,
+        RestartableHolder restartableHolder, IStorage storage, MovableDeletionManager movableDeletionManager,
         Lazy<PowerBlockManager> powerBlockManager, IBigDoorsEventFactory bigDoorsEventFactory,
         IBigDoorsEventCaller bigDoorsEventCaller, DebuggableRegistry debuggableRegistry)
     {
         super(restartableHolder);
         db = storage;
+        this.movableDeletionManager = movableDeletionManager;
         this.bigDoorsEventCaller = bigDoorsEventCaller;
-        this.movableRegistry = movableRegistry;
         this.powerBlockManager = powerBlockManager;
         this.bigDoorsEventFactory = bigDoorsEventFactory;
         initThreadPool();
@@ -232,7 +232,7 @@ public final class DatabaseManager extends Restartable implements IDebuggable
                     return ActionResult.FAIL;
                 }
 
-                movableRegistry.onMovableDeletion(snapshot);
+                movableDeletionManager.onMovableDeletion(snapshot);
 
                 return ActionResult.SUCCESS;
             }, threadPool).exceptionally(ex -> Util.exceptionally(ex, ActionResult.FAIL));

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
@@ -233,10 +233,6 @@ public final class DatabaseManager extends Restartable implements IDebuggable
                     return ActionResult.FAIL;
                 }
 
-                powerBlockManager.get().onMovableAddOrRemove(movable.getWorld().worldName(),
-                                                             new Vector3Di(movable.getPowerBlock().x(),
-                                                                           movable.getPowerBlock().y(),
-                                                                           movable.getPowerBlock().z()));
                 return ActionResult.SUCCESS;
             }, threadPool).exceptionally(ex -> Util.exceptionally(ex, ActionResult.FAIL));
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
@@ -225,13 +225,14 @@ public final class DatabaseManager extends Restartable implements IDebuggable
                     return ActionResult.CANCELLED;
 
                 final MovableSnapshot snapshot = movable.getSnapshot();
-                movableRegistry.onMovableDeletion(snapshot);
                 final boolean result = db.removeMovable(snapshot.getUid());
                 if (!result)
                 {
                     log.atSevere().withStackTrace(StackSize.FULL).log("Failed to process event: %s", event);
                     return ActionResult.FAIL;
                 }
+
+                movableRegistry.onMovableDeletion(snapshot);
 
                 return ActionResult.SUCCESS;
             }, threadPool).exceptionally(ex -> Util.exceptionally(ex, ActionResult.FAIL));

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/MovableDeletionManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/MovableDeletionManager.java
@@ -1,0 +1,112 @@
+package nl.pim16aap2.bigdoors.managers;
+
+import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.bigdoors.api.debugging.DebuggableRegistry;
+import nl.pim16aap2.bigdoors.api.debugging.IDebuggable;
+import nl.pim16aap2.bigdoors.movable.IMovableConst;
+import org.jetbrains.annotations.Nullable;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Singleton
+@Flogger
+public class MovableDeletionManager implements IDebuggable
+{
+    /**
+     * The listeners that will be called when a movable is deleted.
+     */
+    private final List<IDeletionListener> deletionListeners = new CopyOnWriteArrayList<>();
+
+    @Inject MovableDeletionManager(DebuggableRegistry registry)
+    {
+        registry.registerDebuggable(this);
+    }
+
+    @Override
+    public @Nullable String getDebugInformation()
+    {
+        return "MovableDeletionManager: Registered listeners: " + deletionListeners;
+    }
+
+    /**
+     * Handles the deletion of a movable.
+     *
+     * @param movable
+     *     The movable that is deleted.
+     */
+    void onMovableDeletion(IMovableConst movable)
+    {
+        IDeletionListener.callListeners(deletionListeners, movable);
+    }
+
+    /**
+     * Registers a deletion listener which will be used when a door is deleted.
+     *
+     * @param listener
+     *     The listener to register.
+     */
+    public void registerDeletionListener(IDeletionListener listener)
+    {
+        this.deletionListeners.add(listener);
+    }
+
+    /**
+     * Unregisters a deletion listener.
+     *
+     * @param listener
+     *     The listener to unregister.
+     * @return True if the listener was previously registered.
+     */
+    public boolean unregisterDeletionListener(IDeletionListener listener)
+    {
+        boolean unregistered = false;
+        while (this.deletionListeners.remove(listener))
+            unregistered = true;
+        return unregistered;
+    }
+
+    /**
+     * Represents a listener for movable deletion events.
+     */
+    public interface IDeletionListener
+    {
+        /**
+         * Called when a movable is deleted.
+         *
+         * @param movable
+         *     The movable that was deleted.
+         */
+        void onMovableDeletion(IMovableConst movable);
+
+        /**
+         * Safely calls all listeners for a movable that has been deleted.
+         *
+         * @param listeners
+         *     The listeners to call.
+         * @param movable
+         *     The movable that was deleted.
+         */
+        static void callListeners(Collection<IDeletionListener> listeners, IMovableConst movable)
+        {
+            listeners.forEach(listener -> callMovableDeletionListener(listener, movable));
+        }
+
+        private static void callMovableDeletionListener(IDeletionListener listener, IMovableConst movable)
+        {
+            try
+            {
+                listener.onMovableDeletion(movable);
+            }
+            catch (Exception exception)
+            {
+                log.atSevere().withCause(exception)
+                   .log("Failed to call movable deletion listener '%s' for movable %s!",
+                        listener.getClass().getName(), movable);
+            }
+        }
+    }
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/PowerBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/PowerBlockManager.java
@@ -6,8 +6,8 @@ import nl.pim16aap2.bigdoors.api.restartable.Restartable;
 import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.data.cache.timed.TimedCache;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
+import nl.pim16aap2.bigdoors.movable.IMovableConst;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
-import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
 import nl.pim16aap2.bigdoors.util.Util;
 import nl.pim16aap2.bigdoors.util.vector.Vector2Di;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
@@ -200,9 +200,9 @@ public final class PowerBlockManager extends Restartable implements MovableRegis
     }
 
     @Override
-    public void onMovableDeletion(MovableSnapshot snapshot)
+    public void onMovableDeletion(IMovableConst movable)
     {
-        onMovableAddOrRemove(snapshot.getWorld().worldName(), snapshot.getPowerBlock());
+        onMovableAddOrRemove(movable.getWorld().worldName(), movable.getPowerBlock());
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/PowerBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/PowerBlockManager.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Singleton
 @Flogger
-public final class PowerBlockManager extends Restartable implements MovableRegistry.IDeletionListener
+public final class PowerBlockManager extends Restartable implements MovableDeletionManager.IDeletionListener
 {
     private final Map<String, PowerBlockWorld> powerBlockWorlds = new ConcurrentHashMap<>();
     private final IConfigLoader config;
@@ -49,12 +49,14 @@ public final class PowerBlockManager extends Restartable implements MovableRegis
      */
     @Inject PowerBlockManager(
         RestartableHolder restartableHolder, IConfigLoader config, DatabaseManager databaseManager,
-        MovableRegistry registry)
+        MovableDeletionManager movableDeletionManager)
     {
         super(restartableHolder);
-        registry.registerDeletionListener(this);
+
         this.config = config;
         this.databaseManager = databaseManager;
+
+        movableDeletionManager.registerDeletionListener(this);
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/IMovableConst.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/IMovableConst.java
@@ -59,6 +59,14 @@ public interface IMovableConst
     String getName();
 
     /**
+     * @return The name and UID of this movable formatted as "name (uid)".
+     */
+    default String getNameAndUid()
+    {
+        return String.format("%s (%d)", getName(), getUid());
+    }
+
+    /**
      * Gets the IPWorld this {@link IMovable} exists in.
      *
      * @return The IPWorld this {@link IMovable} exists in

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
@@ -7,7 +7,7 @@ import nl.pim16aap2.bigdoors.api.factories.IBigDoorsEventFactory;
 import nl.pim16aap2.bigdoors.api.restartable.Restartable;
 import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.events.IBigDoorsEventCaller;
-import nl.pim16aap2.bigdoors.managers.MovableRegistry;
+import nl.pim16aap2.bigdoors.managers.MovableDeletionManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.IMovableConst;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
  * @author Pim
  */
 @Singleton
-public final class MovableActivityManager extends Restartable implements MovableRegistry.IDeletionListener
+public final class MovableActivityManager extends Restartable implements MovableDeletionManager.IDeletionListener
 {
     private final Map<Long, Optional<BlockMover>> busyMovables = new ConcurrentHashMap<>();
 
@@ -50,10 +50,10 @@ public final class MovableActivityManager extends Restartable implements Movable
     public MovableActivityManager(
         RestartableHolder holder, Lazy<AutoCloseScheduler> autoCloseScheduler,
         IConfigLoader config, IPExecutor executor, IBigDoorsEventFactory eventFactory,
-        IBigDoorsEventCaller bigDoorsEventCaller, MovableRegistry registry)
+        IBigDoorsEventCaller bigDoorsEventCaller, MovableDeletionManager movableDeletionManager)
     {
         super(holder);
-        registry.registerDeletionListener(this);
+        movableDeletionManager.registerDeletionListener(this);
         this.autoCloseScheduler = autoCloseScheduler;
         this.config = config;
         this.executor = executor;

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
@@ -7,7 +7,9 @@ import nl.pim16aap2.bigdoors.api.factories.IBigDoorsEventFactory;
 import nl.pim16aap2.bigdoors.api.restartable.Restartable;
 import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.events.IBigDoorsEventCaller;
+import nl.pim16aap2.bigdoors.managers.MovableRegistry;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
+import nl.pim16aap2.bigdoors.movable.IMovableConst;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.ITimerToggleable;
 import nl.pim16aap2.bigdoors.util.Constants;
@@ -15,6 +17,7 @@ import nl.pim16aap2.bigdoors.util.Constants;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -25,7 +28,7 @@ import java.util.stream.Stream;
  * @author Pim
  */
 @Singleton
-public final class MovableActivityManager extends Restartable
+public final class MovableActivityManager extends Restartable implements MovableRegistry.IDeletionListener
 {
     private final Map<Long, Optional<BlockMover>> busyMovables = new ConcurrentHashMap<>();
 
@@ -47,9 +50,10 @@ public final class MovableActivityManager extends Restartable
     public MovableActivityManager(
         RestartableHolder holder, Lazy<AutoCloseScheduler> autoCloseScheduler,
         IConfigLoader config, IPExecutor executor, IBigDoorsEventFactory eventFactory,
-        IBigDoorsEventCaller bigDoorsEventCaller)
+        IBigDoorsEventCaller bigDoorsEventCaller, MovableRegistry registry)
     {
         super(holder);
+        registry.registerDeletionListener(this);
         this.autoCloseScheduler = autoCloseScheduler;
         this.config = config;
         this.executor = executor;
@@ -167,7 +171,7 @@ public final class MovableActivityManager extends Restartable
      */
     public Optional<BlockMover> getBlockMover(long movableUID)
     {
-        return busyMovables.containsKey(movableUID) ? busyMovables.get(movableUID) : Optional.empty();
+        return Objects.requireNonNullElse(busyMovables.get(movableUID), Optional.empty());
     }
 
     /**
@@ -185,6 +189,13 @@ public final class MovableActivityManager extends Restartable
     {
         busyMovables.forEach((key, value) -> value.ifPresent(BlockMover::abort));
         emptyBusyMovables();
+    }
+
+    @Override
+    public void onMovableDeletion(IMovableConst movable)
+    {
+        Objects.<Optional<BlockMover>>requireNonNullElse(busyMovables.remove(movable.getUid()), Optional.empty())
+               .ifPresent(BlockMover::abort);
     }
 
     @Override

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/AttributeButtonFactory.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/AttributeButtonFactory.java
@@ -2,7 +2,6 @@ package nl.pim16aap2.bigdoors.spigot.gui;
 
 import de.themoep.inventorygui.GuiElement;
 import de.themoep.inventorygui.GuiStateElement;
-import de.themoep.inventorygui.InventoryGui;
 import de.themoep.inventorygui.StaticGuiElement;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.IPExecutor;
@@ -123,14 +122,14 @@ class AttributeButtonFactory
     }
 
     private GuiElement deleteButton(
-        MainGui mainGui, AbstractMovable movable, PPlayerSpigot player, char slotChar)
+        AbstractMovable movable, PPlayerSpigot player, char slotChar)
     {
         return new StaticGuiElement(
             slotChar,
             new ItemStack(Material.BARRIER),
             click ->
             {
-                deleteGuiFactory.newDeleteGui(movable, player, mainGui);
+                deleteGuiFactory.newDeleteGui(movable, player);
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.delete",
@@ -138,8 +137,7 @@ class AttributeButtonFactory
         );
     }
 
-    private GuiElement relocatePowerBlockButton(
-        InventoryGui gui, AbstractMovable movable, PPlayerSpigot player, char slotChar)
+    private GuiElement relocatePowerBlockButton(AbstractMovable movable, PPlayerSpigot player, char slotChar)
     {
         return new StaticGuiElement(
             slotChar,
@@ -147,7 +145,7 @@ class AttributeButtonFactory
             click ->
             {
                 commandFactory.newMovePowerBlock(player, movableRetrieverFactory.of(movable)).run();
-                gui.close(true);
+                GuiUtil.closeAllGuis(player);
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.relocate_power_block",
@@ -155,8 +153,7 @@ class AttributeButtonFactory
         );
     }
 
-    private GuiElement autoCloseTimerButton(
-        InventoryGui gui, AbstractMovable movable, PPlayerSpigot player, char slotChar)
+    private GuiElement autoCloseTimerButton(AbstractMovable movable, PPlayerSpigot player, char slotChar)
     {
         return new StaticGuiElement(
             slotChar,
@@ -164,7 +161,7 @@ class AttributeButtonFactory
             click ->
             {
                 commandFactory.getSetAutoCloseTimeDelayed().runDelayed(player, movableRetrieverFactory.of(movable));
-                gui.close(true);
+                GuiUtil.closeAllGuis(player);
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.auto_close_timer",
@@ -172,8 +169,7 @@ class AttributeButtonFactory
         );
     }
 
-    private GuiElement openDirectionButton(
-        InventoryGui gui, AbstractMovable movable, PPlayerSpigot player, char slotChar)
+    private GuiElement openDirectionButton(AbstractMovable movable, PPlayerSpigot player, char slotChar)
     {
         return new StaticGuiElement(
             slotChar,
@@ -181,7 +177,7 @@ class AttributeButtonFactory
             click ->
             {
                 commandFactory.getSetOpenDirectionDelayed().runDelayed(player, movableRetrieverFactory.of(movable));
-                gui.close(true);
+                GuiUtil.closeAllGuis(player);
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.open_direction",
@@ -189,8 +185,7 @@ class AttributeButtonFactory
         );
     }
 
-    private GuiElement blocksToMoveButton(
-        InventoryGui gui, AbstractMovable movable, PPlayerSpigot player, char slotChar)
+    private GuiElement blocksToMoveButton(AbstractMovable movable, PPlayerSpigot player, char slotChar)
     {
         return new StaticGuiElement(
             slotChar,
@@ -198,7 +193,7 @@ class AttributeButtonFactory
             click ->
             {
                 commandFactory.getSetBlocksToMoveDelayed().runDelayed(player, movableRetrieverFactory.of(movable));
-                gui.close(true);
+                GuiUtil.closeAllGuis(player);
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.blocks_to_move",
@@ -206,8 +201,7 @@ class AttributeButtonFactory
         );
     }
 
-    private GuiElement addOwnerButton(
-        InventoryGui gui, AbstractMovable movable, PPlayerSpigot player, char slotChar)
+    private GuiElement addOwnerButton(AbstractMovable movable, PPlayerSpigot player, char slotChar)
     {
         return new StaticGuiElement(
             slotChar,
@@ -215,7 +209,7 @@ class AttributeButtonFactory
             click ->
             {
                 commandFactory.getAddOwnerDelayed().runDelayed(player, movableRetrieverFactory.of(movable));
-                gui.close(true);
+                GuiUtil.closeAllGuis(player);
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.add_owner",
@@ -223,8 +217,7 @@ class AttributeButtonFactory
         );
     }
 
-    private GuiElement removeOwnerButton(
-        InventoryGui gui, AbstractMovable movable, PPlayerSpigot player, char slotChar)
+    private GuiElement removeOwnerButton(AbstractMovable movable, PPlayerSpigot player, char slotChar)
     {
         return new StaticGuiElement(
             slotChar,
@@ -232,7 +225,7 @@ class AttributeButtonFactory
             click ->
             {
                 commandFactory.getRemoveOwnerDelayed().runDelayed(player, movableRetrieverFactory.of(movable));
-                gui.close(true);
+                GuiUtil.closeAllGuis(player);
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.remove_owner",
@@ -243,9 +236,7 @@ class AttributeButtonFactory
     /**
      * Creates a new GuiElement for the provided attribute.
      */
-    public GuiElement of(
-        InventoryGui gui, MainGui mainGui, MovableAttribute attribute, AbstractMovable movable,
-        PPlayerSpigot player, char slotChar)
+    public GuiElement of(MovableAttribute attribute, AbstractMovable movable, PPlayerSpigot player, char slotChar)
     {
         return switch (attribute)
             {
@@ -253,13 +244,13 @@ class AttributeButtonFactory
                 case TOGGLE -> this.toggleButton(movable, player, slotChar);
                 case SWITCH -> this.switchButton(movable, player, slotChar);
                 case INFO -> this.infoButton(movable, player, slotChar);
-                case DELETE -> this.deleteButton(mainGui, movable, player, slotChar);
-                case RELOCATE_POWERBLOCK -> this.relocatePowerBlockButton(gui, movable, player, slotChar);
-                case AUTO_CLOSE_TIMER -> this.autoCloseTimerButton(gui, movable, player, slotChar);
-                case OPEN_DIRECTION -> this.openDirectionButton(gui, movable, player, slotChar);
-                case BLOCKS_TO_MOVE -> this.blocksToMoveButton(gui, movable, player, slotChar);
-                case ADD_OWNER -> this.addOwnerButton(gui, movable, player, slotChar);
-                case REMOVE_OWNER -> this.removeOwnerButton(gui, movable, player, slotChar);
+                case DELETE -> this.deleteButton(movable, player, slotChar);
+                case RELOCATE_POWERBLOCK -> this.relocatePowerBlockButton(movable, player, slotChar);
+                case AUTO_CLOSE_TIMER -> this.autoCloseTimerButton(movable, player, slotChar);
+                case OPEN_DIRECTION -> this.openDirectionButton(movable, player, slotChar);
+                case BLOCKS_TO_MOVE -> this.blocksToMoveButton(movable, player, slotChar);
+                case ADD_OWNER -> this.addOwnerButton(movable, player, slotChar);
+                case REMOVE_OWNER -> this.removeOwnerButton(movable, player, slotChar);
             };
     }
 }

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/DeleteGui.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/DeleteGui.java
@@ -5,6 +5,8 @@ import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 import de.themoep.inventorygui.InventoryGui;
 import de.themoep.inventorygui.StaticGuiElement;
+import lombok.Getter;
+import lombok.ToString;
 import nl.pim16aap2.bigdoors.commands.CommandFactory;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
@@ -14,7 +16,8 @@ import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetrieverFactory;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
-class DeleteGui
+@ToString(onlyExplicitlyIncluded = true)
+class DeleteGui implements IGuiPage
 {
     private static final ItemStack FILLER = new ItemStack(Material.GRAY_STAINED_GLASS_PANE, 1);
 
@@ -22,16 +25,20 @@ class DeleteGui
     private final ILocalizer localizer;
     private final CommandFactory commandFactory;
     private final MovableRetrieverFactory movableRetrieverFactory;
-    private final AbstractMovable movable;
-    private final PPlayerSpigot inventoryHolder;
-    private final MainGui mainGui;
     private final InventoryGui inventoryGui;
+
+    @ToString.Include
+    private final AbstractMovable movable;
+
+    @Getter
+    @ToString.Include
+    private final PPlayerSpigot inventoryHolder;
 
     @AssistedInject //
     DeleteGui(
         BigDoorsPlugin bigDoorsPlugin, ILocalizer localizer, CommandFactory commandFactory,
         MovableRetrieverFactory movableRetrieverFactory,
-        @Assisted AbstractMovable movable, @Assisted PPlayerSpigot inventoryHolder, @Assisted MainGui mainGui)
+        @Assisted AbstractMovable movable, @Assisted PPlayerSpigot inventoryHolder)
     {
         this.bigDoorsPlugin = bigDoorsPlugin;
         this.localizer = localizer;
@@ -39,12 +46,11 @@ class DeleteGui
         this.movableRetrieverFactory = movableRetrieverFactory;
         this.movable = movable;
         this.inventoryHolder = inventoryHolder;
-        this.mainGui = mainGui;
 
         this.inventoryGui = createGUI();
+
         showGUI();
     }
-
 
     private void showGUI()
     {
@@ -82,7 +88,7 @@ class DeleteGui
             new ItemStack(Material.GREEN_STAINED_GLASS_PANE),
             click ->
             {
-                gui.close(false);
+                GuiUtil.closeGuiPage(gui, inventoryHolder);
                 return true;
             },
             localizer.getMessage("gui.delete_page.cancel",
@@ -94,9 +100,7 @@ class DeleteGui
             click ->
             {
                 commandFactory.newDelete(inventoryHolder, movableRetrieverFactory.of(movable)).run();
-                mainGui.removeMovable(movable);
-                inventoryGui.close(true);
-                mainGui.redraw();
+                GuiUtil.closeGuiPage(gui, inventoryHolder);
                 return true;
             },
             localizer.getMessage("gui.delete_page.confirm",
@@ -104,9 +108,15 @@ class DeleteGui
         ));
     }
 
+    @Override
+    public String getPageName()
+    {
+        return "DeleteGui";
+    }
+
     @AssistedFactory
     interface IFactory
     {
-        DeleteGui newDeleteGui(AbstractMovable movable, PPlayerSpigot playerSpigot, MainGui mainGui);
+        DeleteGui newDeleteGui(AbstractMovable movable, PPlayerSpigot playerSpigot);
     }
 }

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/GuiMovableDeletionManager.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/GuiMovableDeletionManager.java
@@ -5,7 +5,7 @@ import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.api.IPExecutor;
 import nl.pim16aap2.bigdoors.api.debugging.DebuggableRegistry;
 import nl.pim16aap2.bigdoors.api.debugging.IDebuggable;
-import nl.pim16aap2.bigdoors.managers.MovableRegistry;
+import nl.pim16aap2.bigdoors.managers.MovableDeletionManager;
 import nl.pim16aap2.bigdoors.movable.IMovableConst;
 
 import javax.inject.Inject;
@@ -28,18 +28,18 @@ import java.util.List;
  */
 @Singleton
 @Flogger
-class GuiMovableDeletionManager implements MovableRegistry.IDeletionListener, IDebuggable
+class GuiMovableDeletionManager implements MovableDeletionManager.IDeletionListener, IDebuggable
 {
     @GuardedBy("this")
     private final Deque<IGuiPage.IGuiMovableDeletionListener> listeners = new ArrayDeque<>();
     private final IPExecutor executor;
 
     @Inject GuiMovableDeletionManager(
-        MovableRegistry movableRegistry, IPExecutor executor, DebuggableRegistry debuggableRegistry)
+        MovableDeletionManager movableDeletionManager, IPExecutor executor, DebuggableRegistry debuggableRegistry)
     {
         this.executor = executor;
 
-        movableRegistry.registerDeletionListener(this);
+        movableDeletionManager.registerDeletionListener(this);
         debuggableRegistry.registerDebuggable(this);
     }
 
@@ -56,12 +56,12 @@ class GuiMovableDeletionManager implements MovableRegistry.IDeletionListener, ID
     @Override
     public void onMovableDeletion(IMovableConst movable)
     {
-        final List<MovableRegistry.IDeletionListener> copy;
+        final List<MovableDeletionManager.IDeletionListener> copy;
         synchronized (this)
         {
             copy = new ArrayList<>(listeners);
         }
-        executor.scheduleOnMainThread(() -> MovableRegistry.IDeletionListener.callListeners(copy, movable));
+        executor.scheduleOnMainThread(() -> MovableDeletionManager.IDeletionListener.callListeners(copy, movable));
     }
 
     @Override

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/GuiMovableDeletionManager.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/GuiMovableDeletionManager.java
@@ -1,0 +1,93 @@
+package nl.pim16aap2.bigdoors.spigot.gui;
+
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.bigdoors.api.IPExecutor;
+import nl.pim16aap2.bigdoors.api.debugging.DebuggableRegistry;
+import nl.pim16aap2.bigdoors.api.debugging.IDebuggable;
+import nl.pim16aap2.bigdoors.managers.MovableRegistry;
+import nl.pim16aap2.bigdoors.movable.IMovableConst;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Represents a manager for door deletions specifically for the GUI classes.
+ * <p>
+ * The listeners registered with the MovableRegistry have slightly different requirements than the general listeners of
+ * the MovableRegistry's events.
+ * <p>
+ * For one, this class will call listeners in reverse order, as new GUI pages are opened over top of the older ones and
+ * need to be processed in LIFO ordering.
+ * <p>
+ * Secondly, the holder for the GUI listeners will receive a lot of writes, whereas the main holder does not.
+ */
+@Singleton
+@Flogger
+class GuiMovableDeletionManager implements MovableRegistry.IDeletionListener, IDebuggable
+{
+    @GuardedBy("this")
+    private final Deque<IGuiPage.IGuiMovableDeletionListener> listeners = new ArrayDeque<>();
+    private final IPExecutor executor;
+
+    @Inject GuiMovableDeletionManager(
+        MovableRegistry movableRegistry, IPExecutor executor, DebuggableRegistry debuggableRegistry)
+    {
+        this.executor = executor;
+
+        movableRegistry.registerDeletionListener(this);
+        debuggableRegistry.registerDebuggable(this);
+    }
+
+    synchronized void registerDeletionListener(IGuiPage.IGuiMovableDeletionListener listener)
+    {
+        listeners.addFirst(listener);
+    }
+
+    synchronized void unregisterDeletionListener(IGuiPage.IGuiMovableDeletionListener listener)
+    {
+        listeners.remove(listener);
+    }
+
+    @Override
+    public void onMovableDeletion(IMovableConst movable)
+    {
+        final List<MovableRegistry.IDeletionListener> copy;
+        synchronized (this)
+        {
+            copy = new ArrayList<>(listeners);
+        }
+        executor.scheduleOnMainThread(() -> MovableRegistry.IDeletionListener.callListeners(copy, movable));
+    }
+
+    @Override
+    public String getDebugInformation()
+    {
+        return "Deletion listeners registered with GuiMovableDeletionManager:" + formatListenersForDebug();
+    }
+
+    private String formatListenersForDebug()
+    {
+        final List<IGuiPage.IGuiMovableDeletionListener> copy;
+        synchronized (this)
+        {
+            if (listeners.isEmpty())
+                return "\n  []";
+            copy = new ArrayList<>(listeners);
+        }
+
+        final StringBuilder sb = new StringBuilder("\n");
+        for (final var listener : copy)
+            sb.append("  * ").append(formatListenerForDebug(listener)).append('\n');
+        return sb.toString();
+    }
+
+    private String formatListenerForDebug(IGuiPage.IGuiMovableDeletionListener listener)
+    {
+        return String.format("Gui Page: '%s' for player %s", listener.getPageName(), listener.getInventoryHolder());
+    }
+}

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/IGuiPage.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/IGuiPage.java
@@ -1,0 +1,21 @@
+package nl.pim16aap2.bigdoors.spigot.gui;
+
+import nl.pim16aap2.bigdoors.api.IPPlayer;
+import nl.pim16aap2.bigdoors.managers.MovableRegistry;
+
+/**
+ * Represents a Gui page.
+ */
+interface IGuiPage
+{
+    String getPageName();
+
+    IPPlayer getInventoryHolder();
+
+    /**
+     * Represents a union type of {@link IGuiPage} and {@link MovableRegistry.IDeletionListener}.
+     */
+    interface IGuiMovableDeletionListener extends IGuiPage, MovableRegistry.IDeletionListener
+    {
+    }
+}

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/IGuiPage.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/IGuiPage.java
@@ -1,7 +1,7 @@
 package nl.pim16aap2.bigdoors.spigot.gui;
 
 import nl.pim16aap2.bigdoors.api.IPPlayer;
-import nl.pim16aap2.bigdoors.managers.MovableRegistry;
+import nl.pim16aap2.bigdoors.managers.MovableDeletionManager;
 
 /**
  * Represents a Gui page.
@@ -13,9 +13,9 @@ interface IGuiPage
     IPPlayer getInventoryHolder();
 
     /**
-     * Represents a union type of {@link IGuiPage} and {@link MovableRegistry.IDeletionListener}.
+     * Represents a union type of {@link IGuiPage} and {@link MovableDeletionManager.IDeletionListener}.
      */
-    interface IGuiMovableDeletionListener extends IGuiPage, MovableRegistry.IDeletionListener
+    interface IGuiMovableDeletionListener extends IGuiPage, MovableDeletionManager.IDeletionListener
     {
     }
 }

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/InfoGui.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/InfoGui.java
@@ -7,6 +7,8 @@ import de.themoep.inventorygui.GuiElement;
 import de.themoep.inventorygui.GuiElementGroup;
 import de.themoep.inventorygui.InventoryGui;
 import de.themoep.inventorygui.StaticGuiElement;
+import lombok.Getter;
+import lombok.ToString;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.api.IPermissionsManager;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
@@ -29,18 +31,27 @@ import java.util.Map;
  * This contains all the options for a single movable.
  */
 @Flogger
-class InfoGui
+@ToString(onlyExplicitlyIncluded = true)
+class InfoGui implements IGuiPage
 {
     private static final ItemStack FILLER = new ItemStack(Material.GRAY_STAINED_GLASS_PANE, 1);
 
     private final BigDoorsPlugin bigDoorsPlugin;
     private final ILocalizer localizer;
     private final AttributeButtonFactory attributeButtonFactory;
-    private final AbstractMovable movable;
-    private final PPlayerSpigot inventoryHolder;
-    private final MainGui mainGui;
+
+    @Getter
     private final InventoryGui inventoryGui;
+
+    @ToString.Include
+    private final AbstractMovable movable;
+
+    @ToString.Include
     private final List<MovableAttribute> allowedAttributes;
+
+    @Getter
+    @ToString.Include
+    private final PPlayerSpigot inventoryHolder;
 
     // Currently not used, but it's needed later on when we can update the elements
     // When the field in the movable changes.
@@ -51,14 +62,13 @@ class InfoGui
     InfoGui(
         BigDoorsPlugin bigDoorsPlugin, ILocalizer localizer, IPermissionsManager permissionsManager,
         AttributeButtonFactory attributeButtonFactory,
-        @Assisted AbstractMovable movable, @Assisted PPlayerSpigot inventoryHolder, @Assisted MainGui mainGui)
+        @Assisted AbstractMovable movable, @Assisted PPlayerSpigot inventoryHolder)
     {
         this.bigDoorsPlugin = bigDoorsPlugin;
         this.localizer = localizer;
         this.attributeButtonFactory = attributeButtonFactory;
         this.movable = movable;
         this.inventoryHolder = inventoryHolder;
-        this.mainGui = mainGui;
 
         final MovableOwner movableOwner = movable.getOwner(inventoryHolder).orElseGet(this::getDummyOwner);
         this.allowedAttributes = analyzeAttributes(movableOwner, inventoryHolder, permissionsManager);
@@ -66,6 +76,7 @@ class InfoGui
         this.attributeElements = new HashMap<>(this.allowedAttributes.size());
 
         this.inventoryGui = createGUI();
+
         showGUI();
     }
 
@@ -113,7 +124,7 @@ class InfoGui
         for (final MovableAttribute attribute : allowedAttributes)
         {
             final GuiElement element =
-                attributeButtonFactory.of(gui, mainGui, attribute, movable, inventoryHolder, 'g');
+                attributeButtonFactory.of(attribute, movable, inventoryHolder, 'g');
             attributeElements.put(attribute, element);
             group.addElement(element);
         }
@@ -146,9 +157,15 @@ class InfoGui
             permissionsManager.hasBypassPermissionsForAttribute(player, attribute);
     }
 
+    @Override
+    public String getPageName()
+    {
+        return "InfoGui";
+    }
+
     @AssistedFactory
     interface IFactory
     {
-        InfoGui newInfoGUI(AbstractMovable movable, PPlayerSpigot playerSpigot, MainGui mainGui);
+        InfoGui newInfoGUI(AbstractMovable movable, PPlayerSpigot playerSpigot);
     }
 }

--- a/bigdoors-spigot/spigot-core/src/main/resources/SpigotCore.properties
+++ b/bigdoors-spigot/spigot-core/src/main/resources/SpigotCore.properties
@@ -20,3 +20,4 @@ gui.info_page.attribute.remove_owner=Remove an owner.
 gui.delete_page.title=Delete {0} "{1}"
 gui.delete_page.confirm=Yes, delete this {0}
 gui.delete_page.cancel=No, keep this {0}
+gui.notification.movable_inaccessible=You no longer have access to movable: {0}!

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/storage/SQLiteJDBCDriverConnectionTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/storage/SQLiteJDBCDriverConnectionTest.java
@@ -11,6 +11,7 @@ import nl.pim16aap2.bigdoors.api.factories.IPWorldFactory;
 import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.localization.LocalizationManager;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
+import nl.pim16aap2.bigdoors.managers.MovableDeletionManager;
 import nl.pim16aap2.bigdoors.managers.MovableRegistry;
 import nl.pim16aap2.bigdoors.managers.MovableTypeManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
@@ -123,7 +124,9 @@ public class SQLiteJDBCDriverConnectionTest
         MockitoAnnotations.openMocks(this);
 
         worldFactory = new TestPWorldFactory();
-        movableRegistry = MovableRegistry.unCached(restartableHolder, debuggableRegistry);
+        movableRegistry = MovableRegistry.unCached(
+            restartableHolder, debuggableRegistry, Mockito.mock(MovableDeletionManager.class));
+
         movableTypeManager = new MovableTypeManager(restartableHolder, debuggableRegistry, localizationManager);
 
         final AssistedFactoryMocker<MovableBase, MovableBase.IFactory> assistedFactoryMocker =

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/tooluser/creator/CreatorTestsUtil.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/tooluser/creator/CreatorTestsUtil.java
@@ -23,6 +23,7 @@ import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.DelayedCommandInputManager;
 import nl.pim16aap2.bigdoors.managers.LimitsManager;
+import nl.pim16aap2.bigdoors.managers.MovableDeletionManager;
 import nl.pim16aap2.bigdoors.managers.MovableRegistry;
 import nl.pim16aap2.bigdoors.managers.ToolUserManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
@@ -151,7 +152,8 @@ public class CreatorTestsUtil
             new AssistedFactoryMocker<>(MovableBase.class, MovableBase.IFactory.class)
                 .setMock(ILocalizer.class, localizer)
                 .setMock(MovableRegistry.class,
-                         MovableRegistry.unCached(Mockito.mock(RestartableHolder.class), debuggableRegistry))
+                         MovableRegistry.unCached(Mockito.mock(RestartableHolder.class), debuggableRegistry,
+                                                  Mockito.mock(MovableDeletionManager.class)))
                 .getFactory();
         movableBaseBuilder = new MovableBaseBuilder(movableBaseIFactory);
 


### PR DESCRIPTION
When a movable is deleted, several actions need to take place. For example, its BlockMover (if active) needs to be stopped, it needs to be unregistered from the MovableRegistry, and it needs to be removed from any open GUIs.

To make sure every system that needs to know when a movable is deleted is notified correctly, a new manager was introduced; the `MovableDeletionManager`. Other objects can register themselves as listeners to this class, so they will be notified when a movable is deleted.