### PR TITLE
Assortment of AbstractMovable fixes/improvements

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/annotations/InheritedLockField.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/annotations/InheritedLockField.java
@@ -6,12 +6,14 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
- * Indicates that a field in an {@link AbstractMovable} subclass should be persistent.
+ * Indicates that a {@link ReentrantReadWriteLock} field in an {@link AbstractMovable} subclass is inherited from its
+ * super class.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-public @interface PersistentVariable
+public @interface InheritedLockField
 {
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/BaseCommand.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/BaseCommand.java
@@ -8,7 +8,6 @@ import nl.pim16aap2.bigdoors.api.factories.ITextFactory;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableAttribute;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.text.TextType;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetrieverFactory;
@@ -197,14 +196,14 @@ public abstract class BaseCommand
     }
 
     /**
-     * Attempts to get an {@link MovableBase} based on the provided {@link MovableRetrieverFactory} and the current
+     * Attempts to get an {@link AbstractMovable} based on the provided {@link MovableRetrieverFactory} and the current
      * {@link ICommandSender}.
      * <p>
      * If no movable is found, the {@link ICommandSender} will be informed.
      *
      * @param doorRetriever
      *     The {@link MovableRetrieverFactory} to use
-     * @return The {@link MovableBase} if one could be retrieved.
+     * @return The {@link AbstractMovable} if one could be retrieved.
      */
     protected CompletableFuture<Optional<AbstractMovable>> getMovable(MovableRetriever doorRetriever)
     {

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/DelayedCommandInputRequest.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/DelayedCommandInputRequest.java
@@ -11,7 +11,7 @@ import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.api.factories.ITextFactory;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.DelayedCommandInputManager;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
+import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.text.TextType;
 import nl.pim16aap2.bigdoors.util.Util;
 import nl.pim16aap2.bigdoors.util.delayedinput.DelayedInputRequest;
@@ -27,8 +27,8 @@ import java.util.function.Supplier;
  * Represents a request for delayed additional input for a command.
  * <p>
  * Taking the {@link AddOwner} command as an example, it could be initialized using a GUI, in which case it is known who
- * the {@link ICommandSender} is and what the target {@link MovableBase} is. However, for some GUIs (e.g. Spigot), it is
- * not yet known who the target player is and what the desired permission level is. This class can then be used to
+ * the {@link ICommandSender} is and what the target {@link AbstractMovable} is. However, for some GUIs (e.g. Spigot),
+ * it is not yet known who the target player is and what the desired permission level is. This class can then be used to
  * retrieve the additional data that is required to execute the command.
  *
  * @param <T>

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/Delete.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/Delete.java
@@ -9,7 +9,6 @@ import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableAttribute;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetrieverFactory;
 
@@ -70,7 +69,7 @@ public class Delete extends MovableTargetCommand
          * @param commandSender
          *     The {@link ICommandSender} responsible for deleting the movable.
          * @param movableRetriever
-         *     A {@link MovableRetrieverFactory} representing the {@link MovableBase} which will be targeted for
+         *     A {@link MovableRetrieverFactory} representing the {@link AbstractMovable} which will be targeted for
          *     deletion.
          * @return See {@link BaseCommand#run()}.
          */

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/Info.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/Info.java
@@ -12,7 +12,6 @@ import nl.pim16aap2.bigdoors.api.factories.ITextFactory;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableAttribute;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.text.TextType;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetrieverFactory;
@@ -74,8 +73,8 @@ public class Info extends MovableTargetCommand
          *     The {@link ICommandSender} responsible for retrieving the movable info and the receiver of the movable's
          *     information.
          * @param movableRetriever
-         *     A {@link MovableRetrieverFactory} representing the {@link MovableBase} for which the information will be
-         *     retrieved.
+         *     A {@link MovableRetrieverFactory} representing the {@link AbstractMovable} for which the information will
+         *     be retrieved.
          * @return See {@link BaseCommand#run()}.
          */
         Info newInfo(ICommandSender commandSender, MovableRetriever movableRetriever);

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/InspectPowerBlock.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/InspectPowerBlock.java
@@ -8,7 +8,7 @@ import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.api.factories.ITextFactory;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.ToolUserManager;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
+import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.tooluser.PowerBlockInspector;
 import nl.pim16aap2.bigdoors.util.Constants;
 
@@ -65,8 +65,8 @@ public class InspectPowerBlock extends BaseCommand
          * @param commandSender
          *     The {@link ICommandSender} responsible for inspecting the powerblocks.
          *     <p>
-         *     They can only discover {@link MovableBase}s attached to specific locations if they both have access to
-         *     the specific location and access to the specific movable(s).
+         *     They can only discover {@link AbstractMovable}s attached to specific locations if they both have access
+         *     to the specific location and access to the specific movable(s).
          * @return See {@link BaseCommand#run()}.
          */
         InspectPowerBlock newInspectPowerBlock(ICommandSender commandSender);

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/ListMovables.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/ListMovables.java
@@ -8,7 +8,6 @@ import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.api.factories.ITextFactory;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.text.TextType;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetrieverFactory;
@@ -81,7 +80,7 @@ public class ListMovables extends BaseCommand
          *     <p>
          *     This is also the entity that will be informed about the movables that were found.
          * @param movableRetriever
-         *     A {@link MovableRetrieverFactory} representing any number of {@link MovableBase}s.
+         *     A {@link MovableRetrieverFactory} representing any number of {@link AbstractMovable}s.
          * @return See {@link BaseCommand#run()}.
          */
         ListMovables newListMovables(ICommandSender commandSender, MovableRetriever movableRetriever);

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/Lock.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/Lock.java
@@ -11,7 +11,6 @@ import nl.pim16aap2.bigdoors.events.IBigDoorsEventCaller;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableAttribute;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetrieverFactory;
 
@@ -83,8 +82,8 @@ public class Lock extends MovableTargetCommand
          * @param commandSender
          *     The {@link ICommandSender} responsible for changing the locked status of the movable.
          * @param movableRetriever
-         *     A {@link MovableRetrieverFactory} representing the {@link MovableBase} for which the locked status will
-         *     be modified.
+         *     A {@link MovableRetrieverFactory} representing the {@link AbstractMovable} for which the locked status
+         *     will be modified.
          * @param lock
          *     The new lock status.
          * @return See {@link BaseCommand#run()}.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/MovableTargetCommand.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/MovableTargetCommand.java
@@ -10,7 +10,6 @@ import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableAttribute;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.text.TextType;
 import nl.pim16aap2.bigdoors.util.Util;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
@@ -127,7 +126,7 @@ public abstract class MovableTargetCommand extends BaseCommand
      * Performs the action of this command on the {@link AbstractMovable}.
      *
      * @param movable
-     *     The {@link MovableBase} to perform the action on.
+     *     The {@link AbstractMovable} to perform the action on.
      * @return The future of the command execution.
      */
     protected abstract CompletableFuture<?> performAction(AbstractMovable movable);

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/MovePowerBlock.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/MovePowerBlock.java
@@ -10,7 +10,6 @@ import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.ToolUserManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableAttribute;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.tooluser.PowerBlockRelocator;
 import nl.pim16aap2.bigdoors.util.Constants;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
@@ -69,8 +68,8 @@ public class MovePowerBlock extends MovableTargetCommand
          * @param commandSender
          *     The {@link ICommandSender} responsible for moving the powerblock for the movable.
          * @param movableRetriever
-         *     A {@link MovableRetrieverFactory} representing the {@link MovableBase} for which the powerblock will be
-         *     moved.
+         *     A {@link MovableRetrieverFactory} representing the {@link AbstractMovable} for which the powerblock will
+         *     be moved.
          * @return See {@link BaseCommand#run()}.
          */
         MovePowerBlock newMovePowerBlock(ICommandSender commandSender, MovableRetriever movableRetriever);

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/RemoveOwner.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/RemoveOwner.java
@@ -11,7 +11,6 @@ import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableAttribute;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.MovableOwner;
 import nl.pim16aap2.bigdoors.movable.PermissionLevel;
 import nl.pim16aap2.bigdoors.text.TextType;
@@ -124,8 +123,8 @@ public class RemoveOwner extends MovableTargetCommand
          * @param commandSender
          *     The {@link ICommandSender} responsible for removing a co-owner of the movable.
          * @param movableRetriever
-         *     A {@link MovableRetrieverFactory} representing the {@link MovableBase} for which a co-owner is requested
-         *     to be removed.
+         *     A {@link MovableRetrieverFactory} representing the {@link AbstractMovable} for which a co-owner is
+         *     requested to be removed.
          * @param targetPlayer
          *     The co-owner that is requested to be removed.
          * @return See {@link BaseCommand#run()}.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/SetBlocksToMove.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/SetBlocksToMove.java
@@ -8,7 +8,6 @@ import nl.pim16aap2.bigdoors.api.factories.ITextFactory;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableAttribute;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IDiscreteMovement;
 import nl.pim16aap2.bigdoors.text.TextType;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
@@ -76,7 +75,7 @@ public class SetBlocksToMove extends MovableTargetCommand
          * @param commandSender
          *     The {@link ICommandSender} responsible for changing the blocks-to-move distance of the movable.
          * @param movableRetriever
-         *     A {@link MovableRetrieverFactory} representing the {@link MovableBase} for which the blocks-to-move
+         *     A {@link MovableRetrieverFactory} representing the {@link AbstractMovable} for which the blocks-to-move
          *     distance will be modified.
          * @param blocksToMove
          *     The new blocks-to-move distance.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/SetOpenDirection.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/SetOpenDirection.java
@@ -8,7 +8,6 @@ import nl.pim16aap2.bigdoors.api.factories.ITextFactory;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableAttribute;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.text.TextType;
 import nl.pim16aap2.bigdoors.util.MovementDirection;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
@@ -78,8 +77,8 @@ public class SetOpenDirection extends MovableTargetCommand
          * @param commandSender
          *     The {@link ICommandSender} responsible for changing open direction of the movable.
          * @param movableRetriever
-         *     A {@link MovableRetrieverFactory} representing the {@link MovableBase} for which the open direction will
-         *     be modified.
+         *     A {@link MovableRetrieverFactory} representing the {@link AbstractMovable} for which the open direction
+         *     will be modified.
          * @param movementDirection
          *     The new movement direction.
          * @return See {@link BaseCommand#run()}.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/events/movableaction/MovableActionCause.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/events/movableaction/MovableActionCause.java
@@ -1,9 +1,9 @@
 package nl.pim16aap2.bigdoors.events.movableaction;
 
-import nl.pim16aap2.bigdoors.movable.MovableBase;
+import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 
 /**
- * Represents the different kind of causes that can be the reason of a {@link MovableBase} action.
+ * Represents the different kind of causes that can be the reason of a {@link AbstractMovable} action.
  *
  * @author Pim
  */
@@ -20,12 +20,12 @@ public enum MovableActionCause
     REDSTONE,
 
     /**
-     * The {@link MovableBase} was toggled from the console or by a command block.
+     * The {@link AbstractMovable} was toggled from the console or by a command block.
      */
     SERVER,
 
     /**
-     * The {@link MovableBase} was toggled by another plugin.
+     * The {@link AbstractMovable} was toggled by another plugin.
      */
     PLUGIN,
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/events/movableaction/MovableActionType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/events/movableaction/MovableActionType.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.bigdoors.events.movableaction;
 
-import nl.pim16aap2.bigdoors.movable.MovableBase;
+import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 
 /**
  * Represents the different kinds of actions that are applicable to a movable.
@@ -10,17 +10,17 @@ import nl.pim16aap2.bigdoors.movable.MovableBase;
 public enum MovableActionType
 {
     /**
-     * Open a {@link MovableBase} if it is currently open, otherwise close it.
+     * Open a {@link AbstractMovable} if it is currently open, otherwise close it.
      */
     TOGGLE,
 
     /**
-     * Open a {@link MovableBase}, but only if it is currently closed.
+     * Open a {@link AbstractMovable}, but only if it is currently closed.
      */
     OPEN,
 
     /**
-     * Close a {@link MovableBase}, but only if it is currently opened.
+     * Close a {@link AbstractMovable}, but only if it is currently opened.
      */
     CLOSE
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
@@ -19,7 +19,6 @@ import nl.pim16aap2.bigdoors.events.IMovableCreatedEvent;
 import nl.pim16aap2.bigdoors.events.IMovablePrepareCreateEvent;
 import nl.pim16aap2.bigdoors.events.IMovablePrepareDeleteEvent;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.MovableOwner;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
 import nl.pim16aap2.bigdoors.movable.PermissionLevel;
@@ -524,8 +523,8 @@ public final class DatabaseManager extends Restartable implements IDebuggable
                         return ActionResult.FAIL;
                     }
 
-                    ((FriendMovableAccessor) movable.getBase())
-                        .addOwner(player.getUUID(), new MovableOwner(movable.getUid(), permission, playerData));
+                    movable.getFriendMovableAccessor()
+                           .addOwner(player.getUUID(), new MovableOwner(movable.getUid(), permission, playerData));
 
                     return ActionResult.SUCCESS;
                 }, threadPool).exceptionally(ex -> Util.exceptionally(ex, ActionResult.FAIL));
@@ -644,7 +643,7 @@ public final class DatabaseManager extends Restartable implements IDebuggable
                         return ActionResult.FAIL;
                     }
 
-                    ((FriendMovableAccessor) movable.getBase()).removeOwner(playerUUID);
+                    movable.getFriendMovableAccessor().removeOwner(playerUUID);
                     return ActionResult.SUCCESS;
                 }, threadPool).exceptionally(ex -> Util.exceptionally(ex, ActionResult.FAIL));
     }
@@ -653,7 +652,7 @@ public final class DatabaseManager extends Restartable implements IDebuggable
      * Updates the all data of an {@link AbstractMovable}. This includes both the base data and the type-specific data.
      *
      * @param snapshot
-     *     The {@link MovableBase} that describes the base data of movable.
+     *     The {@link AbstractMovable} that describes the base data of movable.
      * @param typeData
      *     The type-specific data of this movable.
      * @return The result of the operation.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
@@ -19,6 +19,7 @@ import nl.pim16aap2.bigdoors.events.IMovableCreatedEvent;
 import nl.pim16aap2.bigdoors.events.IMovablePrepareCreateEvent;
 import nl.pim16aap2.bigdoors.events.IMovablePrepareDeleteEvent;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
+import nl.pim16aap2.bigdoors.movable.MovableModifier;
 import nl.pim16aap2.bigdoors.movable.MovableOwner;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
 import nl.pim16aap2.bigdoors.movable.PermissionLevel;
@@ -65,6 +66,7 @@ public final class DatabaseManager extends Restartable implements IDebuggable
     private final IBigDoorsEventCaller bigDoorsEventCaller;
     private final Lazy<PowerBlockManager> powerBlockManager;
     private final IBigDoorsEventFactory bigDoorsEventFactory;
+    private final MovableModifier movableModifier;
 
     /**
      * Constructs a new {@link DatabaseManager}.
@@ -86,6 +88,7 @@ public final class DatabaseManager extends Restartable implements IDebuggable
         this.bigDoorsEventCaller = bigDoorsEventCaller;
         this.powerBlockManager = powerBlockManager;
         this.bigDoorsEventFactory = bigDoorsEventFactory;
+        this.movableModifier = MovableModifier.get(new FriendKey());
         initThreadPool();
         debuggableRegistry.registerDebuggable(this);
     }
@@ -515,16 +518,19 @@ public final class DatabaseManager extends Restartable implements IDebuggable
                     if (event.isCancelled())
                         return ActionResult.CANCELLED;
 
-                    final PPlayerData playerData = player.getPPlayerData();
-                    final boolean result = db.addOwner(movable.getUid(), playerData, permission);
-                    if (!result)
+                    if (!movableModifier.addOwner(movable, newOwner))
                     {
-                        log.atSevere().withStackTrace(StackSize.FULL).log("Failed to process event: %s", event);
+                        log.atSevere().log("Failed to add owner %s to movable %s!", newOwner, movable);
                         return ActionResult.FAIL;
                     }
 
-                    movable.getFriendMovableAccessor()
-                           .addOwner(player.getUUID(), new MovableOwner(movable.getUid(), permission, playerData));
+                    final boolean result = db.addOwner(movable.getUid(), newOwner.pPlayerData(), permission);
+                    if (!result)
+                    {
+                        log.atSevere().withStackTrace(StackSize.FULL).log("Failed to process event: %s", event);
+                        movableModifier.removeOwner(movable, newOwner.pPlayerData().getUUID());
+                        return ActionResult.FAIL;
+                    }
 
                     return ActionResult.SUCCESS;
                 }, threadPool).exceptionally(ex -> Util.exceptionally(ex, ActionResult.FAIL));
@@ -636,14 +642,21 @@ public final class DatabaseManager extends Restartable implements IDebuggable
                     if (event.isCancelled())
                         return ActionResult.CANCELLED;
 
+                    final @Nullable MovableOwner oldOwner = movableModifier.removeOwner(movable, playerUUID);
+                    if (oldOwner == null)
+                    {
+                        log.atSevere().log("Failed to remove owner %s from movable %s!", movableOwner.get(), movable);
+                        return ActionResult.FAIL;
+                    }
+
                     final boolean result = db.removeOwner(movable.getUid(), playerUUID);
                     if (!result)
                     {
                         log.atSevere().withStackTrace(StackSize.FULL).log("Failed to process event: %s", event);
+                        movableModifier.addOwner(movable, oldOwner);
                         return ActionResult.FAIL;
                     }
 
-                    movable.getFriendMovableAccessor().removeOwner(playerUUID);
                     return ActionResult.SUCCESS;
                 }, threadPool).exceptionally(ex -> Util.exceptionally(ex, ActionResult.FAIL));
     }
@@ -740,39 +753,11 @@ public final class DatabaseManager extends Restartable implements IDebuggable
         FAIL
     }
 
-    /**
-     * Provides private access to certain aspects of the {@link AbstractMovable} class. Kind of like an (inverted, more
-     * cumbersome, and less useful) friend in C++ terms.
-     */
-    // TODO: Consider if this should make work the other way around? That the Movable can access the 'private' methods
-    //       of this class? This has several advantages:
-    //       - The child classes of the movable class don't have access to stuff they shouldn't have access to (these
-    //         methods)
-    //       - All the commands that modify a movable can be pooled in the AbstractMovable class, instead of being split
-    //         over several classes.
-    //       Alternatively, consider creating a separate class with package-private access to either this class or
-    //       the movable one. Might be a bit cleaner.
-    public abstract static class FriendMovableAccessor
+    public static final class FriendKey
     {
-        /**
-         * Adds an owner to the map of Owners.
-         *
-         * @param uuid
-         *     The {@link UUID} of the owner.
-         * @param movableOwner
-         *     The {@link MovableOwner} to add.
-         */
-        protected abstract void addOwner(UUID uuid, MovableOwner movableOwner);
-
-        /**
-         * Removes a {@link MovableOwner} from the list of {@link MovableOwner}s, if possible.
-         *
-         * @param uuid
-         *     The {@link UUID} of the {@link MovableOwner} that is to be removed.
-         * @return True if removal was successful or false if there was no previous {@link MovableOwner} with the
-         * provided {@link UUID}.
-         */
-        protected abstract boolean removeOwner(UUID uuid);
+        private FriendKey()
+        {
+        }
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/MovableRegistry.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/MovableRegistry.java
@@ -9,7 +9,6 @@ import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.data.cache.timed.TimedCache;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.IMovableConst;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -109,12 +108,12 @@ public final class MovableRegistry extends Restartable implements IDebuggable, M
     }
 
     /**
-     * Attempts to get the {@link MovableBase} associated the given UID. It can only retrieve doors that still exist in
-     * the cache.
+     * Attempts to get the {@link AbstractMovable} associated the given UID. It can only retrieve doors that still exist
+     * in the cache.
      *
      * @param movableUID
      *     The UID of the movable.
-     * @return The {@link MovableBase} if it has been retrieved from the database.
+     * @return The {@link AbstractMovable} if it has been retrieved from the database.
      */
     public Optional<AbstractMovable> getRegisteredMovable(long movableUID)
     {
@@ -122,11 +121,11 @@ public final class MovableRegistry extends Restartable implements IDebuggable, M
     }
 
     /**
-     * Checks if a {@link MovableBase} associated with a given UID has been registered.
+     * Checks if a {@link AbstractMovable} associated with a given UID has been registered.
      *
      * @param movableUID
      *     The UID of the movable.
-     * @return True if an entry exists for the {@link MovableBase} with the given UID.
+     * @return True if an entry exists for the {@link AbstractMovable} with the given UID.
      */
     @SuppressWarnings("unused")
     public boolean isRegistered(long movableUID)
@@ -135,12 +134,12 @@ public final class MovableRegistry extends Restartable implements IDebuggable, M
     }
 
     /**
-     * Checks if the exact instance of the provided {@link MovableBase} has been registered. (i.e. it uses '==' to check
-     * if the cached entry is the same).
+     * Checks if the exact instance of the provided {@link AbstractMovable} has been registered. (i.e. it uses '==' to
+     * check if the cached entry is the same).
      *
      * @param movable
      *     The movable.
-     * @return True if an entry exists for the exact instance of the provided {@link MovableBase}.
+     * @return True if an entry exists for the exact instance of the provided {@link AbstractMovable}.
      */
     public boolean isRegistered(AbstractMovable movable)
     {
@@ -148,10 +147,11 @@ public final class MovableRegistry extends Restartable implements IDebuggable, M
     }
 
     /**
-     * Registers an {@link MovableBase} if it hasn't been registered yet.
+     * Registers an {@link AbstractMovable} if it hasn't been registered yet.
      *
      * @param registrable
-     *     The {@link AbstractMovable.Registrable} that belongs to the {@link MovableBase} that is to be registered.
+     *     The {@link AbstractMovable.Registrable} that belongs to the {@link AbstractMovable} that is to be
+     *     registered.
      * @return True if the movable was added successfully (and didn't exist yet).
      */
     public boolean registerMovable(AbstractMovable.Registrable registrable)

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/PowerBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/PowerBlockManager.java
@@ -7,7 +7,6 @@ import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.data.cache.timed.TimedCache;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.IMovableConst;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.util.Util;
 import nl.pim16aap2.bigdoors.util.vector.Vector2Di;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
@@ -82,13 +81,13 @@ public final class PowerBlockManager extends Restartable implements MovableDelet
     }
 
     /**
-     * Gets all {@link MovableBase}s that have a powerblock at a location in a world.
+     * Gets all {@link AbstractMovable}s that have a powerblock at a location in a world.
      *
      * @param loc
      *     The location.
      * @param worldName
      *     The name of the world.
-     * @return All {@link MovableBase}s that have a powerblock at a location in a world.
+     * @return All {@link AbstractMovable}s that have a powerblock at a location in a world.
      */
     // TODO: Try to have about 50% less CompletableFuture here.
     public CompletableFuture<List<CompletableFuture<Optional<AbstractMovable>>>> movablesFromPowerBlockLoc(
@@ -129,10 +128,10 @@ public final class PowerBlockManager extends Restartable implements MovableDelet
     }
 
     /**
-     * Updates the position of the power block of a {@link MovableBase} in the database.
+     * Updates the position of the power block of a {@link AbstractMovable} in the database.
      *
      * @param movable
-     *     The {@link MovableBase}.
+     *     The {@link AbstractMovable}.
      * @param oldPos
      *     The old position.
      * @param newPos

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
@@ -649,17 +649,14 @@ public abstract class AbstractMovable implements IMovable
         return base.getPrimeOwner();
     }
 
-    /**
-     * Gets the friend accessor for this movable.
-     * <p>
-     * Please do not use this!
-     *
-     * @return The friend accessor.
-     */
-    // TODO: Remove this.
-    public DatabaseManager.FriendMovableAccessor getFriendMovableAccessor()
+    @Locked.Write final @Nullable MovableOwner removeOwner(UUID ownerUUID)
     {
-        return base;
+        return base.removeOwner(ownerUUID);
+    }
+
+    @Locked.Write final boolean addOwner(MovableOwner movableOwner)
+    {
+        return base.addOwner(movableOwner);
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableBase.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableBase.java
@@ -43,8 +43,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * @author Pim
  */
 @EqualsAndHashCode(callSuper = false)
-@Flogger
-public final class MovableBase extends DatabaseManager.FriendMovableAccessor
+@Flogger final class MovableBase extends DatabaseManager.FriendMovableAccessor
 {
     @Getter(AccessLevel.PACKAGE)
     @EqualsAndHashCode.Exclude @ToString.Exclude
@@ -56,6 +55,7 @@ public final class MovableBase extends DatabaseManager.FriendMovableAccessor
     @Getter
     private final IPWorld world;
 
+    @EqualsAndHashCode.Exclude @ToString.Exclude
     private final MovableToggleRequestBuilder movableToggleRequestBuilder;
 
     @GuardedBy("lock")

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableBaseBuilder.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableBaseBuilder.java
@@ -144,10 +144,11 @@ public final class MovableBaseBuilder
         }
 
         @Override
-        public MovableBase build()
+        public AbstractMovable.MovableBaseHolder build()
         {
-            return doorBaseFactory.create(movableUID, name, cuboid, rotationPoint, powerBlock, world, isOpen,
-                                          isLocked, openDir, primeOwner, doorOwners);
+            return new AbstractMovable.MovableBaseHolder(
+                doorBaseFactory.create(movableUID, name, cuboid, rotationPoint, powerBlock, world, isOpen,
+                                       isLocked, openDir, primeOwner, doorOwners));
         }
     }
 
