### PR TITLE
Abstract animated block management away

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/factories/IAnimatedBlockFactory.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/factories/IAnimatedBlockFactory.java
@@ -4,7 +4,7 @@ import nl.pim16aap2.bigdoors.api.IPLocation;
 import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlockData;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 
 import java.util.Optional;
@@ -40,6 +40,6 @@ public interface IAnimatedBlockFactory
      */
     Optional<IAnimatedBlock> create(
         IPLocation loc, float radius, float startAngle, boolean bottom, boolean onEdge, AnimationContext context,
-        Vector3Dd finalPosition, BlockMover.MovementMethod movementMethod)
+        Vector3Dd finalPosition, Animator.MovementMethod movementMethod)
         throws Exception;
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
@@ -14,7 +14,7 @@ import nl.pim16aap2.bigdoors.events.movableaction.MovableActionCause;
 import nl.pim16aap2.bigdoors.events.movableaction.MovableActionType;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -310,7 +310,7 @@ public abstract class AbstractMovable implements IMovable
     /**
      * @param data
      *     The data for the toggle request.
-     * @return A new {@link BlockMover} for this type of movable.
+     * @return A new {@link Animator} for this type of movable.
      */
     protected abstract IAnimationComponent constructAnimationComponent(MovementRequestData data)
         throws Exception;

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
@@ -26,7 +26,8 @@ import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.LimitsManager;
 import nl.pim16aap2.bigdoors.managers.MovableTypeManager;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.AnimationBlockManager;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovableActivityManager;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -66,6 +67,7 @@ public final class MovableOpeningHelper
     private final IChunkLoader chunkLoader;
     private final LimitsManager limitsManager;
     private final IBigDoorsEventCaller bigDoorsEventCaller;
+    private final AnimationBlockManager.IFactory animationBlockManagerFactory;
     private final MovementRequestData.IFactory movementRequestDataFactory;
 
     @Inject //
@@ -85,6 +87,7 @@ public final class MovableOpeningHelper
         IChunkLoader chunkLoader,
         LimitsManager limitsManager,
         IBigDoorsEventCaller bigDoorsEventCaller,
+        AnimationBlockManager.IFactory animationBlockManagerFactory,
         MovementRequestData.IFactory movementRequestDataFactory)
     {
         this.localizer = localizer;
@@ -102,6 +105,7 @@ public final class MovableOpeningHelper
         this.chunkLoader = chunkLoader;
         this.limitsManager = limitsManager;
         this.bigDoorsEventCaller = bigDoorsEventCaller;
+        this.animationBlockManagerFactory = animationBlockManagerFactory;
         this.movementRequestDataFactory = movementRequestDataFactory;
     }
 
@@ -233,7 +237,8 @@ public final class MovableOpeningHelper
         try
         {
             final IAnimationComponent component = movable.constructAnimationComponent(data);
-            final BlockMover blockMover = new BlockMover(movable, data, component);
+            final AnimationBlockManager animationBlockManager = animationBlockManagerFactory.newManager();
+            final Animator blockMover = new Animator(movable, data, component, animationBlockManager);
 
             movableActivityManager.addBlockMover(blockMover);
             executor.runOnMainThread(blockMover::startAnimation);
@@ -577,12 +582,11 @@ public final class MovableOpeningHelper
     }
 
     /**
-     * Checks if a {@link BlockMover} of a {@link IMovable} has been registered with the {@link DatabaseManager}.
+     * Checks if a {@link Animator} of a {@link IMovable} has been registered with the {@link DatabaseManager}.
      *
      * @param movableUID
      *     The UID of the {@link IMovable}.
-     * @return True if a {@link BlockMover} has been registered with the {@link DatabaseManager} for the
-     * {@link IMovable}.
+     * @return True if a {@link Animator} has been registered with the {@link DatabaseManager} for the {@link IMovable}.
      */
     @SuppressWarnings("unused")
     public boolean isBlockMoverRegistered(long movableUID)