@@ -306,6 +307,6 @@ public final class MovableBaseBuilder
          *
          * @return The next step of the guided builder process.
          */
-        MovableBase build();
+        AbstractMovable.MovableBaseHolder build();
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableModifier.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableModifier.java
@@ -1,0 +1,68 @@
+package nl.pim16aap2.bigdoors.movable;
+
+import nl.pim16aap2.bigdoors.managers.DatabaseManager;
+import nl.pim16aap2.bigdoors.util.Util;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Class that can modify some protected aspects of movables.
+ */
+public final class MovableModifier
+{
+    private static final MovableModifier INSTANCE = new MovableModifier();
+
+    private MovableModifier()
+    {
+    }
+
+    /**
+     * Obtains the instance of this class.
+     * <p>
+     * Note that only the {@link DatabaseManager} is allowed to get an instance at this time. This is for good reason,
+     * as using this object through other means can leave the movable in an incorrect state. So, if you think you need
+     * to access this class, please think again and again until you realise that you do not.
+     * <p>
+     * Instead, use the publicly accessible methods in the database manager and the movable classes.
+     *
+     * @param friendKey
+     *     The friend key of the database manager class. This is used to verify that the caller is allowed to obtain
+     *     access to this class.
+     * @return The instance of this class.
+     */
+    public static MovableModifier get(DatabaseManager.FriendKey friendKey)
+    {
+        Util.requireNonNull(friendKey, "friendKey");
+        return INSTANCE;
+    }
+
+    /**
+     * Adds an owner to a movable.
+     *
+     * @param movable
+     *     The movable to add the owner to.
+     * @param movableOwner
+     *     The new owner of the door.
+     * @return True if the owner was removed.
+     */
+    public boolean addOwner(AbstractMovable movable, MovableOwner movableOwner)
+    {
+        return movable.addOwner(movableOwner);
+    }
+
+    /**
+     * Removes an owner from this movable.
+     *
+     * @param movable
+     *     The movable to remove the owner from.
+     * @param ownerUUID
+     *     The UUID of the owner to remove.
+     * @return The owner that was removed. If no owner with that UUID exists, or if that specific owner could not be
+     * removed, the result will be null.
+     */
+    public @Nullable MovableOwner removeOwner(AbstractMovable movable, UUID ownerUUID)
+    {
+        return movable.removeOwner(ownerUUID);
+    }
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSerializer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSerializer.java
@@ -173,7 +173,7 @@ public class MovableSerializer<T extends AbstractMovable>
      *     The serialized type-specific data.
      * @return The newly created instance.
      */
-    public T deserialize(MovableBase movable, byte[] data)
+    public T deserialize(AbstractMovable.MovableBaseHolder movable, byte[] data)
         throws Exception
     {
         return instantiate(movable, fromByteArray(data));
@@ -206,7 +206,7 @@ public class MovableSerializer<T extends AbstractMovable>
         }
     }
 
-    T instantiate(MovableBase movableBase, ArrayList<Object> values)
+    T instantiate(AbstractMovable.MovableBaseHolder movableBase, ArrayList<Object> values)
         throws Exception
     {
         if (values.size() != fields.size())
@@ -215,14 +215,14 @@ public class MovableSerializer<T extends AbstractMovable>
 
         try
         {
-            final @Nullable T movable = instantiate(movableBase);
+            final @Nullable T movable = instantiate(movableBase.get());
             if (movable == null)
                 throw new IllegalStateException("Failed to initialize movable!");
 
             for (int idx = 0; idx < fields.size(); ++idx)
                 fields.get(idx).set(movable, values.get(idx));
 
-            final ReentrantReadWriteLock lock = movableBase.getLock();
+            final ReentrantReadWriteLock lock = movableBase.get().getLock();
             for (final Field field : lockFields)
                 field.set(movable, lock);
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSerializer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSerializer.java
@@ -5,6 +5,7 @@ import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.util.FastFieldSetter;
+import nl.pim16aap2.bigdoors.util.LazyValue;
 import nl.pim16aap2.bigdoors.util.UnsafeGetter;
 import nl.pim16aap2.util.SafeStringBuilder;
 import org.jetbrains.annotations.Nullable;
@@ -66,6 +67,12 @@ public class MovableSerializer<T extends AbstractMovable>
     @SuppressWarnings("rawtypes")
     private final @Nullable FastFieldSetter<AbstractMovable, MovableSerializer> fieldSetterSerializer =
         getFieldSetterInAbstractMovable(UNSAFE, MovableSerializer.class, "serializer");
+    @SuppressWarnings("rawtypes")
+    private final @Nullable FastFieldSetter<AbstractMovable, LazyValue> fieldSetterAnimationRange =
+        getFieldSetterInAbstractMovable(UNSAFE, LazyValue.class, "animationRange");
+    @SuppressWarnings("rawtypes")
+    private final @Nullable FastFieldSetter<AbstractMovable, LazyValue> fieldSetterCycleDistance =
+        getFieldSetterInAbstractMovable(UNSAFE, LazyValue.class, "animationCycleDistance");
 
     public MovableSerializer(Class<T> movableClass)
     {
@@ -262,6 +269,8 @@ public class MovableSerializer<T extends AbstractMovable>
         if (UNSAFE == null ||
             fieldSetterMovableBase == null ||
             fieldSetterLock == null ||
+            fieldSetterAnimationRange == null ||
+            fieldSetterCycleDistance == null ||
             fieldSetterSerializer == null)
             return null;
 
@@ -271,6 +280,8 @@ public class MovableSerializer<T extends AbstractMovable>
         fieldSetterMovableBase.copy(movable, movableBase);
         fieldSetterLock.copy(movable, movableBase.getLock());
         fieldSetterSerializer.copy(movable, this);
+        fieldSetterAnimationRange.copy(movable, AbstractMovable.newAnimationRangeVal(movable));
+        fieldSetterCycleDistance.copy(movable, AbstractMovable.newAnimationCycleDistanceVal(movable));
 
         return movable;
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSnapshot.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSnapshot.java
@@ -52,7 +52,7 @@ public final class MovableSnapshot implements IMovableConst
             movable.getOpenDir(),
             movable.isLocked(),
             movable.getPrimeOwner(),
-            Map.copyOf(movable.getBase().getOwnersView())
+            Map.copyOf(movable.getOwnersView())
         );
     }
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/movablearchetypes/IDiscreteMovement.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/movablearchetypes/IDiscreteMovement.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.bigdoors.movable.movablearchetypes;
 
-import nl.pim16aap2.bigdoors.movable.MovableBase;
+import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 
 /**
  * Describes a type of movable that moves a certain number of blocks to open.
@@ -10,20 +10,20 @@ import nl.pim16aap2.bigdoors.movable.MovableBase;
 public interface IDiscreteMovement
 {
     /**
-     * Get the number of blocks this {@link MovableBase} will try to move. As explained at
-     * {@link #setBlocksToMove(int)}, the {@link MovableBase} is not guaranteed to move as far as specified.
+     * Get the number of blocks this {@link AbstractMovable} will try to move. As explained at
+     * {@link #setBlocksToMove(int)}, the {@link AbstractMovable} is not guaranteed to move as far as specified.
      *
-     * @return The number of blocks the {@link MovableBase} will try to move.
+     * @return The number of blocks the {@link AbstractMovable} will try to move.
      */
     int getBlocksToMove();
 
     /**
-     * Change the number of blocks this {@link MovableBase} will try to move when opened. Note that this is only a
+     * Change the number of blocks this {@link AbstractMovable} will try to move when opened. Note that this is only a
      * suggestion. It will never move more blocks than possible. Values less than 1 will use the default value for this
-     * {@link MovableBase}.
+     * {@link AbstractMovable}.
      *
      * @param newBTM
-     *     The number of blocks the {@link MovableBase} will try to move.
+     *     The number of blocks the {@link AbstractMovable} will try to move.
      */
     void setBlocksToMove(int newBTM);
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/movablearchetypes/IHorizontalAxisAligned.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/movablearchetypes/IHorizontalAxisAligned.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.bigdoors.movable.movablearchetypes;
 
-import nl.pim16aap2.bigdoors.movable.MovableBase;
+import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 
 /**
@@ -9,12 +9,12 @@ import nl.pim16aap2.bigdoors.movabletypes.MovableType;
  * Only movables with a depth of 1 block can be extended.
  *
  * @author Pim
- * @see MovableBase
+ * @see AbstractMovable
  */
 public interface IHorizontalAxisAligned
 {
     /**
-     * Checks if the {@link MovableBase} is aligned with the z-axis (North/South).
+     * Checks if the {@link AbstractMovable} is aligned with the z-axis (North/South).
      */
     boolean isNorthSouthAligned();
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movabletypes/MovableType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movabletypes/MovableType.java
@@ -5,7 +5,6 @@ import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.audio.AudioSet;
 import nl.pim16aap2.bigdoors.managers.MovableTypeManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.MovableSerializer;
 import nl.pim16aap2.bigdoors.tooluser.creator.Creator;
 import nl.pim16aap2.bigdoors.util.MovementDirection;
@@ -64,7 +63,7 @@ public abstract class MovableType
 
     /**
      * Gets a list of all theoretically valid {@link MovementDirection} for this given type. It does NOT take the
-     * physical aspects of the {@link MovableBase} into consideration. Therefore, the actual list of valid
+     * physical aspects of the {@link AbstractMovable} into consideration. Therefore, the actual list of valid
      * {@link MovementDirection}s is most likely going to be a subset of those returned by this method.
      *
      * @return A list of all valid {@link MovementDirection} for this given type.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
@@ -5,8 +5,8 @@ import nl.pim16aap2.bigdoors.api.restartable.Restartable;
 import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.events.IBigDoorsEventCaller;
 import nl.pim16aap2.bigdoors.managers.MovableDeletionManager;
+import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.IMovableConst;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -47,11 +47,11 @@ public final class MovableActivityManager extends Restartable implements Movable
     }
 
     /**
-     * Checks if a {@link MovableBase} is 'busy', i.e. currently being animated.
+     * Checks if a {@link AbstractMovable} is 'busy', i.e. currently being animated.
      *
      * @param movableUID
-     *     The UID of the {@link MovableBase}.
-     * @return True if the {@link MovableBase} is busy.
+     *     The UID of the {@link AbstractMovable}.
+     * @return True if the {@link AbstractMovable} is busy.
      */
     @SuppressWarnings("unused")
     public boolean isMovableBusy(long movableUID)
@@ -91,7 +91,7 @@ public final class MovableActivityManager extends Restartable implements Movable
     /**
      * Processed a finished {@link BlockMover}.
      * <p>
-     * The {@link MovableBase} that was being used by the {@link BlockMover} will be registered as inactive and any
+     * The {@link AbstractMovable} that was being used by the {@link BlockMover} will be registered as inactive and any
      * scheduling that is required will be performed.
      *
      * @param blockMover
@@ -136,11 +136,11 @@ public final class MovableActivityManager extends Restartable implements Movable
     }
 
     /**
-     * Gets the {@link BlockMover} of a busy {@link MovableBase}, if it has been registered.
+     * Gets the {@link BlockMover} of a busy {@link AbstractMovable}, if it has been registered.
      *
      * @param movableUID
-     *     The UID of the {@link MovableBase}.
-     * @return The {@link BlockMover} of a busy {@link MovableBase}.
+     *     The UID of the {@link AbstractMovable}.
+     * @return The {@link BlockMover} of a busy {@link AbstractMovable}.
      */
     public Optional<BlockMover> getBlockMover(long movableUID)
     {

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/sqlite/SQLiteJDBCDriverConnection.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/sqlite/SQLiteJDBCDriverConnection.java
@@ -14,7 +14,6 @@ import nl.pim16aap2.bigdoors.managers.MovableRegistry;
 import nl.pim16aap2.bigdoors.managers.MovableTypeManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.IMovableConst;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.MovableBaseBuilder;
 import nl.pim16aap2.bigdoors.movable.MovableOwner;
 import nl.pim16aap2.bigdoors.movable.MovableSerializer;
@@ -361,18 +360,20 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
             playerData);
 
         final Map<UUID, MovableOwner> ownersOfMovable = getOwnersOfMovable(movableUID);
-        final MovableBase movableData = movableBaseBuilder.builder()
-                                                          .uid(movableUID)
-                                                          .name(name)
-                                                          .cuboid(new Cuboid(min, max))
-                                                          .rotationPoint(rotationPoint)
-                                                          .powerBlock(powerBlock)
-                                                          .world(world)
-                                                          .isOpen(isOpen)
-                                                          .isLocked(isLocked)
-                                                          .openDir(openDirection.get())
-                                                          .primeOwner(primeOwner)
-                                                          .ownersOfMovable(ownersOfMovable).build();
+        final AbstractMovable.MovableBaseHolder movableData =
+            movableBaseBuilder.builder()
+                              .uid(movableUID)
+                              .name(name)
+                              .cuboid(new Cuboid(min, max))
+                              .rotationPoint(rotationPoint)
+                              .powerBlock(powerBlock)
+                              .world(world)
+                              .isOpen(isOpen)
+                              .isLocked(isLocked)
+                              .openDir(openDirection.get())
+                              .primeOwner(primeOwner)
+                              .ownersOfMovable(ownersOfMovable)
+                              .build();
 
         final byte[] rawTypeData = movableBaseRS.getBytes("typeData");
         return Optional.of(serializer.deserialize(movableData, rawTypeData));
@@ -551,14 +552,14 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     /**
-     * Attempts to construct a subclass of {@link MovableBase} from a ResultSet containing all data pertaining the
-     * {@link MovableBase} (as stored in the "movableBase" table), as well as the owner (name, UUID, permission) and the
-     * typeTableName.
+     * Attempts to construct a subclass of {@link AbstractMovable} from a ResultSet containing all data pertaining the
+     * {@link AbstractMovable} (as stored in the "movableBase" table), as well as the owner (name, UUID, permission) and
+     * the typeTableName.
      *
      * @param movableBaseRS
      *     The {@link ResultSet} containing a row from the "movableBase" table as well as a row from the
      *     "MovableOwnerPlayer" table and "typeTableName" from the "MovableType" table.
-     * @return An instance of a subclass of {@link MovableBase} if it could be created.
+     * @return An instance of a subclass of {@link AbstractMovable} if it could be created.
      */
     private Optional<AbstractMovable> getMovable(ResultSet movableBaseRS)
         throws Exception
@@ -571,14 +572,14 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     /**
-     * Attempts to construct a list of subclasses of {@link MovableBase} from a ResultSet containing all data pertaining
-     * to one or more {@link MovableBase}s (as stored in the "movableBase" table), as well as the owner (name, UUID,
-     * permission) and the typeTableName.
+     * Attempts to construct a list of subclasses of {@link AbstractMovable} from a ResultSet containing all data
+     * pertaining to one or more {@link AbstractMovable}s (as stored in the "movableBase" table), as well as the owner
+     * (name, UUID, permission) and the typeTableName.
      *
      * @param movableBaseRS
      *     The {@link ResultSet} containing one or more rows from the "movableBase" table as well as matching rows from
      *     the "MovableOwnerPlayer" table and "typeTableName" from the "MovableType" table.
-     * @return An optional with a list of {@link MovableBase}s if any could be constructed. If none could be
+     * @return An optional with a list of {@link AbstractMovable}s if any could be constructed. If none could be
      * constructed, an empty {@link Optional} is returned instead.
      */
     private List<AbstractMovable> getMovables(ResultSet movableBaseRS)
@@ -589,6 +590,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
             return Collections.emptyList();
 
         final List<AbstractMovable> movables = new ArrayList<>();
+
         while (movableBaseRS.next())
             constructMovable(movableBaseRS).ifPresent(movables::add);
         return movables;
@@ -1192,6 +1194,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
         }
         catch (Exception e)
         {
+            e.printStackTrace();
             log.atSevere().withCause(e).log("Failed to execute query: %s", pPreparedStatement);
         }
         return fallback;

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/tooluser/creator/Creator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/tooluser/creator/Creator.java
@@ -10,7 +10,6 @@ import nl.pim16aap2.bigdoors.commands.CommandFactory;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.LimitsManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.MovableBaseBuilder;
 import nl.pim16aap2.bigdoors.movable.MovableOwner;
 import nl.pim16aap2.bigdoors.movable.PermissionLevel;
@@ -268,11 +267,12 @@ public abstract class Creator extends ToolUser
     }
 
     /**
-     * Constructs the {@link MovableBase} for the current movable. This is the same for all movables.
+     * Constructs the {@link AbstractMovable.MovableBaseHolder} for the current movable. This is the same for all
+     * movables.
      *
-     * @return The {@link MovableBase} for the current movable.
+     * @return The {@link AbstractMovable.MovableBaseHolder} for the current movable.
      */