@@ -591,13 +595,13 @@ public final class MovableOpeningHelper
     }
 
     /**
-     * Gets the {@link BlockMover} of a {@link IMovable} if it has been registered with the {@link DatabaseManager}.
+     * Gets the {@link Animator} of a {@link IMovable} if it has been registered with the {@link DatabaseManager}.
      *
      * @param movableUID
      *     The UID of the {@link IMovable}.
-     * @return The {@link BlockMover} of a {@link IMovable} if it has been registered with the {@link DatabaseManager}.
+     * @return The {@link Animator} of a {@link IMovable} if it has been registered with the {@link DatabaseManager}.
      */
-    public Optional<BlockMover> getBlockMover(long movableUID)
+    public Optional<Animator> getBlockMover(long movableUID)
     {
         return movableActivityManager.getBlockMover(movableUID);
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationBlockManager.java
@@ -1,0 +1,179 @@
+package nl.pim16aap2.bigdoors.moveblocks;
+
+import dagger.assisted.AssistedFactory;
+import dagger.assisted.AssistedInject;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.bigdoors.api.IPExecutor;
+import nl.pim16aap2.bigdoors.api.IPLocation;
+import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
+import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.api.factories.IAnimatedBlockFactory;
+import nl.pim16aap2.bigdoors.api.factories.IPLocationFactory;
+import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
+import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
+import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Flogger
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ToString(onlyExplicitlyIncluded = true)
+public class AnimationBlockManager implements IAnimationBlockManager
+{
+    private final IPLocationFactory locationFactory;
+    private final IAnimatedBlockFactory animatedBlockFactory;
+    private final IPExecutor executor;
+
+    /**
+     * The modifiable list of animated blocks.
+     */
+    private final List<IAnimatedBlock> privateAnimatedBlocks;
+
+    /**
+     * The (unmodifiable) list of animated blocks.
+     */
+    @Getter
+    @ToString.Include @EqualsAndHashCode.Include
+    private final List<IAnimatedBlock> animatedBlocks;
+
+    @AssistedInject AnimationBlockManager(
+        IPLocationFactory locationFactory, IAnimatedBlockFactory animatedBlockFactory, IPExecutor executor)
+    {
+        this.locationFactory = locationFactory;
+        this.animatedBlockFactory = animatedBlockFactory;
+        this.executor = executor;
+
+        privateAnimatedBlocks = new CopyOnWriteArrayList<>();
+        animatedBlocks = Collections.unmodifiableList(privateAnimatedBlocks);
+    }
+
+    @Override
+    public boolean createAnimatedBlocks(
+        MovableSnapshot snapshot, IAnimationComponent animationComponent, AnimationContext animationContext,
+        Animator.MovementMethod movementMethod)
+    {
+        final List<IAnimatedBlock> animatedBlocksTmp = new ArrayList<>(snapshot.getBlockCount());
+
+        try
+        {
+            final int xMin = snapshot.getCuboid().getMin().x();
+            final int yMin = snapshot.getCuboid().getMin().y();
+            final int zMin = snapshot.getCuboid().getMin().z();
+
+            final int xMax = snapshot.getCuboid().getMax().x();
+            final int yMax = snapshot.getCuboid().getMax().y();
+            final int zMax = snapshot.getCuboid().getMax().z();
+
+            for (int xAxis = xMin; xAxis <= xMax; ++xAxis)
+                for (int yAxis = yMax; yAxis >= yMin; --yAxis)
+                    for (int zAxis = zMin; zAxis <= zMax; ++zAxis)
+                    {
+                        final boolean onEdge =
+                            xAxis == xMin || xAxis == xMax ||
+                                yAxis == yMin || yAxis == yMax ||
+                                zAxis == zMin || zAxis == zMax;
+
+                        final IPLocation location =
+                            locationFactory.create(snapshot.getWorld(), xAxis + 0.5, yAxis, zAxis + 0.5);
+                        final boolean bottom = (yAxis == yMin);
+                        final float radius = animationComponent.getRadius(xAxis, yAxis, zAxis);
+                        final float startAngle = animationComponent.getStartAngle(xAxis, yAxis, zAxis);
+                        final Vector3Dd startPosition = new Vector3Dd(xAxis + 0.5, yAxis, zAxis + 0.5);
+                        final Vector3Dd finalPosition = animationComponent.getFinalPosition(startPosition, radius);
+
+                        animatedBlockFactory
+                            .create(location, radius, startAngle, bottom, onEdge, animationContext, finalPosition,
+                                    movementMethod)
+                            .ifPresent(animatedBlocksTmp::add);
+                    }
+
+            tryRemoveOriginalBlocks(animatedBlocksTmp, false);
+            tryRemoveOriginalBlocks(animatedBlocksTmp, true);
+        }
+        catch (Exception e)
+        {
+            log.atSevere().withCause(e).log();
+            this.privateAnimatedBlocks.addAll(animatedBlocksTmp);
+            return false;
+        }
+
+        this.privateAnimatedBlocks.addAll(animatedBlocksTmp);
+        return true;
+    }
+
+    /**
+     * Tries to remove the original blocks of a list of animated blocks.
+     *
+     * @param animatedBlocks
+     *     The animated blocks to process.
+     * @param edgePass
+     *     True to do a pass over the edges specifically.
+     * @return True if the original blocks could be spawned. If something went wrong and the process had to be aborted,
+     * false is returned instead.
+     */
+    private void tryRemoveOriginalBlocks(List<IAnimatedBlock> animatedBlocks, boolean edgePass)
+    {
+        executor.assertMainThread("Blocks must be removed on the main thread!");
+
+        for (final IAnimatedBlock animatedBlock : animatedBlocks)
+        {
+            if (edgePass && !animatedBlock.isOnEdge())
+                continue;
+            animatedBlock.getAnimatedBlockData().deleteOriginalBlock(edgePass);
+        }
+    }
+
+    @Override
+    public void restoreBlocksOnFailure()
+    {
+        executor.assertMainThread("Blocks cannot be placed asynchronously!");
+        for (final IAnimatedBlock animatedBlock : getAnimatedBlocks())
+        {
+            try
+            {
+                animatedBlock.kill();
+            }
+            catch (Exception e)
+            {
+                log.atSevere().withCause(e).log("Failed to kill animated block: %s", animatedBlock);
+            }
+            try
+            {
+                final Vector3Dd startPos = animatedBlock.getStartPosition();
+                final Vector3Di goalPos = new Vector3Di((int) startPos.x(),
+                                                        (int) Math.round(startPos.y()),
+                                                        (int) startPos.z());
+                animatedBlock.getAnimatedBlockData().putBlock(goalPos);
+            }
+            catch (Exception e)
+            {
+                log.atSevere().withCause(e).log("Failed to restore block: %s", animatedBlock);
+            }
+        }
+        privateAnimatedBlocks.clear();
+    }
+
+    @Override
+    public void handleAnimationCompletion()
+    {
+        executor.assertMainThread("Blocks cannot be placed asynchronously!");
+        for (final IAnimatedBlock animatedBlock : privateAnimatedBlocks)
+        {
+            animatedBlock.kill();
+            animatedBlock.getAnimatedBlockData().putBlock(animatedBlock.getFinalPosition());
+        }
+        privateAnimatedBlocks.clear();
+    }
+
+    @AssistedFactory
+    public interface IFactory
+    {
+        AnimationBlockManager newManager();
+    }
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/IAnimationBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/IAnimationBlockManager.java
@@ -1,0 +1,56 @@
+package nl.pim16aap2.bigdoors.moveblocks;
+
+import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
+import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
+
+import java.util.List;
+
+/**
+ * Represents a manager for animated blocks.
+ * <p>
+ * It is responsible for the creation and cleanup of animated blocks.
+ * <p>
+ * The most common example will be a manager that replaces existing blocks with animated blocks and places them in the
+ * new location after the animation ends.
+ */
+public interface IAnimationBlockManager
+{
+    /**
+     * Attempts to create and spawn the animated blocks for the given input.
+     *
+     * @param snapshot
+     *     The snapshot of the movable to create the animated blocks for.
+     * @param animationComponent
+     *     The animation component to use for retrieving additional information for the animated blocks.
+     * @param animationContext
+     *     The animation context for the animated blocks.
+     * @param movementMethod
+     *     The movement method to use for the animation.
+     * @return The result of the attempted creation of the animated blocks.
+     */
+    boolean createAnimatedBlocks(
+        MovableSnapshot snapshot, IAnimationComponent animationComponent, AnimationContext animationContext,
+        Animator.MovementMethod movementMethod);
+
+    /**
+     * @return All the animated blocks that are part of the animation. In case an error occurred during the creation,
+     * this will contain all the animated blocks that have been created up to the point that the problem occurred.
+     */
+    List<IAnimatedBlock> getAnimatedBlocks();
+
+    /**
+     * Restores all spawned animated blocks to their original positions.
+     * <p>
+     * Should be used in case something failed.
+     */
+    void restoreBlocksOnFailure();
+
+    /**
+     * Handles the blocks when the animation is completed.
+     * <p>
+     * For the most common use-case, this means that the animated blocks will be killed and the blocks they represented
+     * will be placed in their final positions.
+     */
+    void handleAnimationCompletion();
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/IAnimationComponent.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/IAnimationComponent.java
@@ -45,11 +45,11 @@ public interface IAnimationComponent
      * <p>
      * Subclasses are free to override this if a different type of movement is desired for that type.
      * <p>
-     * Each animated block is moved using {@link BlockMover.MovementMethod#apply(IAnimatedBlock, Vector3Dd, int)}.
+     * Each animated block is moved using {@link Animator.MovementMethod#apply(IAnimatedBlock, Vector3Dd, int)}.
      */
-    default BlockMover.MovementMethod getMovementMethod()
+    default Animator.MovementMethod getMovementMethod()
     {
-        return BlockMover.MovementMethod.TELEPORT_VELOCITY;
+        return Animator.MovementMethod.TELEPORT_VELOCITY;
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 @Singleton
 public final class MovableActivityManager extends Restartable implements MovableDeletionManager.IDeletionListener
 {
-    private final Map<Long, Optional<BlockMover>> busyMovables = new ConcurrentHashMap<>();
+    private final Map<Long, Optional<Animator>> busyMovables = new ConcurrentHashMap<>();
 
     private final IBigDoorsEventFactory eventFactory;
     private final IBigDoorsEventCaller bigDoorsEventCaller;
@@ -89,20 +89,20 @@ public final class MovableActivityManager extends Restartable implements Movable
     }
 
     /**
-     * Processed a finished {@link BlockMover}.
+     * Processed a finished {@link Animator}.
      * <p>
-     * The {@link AbstractMovable} that was being used by the {@link BlockMover} will be registered as inactive and any
+     * The {@link AbstractMovable} that was being used by the {@link Animator} will be registered as inactive and any
      * scheduling that is required will be performed.
      *
      * @param blockMover
-     *     The {@link BlockMover} to post-process.
+     *     The {@link Animator} to post-process.
      */
-    void processFinishedBlockMover(BlockMover blockMover)
+    void processFinishedBlockMover(Animator blockMover)
     {
         handleFinishedBlockMover(blockMover);
     }
 
-    private void handleFinishedBlockMover(BlockMover blockMover)
+    private void handleFinishedBlockMover(Animator blockMover)
     {
         setMovableAvailable(blockMover.getMovable().getUid());
 
@@ -114,35 +114,35 @@ public final class MovableActivityManager extends Restartable implements Movable
     }
 
     /**
-     * Stores a {@link BlockMover} in the appropriate slot in {@link #busyMovables}
+     * Stores a {@link Animator} in the appropriate slot in {@link #busyMovables}
      *
      * @param mover
-     *     The {@link BlockMover}.
+     *     The {@link Animator}.
      */
-    public void addBlockMover(BlockMover mover)
+    public void addBlockMover(Animator mover)
     {
         busyMovables.replace(mover.getMovableUID(), Optional.of(mover));
     }
 
     /**
-     * Gets all the currently active {@link BlockMover}s.
+     * Gets all the currently active {@link Animator}s.
      *
-     * @return All the currently active {@link BlockMover}s.
+     * @return All the currently active {@link Animator}s.
      */
     @SuppressWarnings("unused")
-    public Stream<BlockMover> getBlockMovers()
+    public Stream<Animator> getBlockMovers()
     {
         return busyMovables.values().stream().filter(Optional::isPresent).map(Optional::get);
     }
 
     /**
-     * Gets the {@link BlockMover} of a busy {@link AbstractMovable}, if it has been registered.
+     * Gets the {@link Animator} of a busy {@link AbstractMovable}, if it has been registered.
      *
      * @param movableUID
      *     The UID of the {@link AbstractMovable}.
-     * @return The {@link BlockMover} of a busy {@link AbstractMovable}.
+     * @return The {@link Animator} of a busy {@link AbstractMovable}.
      */
-    public Optional<BlockMover> getBlockMover(long movableUID)
+    public Optional<Animator> getBlockMover(long movableUID)
     {
         return Objects.requireNonNullElse(busyMovables.get(movableUID), Optional.empty());
     }
@@ -160,15 +160,15 @@ public final class MovableActivityManager extends Restartable implements Movable
      */
     public void stopMovables()
     {
-        busyMovables.forEach((key, value) -> value.ifPresent(BlockMover::abort));
+        busyMovables.forEach((key, value) -> value.ifPresent(Animator::abort));
         emptyBusyMovables();
     }
 
     @Override
     public void onMovableDeletion(IMovableConst movable)
     {
-        Objects.<Optional<BlockMover>>requireNonNullElse(busyMovables.remove(movable.getUid()), Optional.empty())
-               .ifPresent(BlockMover::abort);
+        Objects.<Optional<Animator>>requireNonNullElse(busyMovables.remove(movable.getUid()), Optional.empty())
+               .ifPresent(Animator::abort);
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovementRequestData.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovementRequestData.java
@@ -8,8 +8,6 @@ import nl.pim16aap2.bigdoors.api.GlowingBlockSpawner;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.IPExecutor;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
-import nl.pim16aap2.bigdoors.api.factories.IAnimatedBlockFactory;
-import nl.pim16aap2.bigdoors.api.factories.IPLocationFactory;
 import nl.pim16aap2.bigdoors.audio.IAudioPlayer;
 import nl.pim16aap2.bigdoors.events.movableaction.MovableActionCause;
 import nl.pim16aap2.bigdoors.events.movableaction.MovableActionType;
@@ -26,10 +24,8 @@ import javax.inject.Named;
 public final class MovementRequestData
 {
     private final MovableActivityManager movableActivityManager;
-    private final IPLocationFactory locationFactory;
     private final IAudioPlayer audioPlayer;
     private final IPExecutor executor;
-    private final IAnimatedBlockFactory animatedBlockFactory;
     private final AnimationHookManager animationHookManager;
     private final GlowingBlockSpawner glowingBlockSpawner;
     private final IConfigLoader config;
@@ -44,10 +40,8 @@ public final class MovementRequestData
 
     @AssistedInject MovementRequestData(
         MovableActivityManager movableActivityManager,
-        IPLocationFactory locationFactory,
         IAudioPlayer audioPlayer,
         IPExecutor executor,
-        IAnimatedBlockFactory animatedBlockFactory,
         AnimationHookManager animationHookManager,
         GlowingBlockSpawner glowingBlockSpawner,
         IConfigLoader config,
@@ -61,10 +55,8 @@ public final class MovementRequestData
         @Assisted MovableActionType actionType)
     {
         this.movableActivityManager = movableActivityManager;
-        this.locationFactory = locationFactory;
         this.audioPlayer = audioPlayer;
         this.executor = executor;
-        this.animatedBlockFactory = animatedBlockFactory;
         this.animationHookManager = animationHookManager;
         this.glowingBlockSpawner = glowingBlockSpawner;
         this.config = config;

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/ClockAnimationComponent.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/ClockAnimationComponent.java
@@ -2,7 +2,7 @@ package nl.pim16aap2.bigdoors.movable.clock;
 
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.windmill.WindmillAnimationComponent;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.MathUtil;
@@ -15,7 +15,7 @@ import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 import java.util.function.Function;
 
 /**
- * Represents a {@link BlockMover} for {@link Clock}s.
+ * Represents a {@link Animator} for {@link Clock}s.
  *
  * @author Pim
  */
@@ -59,9 +59,9 @@ public final class ClockAnimationComponent extends WindmillAnimationComponent
     }
 
     @Override
-    public BlockMover.MovementMethod getMovementMethod()
+    public Animator.MovementMethod getMovementMethod()
     {
-        return BlockMover.MovementMethod.TELEPORT;
+        return Animator.MovementMethod.TELEPORT;
     }
 
     /**

--- a/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/DrawbridgeAnimationComponent.java
+++ b/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/DrawbridgeAnimationComponent.java
@@ -3,7 +3,7 @@ package nl.pim16aap2.bigdoors.movable.drawbridge;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationUtil;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -15,7 +15,7 @@ import nl.pim16aap2.bigdoors.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 
 /**
- * Represents a {@link BlockMover} for {@link Drawbridge}s.
+ * Represents a {@link Animator} for {@link Drawbridge}s.
  *
  * @author Pim
  */

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/FlagAnimationComponent.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/FlagAnimationComponent.java
@@ -4,7 +4,7 @@ import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -17,7 +17,7 @@ import nl.pim16aap2.jcalculator.JCalculator;
 import java.util.function.BiFunction;
 
 /**
- * Represents a {@link BlockMover} for {@link Flag}s.
+ * Represents a {@link Animator} for {@link Flag}s.
  *
  * @author Pim
  */
@@ -49,9 +49,9 @@ public final class FlagAnimationComponent implements IAnimationComponent
     }
 
     @Override
-    public BlockMover.MovementMethod getMovementMethod()
+    public Animator.MovementMethod getMovementMethod()
     {
-        return BlockMover.MovementMethod.TELEPORT;
+        return Animator.MovementMethod.TELEPORT;
     }
 
     private double getOffset(int counter, IAnimatedBlock animatedBlock)

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoorAnimationComponent.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoorAnimationComponent.java
@@ -3,7 +3,7 @@ package nl.pim16aap2.bigdoors.movable.garagedoor;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationUtil;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -17,7 +17,7 @@ import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
 import java.util.function.BiFunction;
 
 /**
- * Represents a {@link BlockMover} for {@link GarageDoor}s.
+ * Represents a {@link Animator} for {@link GarageDoor}s.
  *
  * @author Pim
  */

--- a/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/VerticalAnimationComponent.java
+++ b/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/VerticalAnimationComponent.java
@@ -2,7 +2,7 @@ package nl.pim16aap2.bigdoors.movable.portcullis;
 
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationUtil;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -10,7 +10,7 @@ import nl.pim16aap2.bigdoors.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 
 /**
- * Represents a {@link BlockMover} for {@link Portcullis}'s.
+ * Represents a {@link Animator} for {@link Portcullis}'s.
  *
  * @author Pim
  */

--- a/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoorAnimationComponent.java
+++ b/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoorAnimationComponent.java
@@ -3,7 +3,7 @@ package nl.pim16aap2.bigdoors.movable.revolvingdoor;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationUtil;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -15,7 +15,7 @@ import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 import java.util.function.BiFunction;
 
 /**
- * Represents a {@link BlockMover} for {@link RevolvingDoor}s.
+ * Represents a {@link Animator} for {@link RevolvingDoor}s.
  *
  * @author Pim
  */

--- a/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoorAnimationComponent.java
+++ b/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoorAnimationComponent.java
@@ -2,7 +2,7 @@ package nl.pim16aap2.bigdoors.movable.slidingdoor;
 
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationUtil;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -12,7 +12,7 @@ import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Represents a {@link BlockMover} for {@link SlidingDoor}.
+ * Represents a {@link Animator} for {@link SlidingDoor}.
  *
  * @author Pim
  */

--- a/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/WindmillAnimationComponent.java
+++ b/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/WindmillAnimationComponent.java
@@ -2,7 +2,7 @@ package nl.pim16aap2.bigdoors.movable.windmill;
 
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.drawbridge.DrawbridgeAnimationComponent;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.MathUtil;
@@ -12,7 +12,7 @@ import nl.pim16aap2.bigdoors.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 
 /**
- * Represents a {@link BlockMover} for {@link Windmill}s.
+ * Represents a {@link Animator} for {@link Windmill}s.
  *
  * @author Pim
  */

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/listeners/ChunkListener.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/listeners/ChunkListener.java
@@ -6,7 +6,7 @@ import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.PowerBlockManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.MovableActivityManager;
 import nl.pim16aap2.bigdoors.spigot.util.SpigotAdapter;
 import nl.pim16aap2.bigdoors.util.Rectangle;
@@ -77,7 +77,7 @@ public class ChunkListener extends AbstractListener
                 .getBlockMovers()
                 .filter(mover -> mover.getSnapshot().getWorld().equals(world))
                 .filter(mover -> chunkInsideAnimationRange(chunkCoords, mover.getSnapshot().getAnimationRange()))
-                .forEach(BlockMover::abort);
+                .forEach(Animator::abort);
         }
         catch (Exception e)
         {

--- a/bigdoors-spigot/spigot-v1_19_R2/src/main/java/nl/pim16aap2/bigdoors/spigot/v1_19_R2/AnimatedBlockFactory_V1_19_R2.java
+++ b/bigdoors-spigot/spigot-v1_19_R2/src/main/java/nl/pim16aap2/bigdoors/spigot/v1_19_R2/AnimatedBlockFactory_V1_19_R2.java
@@ -6,7 +6,7 @@ import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.api.factories.IAnimatedBlockFactory;
 import nl.pim16aap2.bigdoors.managers.AnimatedBlockHookManager;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.spigot.util.SpigotAdapter;
 import nl.pim16aap2.bigdoors.util.Constants;
 import nl.pim16aap2.bigdoors.util.Util;
@@ -40,7 +40,7 @@ public final class AnimatedBlockFactory_V1_19_R2 implements IAnimatedBlockFactor
     @Override
     public Optional<IAnimatedBlock> create(
         IPLocation loc, float radius, float startAngle, boolean bottom, boolean onEdge, AnimationContext context,
-        Vector3Dd finalPosition, BlockMover.MovementMethod movementMethod)
+        Vector3Dd finalPosition, Animator.MovementMethod movementMethod)
         throws Exception
     {
         final Location spigotLocation = SpigotAdapter.getBukkitLocation(loc);

--- a/bigdoors-spigot/spigot-v1_19_R2/src/main/java/nl/pim16aap2/bigdoors/spigot/v1_19_R2/CustomEntityFallingBlock_V1_19_R2.java
+++ b/bigdoors-spigot/spigot-v1_19_R2/src/main/java/nl/pim16aap2/bigdoors/spigot/v1_19_R2/CustomEntityFallingBlock_V1_19_R2.java
@@ -33,7 +33,7 @@ import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlockHook;
 import nl.pim16aap2.bigdoors.managers.AnimatedBlockHookManager;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.spigot.util.SpigotAdapter;
 import nl.pim16aap2.bigdoors.spigot.util.api.IAnimatedBlockSpigot;
 import nl.pim16aap2.bigdoors.spigot.util.implementations.PLocationSpigot;
@@ -85,7 +85,7 @@ public class CustomEntityFallingBlock_V1_19_R2 extends EntityFallingBlock implem
     @Getter
     private final float startAngle;
 
-    private final BlockMover.MovementMethod movementMethod;
+    private final Animator.MovementMethod movementMethod;
 
     @Getter
     private final boolean onEdge;
@@ -133,7 +133,7 @@ public class CustomEntityFallingBlock_V1_19_R2 extends EntityFallingBlock implem
 
     public CustomEntityFallingBlock_V1_19_R2(
         IPExecutor executor, IPWorld pWorld, World world, double posX, double posY, double posZ, float radius,
-        float startAngle, BlockMover.MovementMethod movementMethod,
+        float startAngle, Animator.MovementMethod movementMethod,
         boolean onEdge, AnimationContext context, AnimatedBlockHookManager animatedBlockHookManager,
         Vector3Dd finalPosition)
     {


### PR DESCRIPTION
- The responsibilities of the old BlockMover (now Animator) class have been reduced. It no longer spawns them, nor does it remove/place any blocks in the world. These responsibilities have been moved into the IAnimationBlockManager interface. It currently only has a single subclass that does the exact same thing the BlockMover used to do. In the future we can use this interface to create other subclasses which can do interesting things like create animations using glowing blocks.
- Renamed BlockMover to Animator to better reflect its current role in the whole operation.