-    protected final MovableBase constructMovableData()
+    protected final AbstractMovable.MovableBaseHolder constructMovableData()
     {
         final long movableUID = -1;
         final var owner = new MovableOwner(movableUID, PermissionLevel.CREATOR, getPlayer().getPPlayerData());

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/util/LazyValue.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/util/LazyValue.java
@@ -1,0 +1,78 @@
+package nl.pim16aap2.bigdoors.util;
+
+import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.function.Supplier;
+
+/**
+ * Represents a wrapper class for lazily retrieved values.
+ *
+ * @param <T>
+ *     The type of the data to store.
+ */
+@ThreadSafe
+public final class LazyValue<T>
+{
+    private final Supplier<T> supplier;
+    private volatile @Nullable T value;
+
+    /**
+     * @param supplier
+     *     The supplier used to set the value. Note that the return value may not be null!
+     */
+    public LazyValue(Supplier<T> supplier)
+    {
+        this.supplier = supplier;
+    }
+
+    /**
+     * Gets the lazily initialized value.
+     * <p>
+     * If the value has not been initialized yet, it will be initialized using {@link #supplier}.
+     *
+     * @return The lazily initialized value.
+     *
+     * @throws NullPointerException
+     *     If the value returned by the {@link #supplier} is null.
+     */
+    public T get()
+    {
+        @Nullable T tmp = this.value;
+        if (tmp == null)
+        {
+            synchronized (this)
+            {
+                tmp = this.value;
+                if (tmp == null)
+                    this.value = tmp = Util.requireNonNull(supplier.get(), "Lazily supplied value");
+            }
+        }
+        return tmp;
+    }
+
+    /**
+     * Invalidates the lazily initialized value (if it has been initialized yet).
+     *
+     * @return The previously-initialized value.
+     */
+    public @Nullable T invalidate()
+    {
+        @Nullable T tmp = this.value;
+        if (tmp != null)
+        {
+            synchronized (this)
+            {
+                tmp = this.value;
+                this.value = null;
+            }
+        }
+        return tmp;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "LazyValue(value=" + this.value + ")";
+    }
+}

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/util/LazyValueTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/util/LazyValueTest.java
@@ -40,7 +40,7 @@ class LazyValueTest
 
         Mockito.when(supplier.get()).thenReturn(16);
         Assertions.assertEquals(16, lazyValue.get());
-        Mockito.verify(supplier, Mockito.times(2));
+        Mockito.verify(supplier, Mockito.times(2)).get();
     }
 
     @Test

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/util/LazyValueTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/util/LazyValueTest.java
@@ -1,0 +1,63 @@
+package nl.pim16aap2.bigdoors.util;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.function.Supplier;
+
+class LazyValueTest
+{
+    @Test
+    void testGet()
+    {
+        final Supplier<Integer> supplier = getIntegerSupplier(42);
+        final LazyValue<Integer> lazyValue = new LazyValue<>(supplier);
+        Mockito.verify(supplier, Mockito.never()).get();
+
+        Assertions.assertEquals(42, lazyValue.get());
+        Mockito.verify(supplier, Mockito.atMostOnce()).get();
+
+        Mockito.when(supplier.get()).thenReturn(16);
+        Assertions.assertEquals(42, lazyValue.get());
+
+        Mockito.verify(supplier, Mockito.atMostOnce()).get();
+    }
+
+    @Test
+    void testInvalidation()
+    {
+        final Supplier<Integer> supplier = getIntegerSupplier(42);
+        final LazyValue<Integer> lazyValue = new LazyValue<>(supplier);
+
+        Assertions.assertNull(lazyValue.invalidate());
+        Mockito.verify(supplier, Mockito.never()).get();
+
+        Assertions.assertEquals(42, lazyValue.get());
+        Assertions.assertEquals(42, lazyValue.invalidate());
+        Mockito.verify(supplier, Mockito.times(1)).get();
+
+        Mockito.when(supplier.get()).thenReturn(16);
+        Assertions.assertEquals(16, lazyValue.get());
+        Mockito.verify(supplier, Mockito.times(2));
+    }
+
+    @Test
+    void testInvalidSupplier()
+    {
+        final Supplier<Integer> supplier = getIntegerSupplier(null);
+        final LazyValue<Integer> lazyValue = new LazyValue<>(supplier);
+
+        Assertions.assertThrows(NullPointerException.class, lazyValue::get);
+    }
+
+    private static Supplier<Integer> getIntegerSupplier(@Nullable Integer value)
+    {
+        @SuppressWarnings("unchecked")//
+        final Supplier<Integer> supplier = (Supplier<Integer>) Mockito.mock(Supplier.class);
+        if (value != null)
+            Mockito.when(supplier.get()).thenReturn(value);
+        return supplier;
+    }
+}

--- a/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/BigDoor.java
+++ b/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/BigDoor.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
@@ -34,6 +35,7 @@ public class BigDoor extends AbstractMovable
     private static final MovableType MOVABLE_TYPE = MovableBigDoor.get();
 
     @EqualsAndHashCode.Exclude
+    @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
     @Getter

--- a/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/BigDoor.java
+++ b/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/BigDoor.java
@@ -7,7 +7,6 @@ import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -39,12 +38,14 @@ public class BigDoor extends AbstractMovable
     private final ReentrantReadWriteLock lock;
 
     @Getter
+    @EqualsAndHashCode.Exclude @ToString.Exclude
     private final double longestAnimationCycleDistance;
 
     @Getter
+    @EqualsAndHashCode.Exclude @ToString.Exclude
     private final Rectangle animationRange;
 
-    public BigDoor(MovableBase base)
+    public BigDoor(AbstractMovable.MovableBaseHolder base)
     {
         super(base);
         this.lock = getLock();

--- a/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/BigDoor.java
+++ b/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/BigDoor.java
@@ -1,7 +1,6 @@
 package nl.pim16aap2.bigdoors.movable.bigdoor;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
@@ -37,22 +36,10 @@ public class BigDoor extends AbstractMovable
     @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
-    @Getter
-    @EqualsAndHashCode.Exclude @ToString.Exclude
-    private final double longestAnimationCycleDistance;
-
-    @Getter
-    @EqualsAndHashCode.Exclude @ToString.Exclude
-    private final Rectangle animationRange;
-
     public BigDoor(AbstractMovable.MovableBaseHolder base)
     {
         super(base);
         this.lock = getLock();
-
-        final double maxRadius = getMaxRadius(getCuboid(), getRotationPoint());
-        this.longestAnimationCycleDistance = maxRadius * MathUtil.HALF_PI;
-        this.animationRange = calculateAnimationRange(maxRadius, getCuboid());
     }
 
     @Override
@@ -96,6 +83,22 @@ public class BigDoor extends AbstractMovable
         }
 
         return Optional.of(getCuboid().updatePositions(vec -> vec.rotateAroundYAxis(getRotationPoint(), angle)));
+    }
+
+    @Override
+    @Locked.Read
+    protected double calculateAnimationCycleDistance()
+    {
+        final double maxRadius = getMaxRadius(getCuboid(), getRotationPoint());
+        return maxRadius * MathUtil.HALF_PI;
+    }
+
+    @Override
+    @Locked.Read
+    protected Rectangle calculateAnimationRange()
+    {
+        final double maxRadius = getMaxRadius(getCuboid(), getRotationPoint());
+        return calculateAnimationRange(maxRadius, getCuboid());
     }
 
     /**

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/Clock.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/Clock.java
@@ -4,6 +4,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Locked;
+import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
@@ -31,6 +32,7 @@ public class Clock extends AbstractMovable implements IHorizontalAxisAligned
     private static final MovableType MOVABLE_TYPE = MovableTypeClock.get();
 
     @EqualsAndHashCode.Exclude
+    @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
     /**

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/Clock.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/Clock.java
@@ -7,7 +7,6 @@ import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
@@ -64,7 +63,7 @@ public class Clock extends AbstractMovable implements IHorizontalAxisAligned
     @Getter
     protected final PBlockFace hourArmSide;
 
-    public Clock(MovableBase base, boolean northSouthAligned, PBlockFace hourArmSide)
+    public Clock(AbstractMovable.MovableBaseHolder base, boolean northSouthAligned, PBlockFace hourArmSide)
     {
         super(base);
         this.lock = getLock();

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/Clock.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/Clock.java
@@ -78,20 +78,15 @@ public class Clock extends AbstractMovable implements IHorizontalAxisAligned
     }
 
     @Override
-    public MovementDirection cycleOpenDirection()
-    {
-        return getOpenDir();
-    }
-
-    @Override
-    protected double getLongestAnimationCycleDistance()
+    protected double calculateAnimationCycleDistance()
     {
         // Not needed for this type, as it is not affected by time/speed calculations anyway.
-        return 0.0D;
+        return 0;
     }
 
     @Override
-    public Rectangle getAnimationRange()
+    @Locked.Read
+    protected Rectangle calculateAnimationRange()
     {
         final Cuboid cuboid = getCuboid();
 
@@ -102,6 +97,12 @@ public class Clock extends AbstractMovable implements IHorizontalAxisAligned
         final int delta = boxRadius - circleRadius;
 
         return (isNorthSouthAligned() ? cuboid.grow(0, delta, delta) : cuboid.grow(delta, delta, 0)).asFlatRectangle();
+    }
+
+    @Override
+    public MovementDirection cycleOpenDirection()
+    {
+        return getOpenDir();
     }
 
     @Override

--- a/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/Drawbridge.java
+++ b/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/Drawbridge.java
@@ -3,7 +3,6 @@ package nl.pim16aap2.bigdoors.movable.drawbridge;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
@@ -39,14 +38,6 @@ public class Drawbridge extends AbstractMovable implements IHorizontalAxisAligne
     @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
-    @Getter
-    @EqualsAndHashCode.Exclude @ToString.Exclude
-    private final double longestAnimationCycleDistance;
-
-    @Getter
-    @EqualsAndHashCode.Exclude @ToString.Exclude
-    private final Rectangle animationRange;
-
     /**
      * Describes if this drawbridge's vertical position points (when taking the rotation point Y value as center) up
      * <b>(= TRUE)</b> or down <b>(= FALSE)</b>
@@ -64,10 +55,6 @@ public class Drawbridge extends AbstractMovable implements IHorizontalAxisAligne
         super(base);
         this.lock = getLock();
         this.modeUp = modeUp;
-
-        final double maxRadius = getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint());
-        this.longestAnimationCycleDistance = maxRadius * MathUtil.HALF_PI;
-        this.animationRange = calculateAnimationRange(maxRadius, getCuboid());
     }
 
     @SuppressWarnings("unused")
@@ -128,6 +115,22 @@ public class Drawbridge extends AbstractMovable implements IHorizontalAxisAligne
     {
         final MovementDirection openDir = getOpenDir();
         return openDir == MovementDirection.NORTH || openDir == MovementDirection.SOUTH;
+    }
+
+    @Override
+    @Locked.Read
+    protected double calculateAnimationCycleDistance()
+    {
+        final double maxRadius = getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint());
+        return maxRadius * MathUtil.HALF_PI;
+    }
+
+    @Override
+    @Locked.Read
+    protected Rectangle calculateAnimationRange()
+    {
+        final double maxRadius = getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint());
+        return calculateAnimationRange(maxRadius, getCuboid());
     }
 
     /**

--- a/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/Drawbridge.java
+++ b/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/Drawbridge.java
@@ -3,12 +3,12 @@ package nl.pim16aap2.bigdoors.movable.drawbridge;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
@@ -40,9 +40,11 @@ public class Drawbridge extends AbstractMovable implements IHorizontalAxisAligne
     private final ReentrantReadWriteLock lock;
 
     @Getter
+    @EqualsAndHashCode.Exclude @ToString.Exclude
     private final double longestAnimationCycleDistance;
 
     @Getter
+    @EqualsAndHashCode.Exclude @ToString.Exclude
     private final Rectangle animationRange;
 
     /**
@@ -57,7 +59,7 @@ public class Drawbridge extends AbstractMovable implements IHorizontalAxisAligne
     @Setter(onMethod_ = @Locked.Write)
     protected boolean modeUp;
 
-    public Drawbridge(MovableBase base, boolean modeUp)
+    public Drawbridge(AbstractMovable.MovableBaseHolder base, boolean modeUp)
     {
         super(base);
         this.lock = getLock();
@@ -69,7 +71,7 @@ public class Drawbridge extends AbstractMovable implements IHorizontalAxisAligne
     }
 
     @SuppressWarnings("unused")
-    private Drawbridge(MovableBase base)
+    private Drawbridge(AbstractMovable.MovableBaseHolder base)
     {
         this(base, false); // Add tmp/default values
     }

--- a/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/Drawbridge.java
+++ b/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/Drawbridge.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
@@ -35,6 +36,7 @@ public class Drawbridge extends AbstractMovable implements IHorizontalAxisAligne
     private static final MovableType MOVABLE_TYPE = MovableTypeDrawbridge.get();
 
     @EqualsAndHashCode.Exclude
+    @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
     @Getter

--- a/bigdoors-doors/doors-elevator/src/main/java/nl/pim16aap2/bigdoors/movable/elevator/Elevator.java
+++ b/bigdoors-doors/doors-elevator/src/main/java/nl/pim16aap2/bigdoors/movable/elevator/Elevator.java
@@ -2,7 +2,7 @@ package nl.pim16aap2.bigdoors.movable.elevator;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
+import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.portcullis.Portcullis;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 
@@ -18,13 +18,13 @@ public class Elevator extends Portcullis
 {
     private static final MovableType MOVABLE_TYPE = MovableTypeElevator.get();
 
-    public Elevator(MovableBase base, int blocksToMove)
+    public Elevator(AbstractMovable.MovableBaseHolder base, int blocksToMove)
     {
         super(base, blocksToMove);
     }
 
     @SuppressWarnings("unused")
-    private Elevator(MovableBase base)
+    private Elevator(AbstractMovable.MovableBaseHolder base)
     {
         this(base, -1); // Add tmp/default values
     }

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/Flag.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/Flag.java
@@ -67,13 +67,14 @@ public class Flag extends AbstractMovable implements IHorizontalAxisAligned, IPe
     }
 
     @Override
-    protected double getLongestAnimationCycleDistance()
+    protected double calculateAnimationCycleDistance()
     {
         return 0.0D;
     }
 
     @Override
-    public Rectangle getAnimationRange()
+    @Locked.Read
+    protected Rectangle calculateAnimationRange()
     {
         final Cuboid cuboid = getCuboid();
         final Vector3Di rotationPoint = getRotationPoint();

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/Flag.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/Flag.java
@@ -4,6 +4,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Locked;
+import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
@@ -33,6 +34,7 @@ public class Flag extends AbstractMovable implements IHorizontalAxisAligned, IPe
     private static final MovableType MOVABLE_TYPE = MovableTypeFlag.get();
 
     @EqualsAndHashCode.Exclude
+    @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
     /**

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/Flag.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/Flag.java
@@ -7,7 +7,6 @@ import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IPerpetualMover;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
@@ -25,7 +24,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Represents a Flag movable type.
  *
  * @author Pim
- * @see MovableBase
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -50,14 +48,14 @@ public class Flag extends AbstractMovable implements IHorizontalAxisAligned, IPe
     @PersistentVariable
     protected final boolean northSouthAligned;
 
-    public Flag(MovableBase base, boolean northSouthAligned)
+    public Flag(AbstractMovable.MovableBaseHolder base, boolean northSouthAligned)
     {
         super(base);
         this.lock = getLock();
         this.northSouthAligned = northSouthAligned;
     }
 
-    private Flag(MovableBase base)
+    private Flag(AbstractMovable.MovableBaseHolder base)
     {
         this(base, false); // Add tmp/default values
     }

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoor.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoor.java
@@ -75,7 +75,7 @@ public class GarageDoor extends AbstractMovable implements IHorizontalAxisAligne
 
     @Override
     @Locked.Read
-    protected double getLongestAnimationCycleDistance()
+    protected double calculateAnimationCycleDistance()
     {
         final Cuboid cuboid = getCuboid();
         final Vector3Di dims = cuboid.getDimensions();
@@ -90,7 +90,8 @@ public class GarageDoor extends AbstractMovable implements IHorizontalAxisAligne
     }
 
     @Override
-    public Rectangle getAnimationRange()
+    @Locked.Read
+    protected Rectangle calculateAnimationRange()
     {
         final Cuboid cuboid = getCuboid();
         if (isOpen())

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoor.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoor.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
@@ -36,6 +37,7 @@ public class GarageDoor extends AbstractMovable implements IHorizontalAxisAligne
     private static final MovableType MOVABLE_TYPE = MovableGarageDoor.get();
 
     @EqualsAndHashCode.Exclude
+    @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
     /**

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoor.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoor.java
@@ -9,7 +9,6 @@ import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
@@ -55,7 +54,7 @@ public class GarageDoor extends AbstractMovable implements IHorizontalAxisAligne
     @PersistentVariable
     protected final boolean northSouthAligned;
 
-    public GarageDoor(MovableBase base, boolean northSouthAligned)
+    public GarageDoor(AbstractMovable.MovableBaseHolder base, boolean northSouthAligned)
     {
         super(base);
         this.lock = getLock();
@@ -63,7 +62,7 @@ public class GarageDoor extends AbstractMovable implements IHorizontalAxisAligne
     }
 
     @SuppressWarnings("unused")
-    private GarageDoor(MovableBase base)
+    private GarageDoor(AbstractMovable.MovableBaseHolder base)
     {
         this(base, false); // Add tmp/default values
     }

--- a/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
+++ b/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
@@ -2,7 +2,6 @@ package nl.pim16aap2.bigdoors.movable.portcullis;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
@@ -39,7 +38,6 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
     @PersistentVariable
     @GuardedBy("lock")
     @Getter(onMethod_ = @Locked.Read)
-    @Setter(onMethod_ = @Locked.Write)
     protected int blocksToMove;
 
     public Portcullis(AbstractMovable.MovableBaseHolder base, int blocksToMove)
@@ -57,7 +55,7 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
 
     @Override
     @Locked.Read
-    protected double getLongestAnimationCycleDistance()
+    protected double calculateAnimationCycleDistance()
     {
         return blocksToMove;
     }
@@ -69,13 +67,14 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
     }
 
     @Override
-    public Rectangle getAnimationRange()
+    @Locked.Read
+    protected Rectangle calculateAnimationRange()
     {
         final Cuboid cuboid = getCuboid();
         final Vector3Di min = cuboid.getMin();
         final Vector3Di max = cuboid.getMax();
 
-        return new Cuboid(min.add(0, -getBlocksToMove(), 0), max.add(0, getBlocksToMove(), 0)).asFlatRectangle();
+        return new Cuboid(min.add(0, -blocksToMove, 0), max.add(0, blocksToMove, 0)).asFlatRectangle();
     }
 
     @Override
@@ -119,5 +118,12 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
         throws Exception
     {
         return new VerticalMover(this, data, getDirectedBlocksToMove());
+    }
+
+    @Locked.Write
+    public void setBlocksToMove(int blocksToMove)
+    {
+        this.blocksToMove = blocksToMove;
+        super.invalidateAnimationData();
     }
 }

--- a/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
+++ b/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
@@ -8,7 +8,6 @@ import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IDiscreteMovement;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
@@ -26,7 +25,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Represents a Portcullis movable type.
  *
  * @author Pim
- * @see MovableBase
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -44,7 +42,7 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
     @Setter(onMethod_ = @Locked.Write)
     protected int blocksToMove;
 
-    public Portcullis(MovableBase base, int blocksToMove)
+    public Portcullis(AbstractMovable.MovableBaseHolder base, int blocksToMove)
     {
         super(base);
         this.lock = getLock();
@@ -52,7 +50,7 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
     }
 
     @SuppressWarnings("unused")
-    private Portcullis(MovableBase base)
+    private Portcullis(AbstractMovable.MovableBaseHolder base)
     {
         this(base, -1); // Add tmp/default values
     }

--- a/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
+++ b/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Locked;
+import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
@@ -34,6 +35,7 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
     private static final MovableType MOVABLE_TYPE = MovableTypePortcullis.get();
 
     @EqualsAndHashCode.Exclude
+    @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
     @PersistentVariable

--- a/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
+++ b/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
@@ -120,6 +120,7 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
         return new VerticalMover(this, data, getDirectedBlocksToMove());
     }
 
+    @Override
     @Locked.Write
     public void setBlocksToMove(int blocksToMove)
     {

--- a/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoor.java
+++ b/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoor.java
@@ -8,7 +8,6 @@ import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.bigdoor.BigDoor;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
@@ -26,7 +25,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Represents a Revolving Door movable type.
  *
  * @author Pim
- * @see MovableBase
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
@@ -39,9 +37,11 @@ public class RevolvingDoor extends AbstractMovable
     private final ReentrantReadWriteLock lock;
 
     @Getter
+    @EqualsAndHashCode.Exclude @ToString.Exclude
     private final double longestAnimationCycleDistance;
 
     @Getter
+    @EqualsAndHashCode.Exclude @ToString.Exclude
     private final Rectangle animationRange;
 
     /**
@@ -55,7 +55,7 @@ public class RevolvingDoor extends AbstractMovable
     @Setter(onMethod_ = @Locked.Write)
     private int quarterCircles;
 
-    public RevolvingDoor(MovableBase base, int quarterCircles)
+    public RevolvingDoor(AbstractMovable.MovableBaseHolder base, int quarterCircles)
     {
         super(base);
         this.lock = getLock();
@@ -66,7 +66,7 @@ public class RevolvingDoor extends AbstractMovable
         this.animationRange = BigDoor.calculateAnimationRange(maxRadius, getCuboid());
     }
 
-    public RevolvingDoor(MovableBase base)
+    public RevolvingDoor(AbstractMovable.MovableBaseHolder base)
     {
         this(base, 1);
     }

--- a/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoor.java
+++ b/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoor.java
@@ -36,14 +36,6 @@ public class RevolvingDoor extends AbstractMovable
     @EqualsAndHashCode.Exclude
     private final ReentrantReadWriteLock lock;
 
-    @Getter
-    @EqualsAndHashCode.Exclude @ToString.Exclude
-    private final double longestAnimationCycleDistance;
-
-    @Getter
-    @EqualsAndHashCode.Exclude @ToString.Exclude
-    private final Rectangle animationRange;
-
     /**
      * The number of quarter circles (so 90 degree rotations) this movable will make before stopping.
      *
@@ -60,15 +52,26 @@ public class RevolvingDoor extends AbstractMovable
         super(base);
         this.lock = getLock();
         this.quarterCircles = quarterCircles;
-
-        final double maxRadius = BigDoor.getMaxRadius(getCuboid(), getRotationPoint());
-        this.longestAnimationCycleDistance = maxRadius * MathUtil.HALF_PI;
-        this.animationRange = BigDoor.calculateAnimationRange(maxRadius, getCuboid());
     }
 
     public RevolvingDoor(AbstractMovable.MovableBaseHolder base)
     {
         this(base, 1);
+    }
+
+    @Override
+    @Locked.Read
+    protected double calculateAnimationCycleDistance()
+    {
+        return BigDoor.getMaxRadius(getCuboid(), getRotationPoint()) * MathUtil.HALF_PI;
+    }
+
+    @Override
+    @Locked.Read
+    protected Rectangle calculateAnimationRange()
+    {
+        final double maxRadius = BigDoor.getMaxRadius(getCuboid(), getRotationPoint());
+        return BigDoor.calculateAnimationRange(maxRadius, getCuboid());
     }
 
     @Override

--- a/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
+++ b/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
@@ -125,6 +125,7 @@ public class SlidingDoor extends AbstractMovable implements IDiscreteMovement
         return new SlidingMover(this, data, getCurrentToggleDir(), getBlocksToMove());
     }
 
+    @Override
     @Locked.Write
     public void setBlocksToMove(int blocksToMove)
     {

--- a/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
+++ b/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Locked;
+import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
@@ -35,6 +36,7 @@ public class SlidingDoor extends AbstractMovable implements IDiscreteMovement
     private static final MovableType MOVABLE_TYPE = MovableSlidingDoor.get();
 
     @EqualsAndHashCode.Exclude
+    @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
     @PersistentVariable

--- a/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
+++ b/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
@@ -8,7 +8,6 @@ import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IDiscreteMovement;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
@@ -45,7 +44,7 @@ public class SlidingDoor extends AbstractMovable implements IDiscreteMovement
     @Setter(onMethod_ = @Locked.Write)
     protected int blocksToMove;
 
-    public SlidingDoor(MovableBase base, int blocksToMove)
+    public SlidingDoor(AbstractMovable.MovableBaseHolder base, int blocksToMove)
     {
         super(base);
         this.lock = getLock();
@@ -53,7 +52,7 @@ public class SlidingDoor extends AbstractMovable implements IDiscreteMovement
     }
 
     @SuppressWarnings("unused")
-    private SlidingDoor(MovableBase base)
+    private SlidingDoor(AbstractMovable.MovableBaseHolder base)
     {
         this(base, -1); // Add tmp/default values
     }

--- a/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
+++ b/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
@@ -2,7 +2,6 @@ package nl.pim16aap2.bigdoors.movable.slidingdoor;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
@@ -41,7 +40,6 @@ public class SlidingDoor extends AbstractMovable implements IDiscreteMovement
     @PersistentVariable
     @GuardedBy("lock")
     @Getter(onMethod_ = @Locked.Read)
-    @Setter(onMethod_ = @Locked.Write)
     protected int blocksToMove;
 
     public SlidingDoor(AbstractMovable.MovableBaseHolder base, int blocksToMove)
@@ -65,14 +63,14 @@ public class SlidingDoor extends AbstractMovable implements IDiscreteMovement
 
     @Override
     @Locked.Read
-    protected double getLongestAnimationCycleDistance()
+    protected double calculateAnimationCycleDistance()
     {
         return blocksToMove;
     }
 
     @Override
     @Locked.Read
-    public Rectangle getAnimationRange()
+    protected Rectangle calculateAnimationRange()
     {
         final Cuboid cuboid = getCuboid();
         final Vector3Di min = cuboid.getMin();
@@ -125,5 +123,12 @@ public class SlidingDoor extends AbstractMovable implements IDiscreteMovement
         throws Exception
     {
         return new SlidingMover(this, data, getCurrentToggleDir(), getBlocksToMove());
+    }
+
+    @Locked.Write
+    public void setBlocksToMove(int blocksToMove)
+    {
+        this.blocksToMove = blocksToMove;
+        super.invalidateAnimationData();
     }
 }

--- a/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/Windmill.java
+++ b/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/Windmill.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Locked;
+import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableBase;
@@ -35,6 +36,7 @@ public class Windmill extends AbstractMovable implements IHorizontalAxisAligned,
     private static final MovableType MOVABLE_TYPE = MovableTypeWindmill.get();
 
     @EqualsAndHashCode.Exclude
+    @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
     @Getter

--- a/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/Windmill.java
+++ b/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/Windmill.java
@@ -8,7 +8,6 @@ import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.annotations.InheritedLockField;
 import nl.pim16aap2.bigdoors.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.drawbridge.Drawbridge;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IPerpetualMover;
@@ -40,9 +39,11 @@ public class Windmill extends AbstractMovable implements IHorizontalAxisAligned,
     private final ReentrantReadWriteLock lock;
 
     @Getter
+    @EqualsAndHashCode.Exclude @ToString.Exclude
     private final double longestAnimationCycleDistance;
 
     @Getter
+    @EqualsAndHashCode.Exclude @ToString.Exclude
     private final Rectangle animationRange;
 
     /**
@@ -56,7 +57,7 @@ public class Windmill extends AbstractMovable implements IHorizontalAxisAligned,
     @Setter(onMethod_ = @Locked.Write)
     private int quarterCircles;
 
-    public Windmill(MovableBase base, int quarterCircles)
+    public Windmill(AbstractMovable.MovableBaseHolder base, int quarterCircles)
     {
         super(base);
         this.lock = getLock();
@@ -67,7 +68,7 @@ public class Windmill extends AbstractMovable implements IHorizontalAxisAligned,
         this.animationRange = Drawbridge.calculateAnimationRange(maxRadius, getCuboid());
     }
 
-    public Windmill(MovableBase doorBase)
+    public Windmill(AbstractMovable.MovableBaseHolder doorBase)
     {
         this(doorBase, 1);
     }

--- a/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/Windmill.java
+++ b/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/Windmill.java
@@ -38,14 +38,6 @@ public class Windmill extends AbstractMovable implements IHorizontalAxisAligned,
     @InheritedLockField
     private final ReentrantReadWriteLock lock;
 
-    @Getter
-    @EqualsAndHashCode.Exclude @ToString.Exclude
-    private final double longestAnimationCycleDistance;
-
-    @Getter
-    @EqualsAndHashCode.Exclude @ToString.Exclude
-    private final Rectangle animationRange;
-
     /**
      * The number of quarter circles (so 90 degree rotations) this movable will make before stopping.
      *
@@ -62,10 +54,6 @@ public class Windmill extends AbstractMovable implements IHorizontalAxisAligned,
         super(base);
         this.lock = getLock();
         this.quarterCircles = quarterCircles;
-
-        final double maxRadius = Drawbridge.getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint());
-        this.longestAnimationCycleDistance = maxRadius * MathUtil.HALF_PI;
-        this.animationRange = Drawbridge.calculateAnimationRange(maxRadius, getCuboid());
     }
 
     public Windmill(AbstractMovable.MovableBaseHolder doorBase)
@@ -102,6 +90,22 @@ public class Windmill extends AbstractMovable implements IHorizontalAxisAligned,
     {
         final MovementDirection openDir = getOpenDir();
         return openDir == MovementDirection.EAST || openDir == MovementDirection.WEST;
+    }
+
+    @Override
+    @Locked.Read
+    protected double calculateAnimationCycleDistance()
+    {
+        final double maxRadius = Drawbridge.getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint());
+        return maxRadius * MathUtil.HALF_PI;
+    }
+
+    @Override
+    @Locked.Read
+    protected Rectangle calculateAnimationRange()
+    {
+        final double maxRadius = Drawbridge.getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint());
+        return Drawbridge.calculateAnimationRange(maxRadius, getCuboid());
     }
 
     @Override

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/listeners/ChunkListener.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/listeners/ChunkListener.java
@@ -6,7 +6,6 @@ import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.PowerBlockManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
 import nl.pim16aap2.bigdoors.moveblocks.MovableActivityManager;
 import nl.pim16aap2.bigdoors.spigot.util.SpigotAdapter;
@@ -58,7 +57,8 @@ public class ChunkListener extends AbstractListener
     }
 
     /**
-     * Listens to chunks being unloaded and checks if it intersects with the region of the active {@link MovableBase}s.
+     * Listens to chunks being unloaded and checks if it intersects with the region of the active
+     * {@link AbstractMovable}s.
      */
     @EventHandler(priority = EventPriority.LOWEST)
     public void onChunkUnload(ChunkUnloadEvent event)

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/movable/MovableSerializerTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/movable/MovableSerializerTest.java
@@ -13,6 +13,7 @@ import nl.pim16aap2.bigdoors.testimplementations.TestPWorld;
 import nl.pim16aap2.bigdoors.util.Cuboid;
 import nl.pim16aap2.bigdoors.util.MovementDirection;
 import nl.pim16aap2.bigdoors.util.Rectangle;
+import nl.pim16aap2.bigdoors.util.vector.Vector2Di;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
 import nl.pim16aap2.testing.AssistedFactoryMocker;
 import org.jetbrains.annotations.Nullable;
@@ -178,27 +179,27 @@ class MovableSerializerTest
         }
 
         @Override
-        protected double getLongestAnimationCycleDistance()
-        {
-            return 0;
-        }
-
-        @Override
         public MovableType getType()
         {
             return MOVABLE_TYPE;
         }
 
         @Override
-        public boolean canSkipAnimation()
+        protected double calculateAnimationCycleDistance()
         {
-            return false;
+            return 0;
         }
 
         @Override
-        public Rectangle getAnimationRange()
+        protected Rectangle calculateAnimationRange()
         {
-            return null;
+            return new Rectangle(new Vector2Di(0, 0), new Vector2Di(0, 0));
+        }
+
+        @Override
+        public boolean canSkipAnimation()
+        {
+            return false;
         }
 
         @Override

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/movable/MovableSerializerTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/movable/MovableSerializerTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 class MovableSerializerTest
 {
-    private MovableBase movableBase;
+    private AbstractMovable.MovableBaseHolder movableBase;
 
     @BeforeEach
     void init()
@@ -124,8 +124,8 @@ class MovableSerializerTest
         final var testMovableSubType2 = Assertions.assertDoesNotThrow(
             () -> instantiator.deserialize(movableBase, serialized));
 
-        Assertions.assertEquals(movableBase.getLock(), testMovableSubType2.getLockTestMovableType());
-        Assertions.assertEquals(movableBase.getLock(), testMovableSubType2.getLockTestMovableSubTypeAnnotated());
+        Assertions.assertEquals(movableBase.get().getLock(), testMovableSubType2.getLockTestMovableType());
+        Assertions.assertEquals(movableBase.get().getLock(), testMovableSubType2.getLockTestMovableSubTypeAnnotated());
         Assertions.assertNull(testMovableSubType2.getLockTestMovableSubTypeUnannotated());
     }
 
@@ -156,16 +156,17 @@ class MovableSerializerTest
         private static final MovableType MOVABLE_TYPE = Mockito.mock(MovableType.class);
 
         @SuppressWarnings("unused")
-        public TestMovableType(MovableBase movableBase)
+        public TestMovableType(AbstractMovable.MovableBaseHolder movableBase)
         {
             super(movableBase);
-            this.lock = movableBase.getLock();
+            this.lock = movableBase.get().getLock();
         }
 
-        public TestMovableType(MovableBase movableBase, String testName, boolean isCoolType, int blockTestCount)
+        public TestMovableType(
+            AbstractMovable.MovableBaseHolder movableBase, String testName, boolean isCoolType, int blockTestCount)
         {
             super(movableBase);
-            this.lock = movableBase.getLock();
+            this.lock = movableBase.get().getLock();
             this.testName = testName;
             this.isCoolType = isCoolType;
             this.blockTestCount = blockTestCount;
@@ -240,15 +241,16 @@ class MovableSerializerTest
         private final int subclassTestValue;
 
         public TestMovableSubType(
-            MovableBase movableBase, String testName, boolean isCoolType, int blockTestCount, int subclassTestValue)
+            AbstractMovable.MovableBaseHolder base, String testName, boolean isCoolType, int blockTestCount,
+            int subclassTestValue)
         {
-            super(movableBase, testName, isCoolType, blockTestCount);
-            this.nonStandardLockName = movableBase.getLock();
-            this.lock = movableBase.getLock();
+            super(base, testName, isCoolType, blockTestCount);
+
+            this.nonStandardLockName = base.get().getLock();
+            this.lock = base.get().getLock();
 
             this.testName = testName;
             this.isCoolType = isCoolType;
-
             this.subclassTestValue = subclassTestValue;
         }
 

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/storage/SQLiteJDBCDriverConnectionTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/storage/SQLiteJDBCDriverConnectionTest.java
@@ -1,7 +1,7 @@
 package nl.pim16aap2.bigdoors.storage;
 
 import com.google.common.flogger.LogSiteStackTrace;
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.UnitTestUtil;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.api.IPWorld;
@@ -15,7 +15,6 @@ import nl.pim16aap2.bigdoors.managers.MovableDeletionManager;
 import nl.pim16aap2.bigdoors.managers.MovableRegistry;
 import nl.pim16aap2.bigdoors.managers.MovableTypeManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.MovableBaseBuilder;
 import nl.pim16aap2.bigdoors.movable.MovableOwner;
 import nl.pim16aap2.bigdoors.movable.MovableSerializer;
@@ -33,7 +32,6 @@ import nl.pim16aap2.bigdoors.util.MovementDirection;
 import nl.pim16aap2.bigdoors.util.Util;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
 import nl.pim16aap2.testing.AssertionsUtil;
-import nl.pim16aap2.testing.AssistedFactoryMocker;
 import nl.pim16aap2.testing.logging.LogInspector;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -54,7 +52,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-@Slf4j
+import static nl.pim16aap2.bigdoors.UnitTestUtil.newMovableBaseBuilder;
+
+@Flogger
 public class SQLiteJDBCDriverConnectionTest
 {
     /**
@@ -119,7 +119,7 @@ public class SQLiteJDBCDriverConnectionTest
 
     @BeforeEach
     void beforeEach()
-        throws NoSuchMethodException
+        throws Exception
     {
         MockitoAnnotations.openMocks(this);
 
@@ -129,11 +129,9 @@ public class SQLiteJDBCDriverConnectionTest
 
         movableTypeManager = new MovableTypeManager(restartableHolder, debuggableRegistry, localizationManager);
 
-        final AssistedFactoryMocker<MovableBase, MovableBase.IFactory> assistedFactoryMocker =
-            new AssistedFactoryMocker<>(MovableBase.class, MovableBase.IFactory.class)
-                .setMock(MovableRegistry.class, movableRegistry);
-
-        movableBaseBuilder = new MovableBaseBuilder(assistedFactoryMocker.getFactory());
+        final var builderResult = newMovableBaseBuilder();
+        builderResult.assistedFactoryMocker().setMock(MovableRegistry.class, movableRegistry);
+        movableBaseBuilder = builderResult.movableBaseBuilder();
 
         initMovables();
 
@@ -171,7 +169,7 @@ public class SQLiteJDBCDriverConnectionTest
         }
         catch (Exception exception)
         {
-            log.error("Failed to move database file to finished file.", exception);
+            log.atSevere().withCause(exception).log("Failed to move database file to finished file!");
         }
         try
         {

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/tooluser/creator/CreatorTestsUtil.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/tooluser/creator/CreatorTestsUtil.java
@@ -28,7 +28,6 @@ import nl.pim16aap2.bigdoors.managers.MovableDeletionManager;
 import nl.pim16aap2.bigdoors.managers.MovableRegistry;
 import nl.pim16aap2.bigdoors.managers.ToolUserManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.MovableBase;
 import nl.pim16aap2.bigdoors.movable.MovableBaseBuilder;
 import nl.pim16aap2.bigdoors.movable.MovableOwner;
 import nl.pim16aap2.bigdoors.movable.PermissionLevel;
@@ -58,6 +57,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static nl.pim16aap2.bigdoors.UnitTestUtil.getWorld;
+import static nl.pim16aap2.bigdoors.UnitTestUtil.newMovableBaseBuilder;
 
 public class CreatorTestsUtil
 {
@@ -149,14 +149,13 @@ public class CreatorTestsUtil
         localizer = UnitTestUtil.initLocalizer();
         limitsManager = new LimitsManager(permissionsManager, configLoader);
 
-        final MovableBase.IFactory movableBaseIFactory =
-            new AssistedFactoryMocker<>(MovableBase.class, MovableBase.IFactory.class)
-                .setMock(ILocalizer.class, localizer)
-                .setMock(MovableRegistry.class,
-                         MovableRegistry.unCached(Mockito.mock(RestartableHolder.class), debuggableRegistry,
-                                                  Mockito.mock(MovableDeletionManager.class)))
-                .getFactory();
-        movableBaseBuilder = new MovableBaseBuilder(movableBaseIFactory);
+        final var builderResult = newMovableBaseBuilder();
+        builderResult.assistedFactoryMocker()
+                     .setMock(ILocalizer.class, localizer)
+                     .setMock(MovableRegistry.class,
+                              MovableRegistry.unCached(Mockito.mock(RestartableHolder.class), debuggableRegistry,
+                                                       Mockito.mock(MovableDeletionManager.class)));
+        movableBaseBuilder = builderResult.movableBaseBuilder();
 
         final var assistedStepFactory = Mockito.mock(Step.Factory.IFactory.class);
         //noinspection deprecation
@@ -261,7 +260,7 @@ public class CreatorTestsUtil
     }
 
 
-    protected MovableBase constructMovableBase()
+    protected AbstractMovable.MovableBaseHolder constructMovableBase()
     {
         return movableBaseBuilder.builder()
                                  .uid(-1).name(movableName).cuboid(new Cuboid(min, max)).rotationPoint(rotationPoint)


### PR DESCRIPTION
- Fixed `Unsafe` deserialization of Movables not setting some variables in the `AbstractMovable` class. The fields were not really needed anyway, so they have been removed.
- Fixed `Unsafe` deserialization not setting the `lock` objects in the subclasses of `AbstractMovable`.
- Fixed incorrect Movable UID being set in `MovableOwners` when inserting it into the database.
- The animation range and the animation cycle distance are now initialized lazily and reset when needed.
- Access to the `MovableBase` class has been restricted to package-private. The field in the `AbstractMovable` class is now also private and without a getter to avoid it leaking.
- Replaced the old friend accessing system for the database manager with a new `MovableModifier` class. Only the `DatabaseManager` has access to this class.