### PR TITLE
Add animation previews

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/animatedblock/IAnimatedBlock.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/animatedblock/IAnimatedBlock.java
@@ -45,7 +45,7 @@ public interface IAnimatedBlock
      *
      * @return The world this animated block exists in.
      */
-    IPWorld getPWorld();
+    IPWorld getWorld();
 
     /**
      * Moves this animated block to the target.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/factories/IAnimatedBlockFactory.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/factories/IAnimatedBlockFactory.java
@@ -4,7 +4,7 @@ import nl.pim16aap2.bigdoors.api.IPLocation;
 import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlockData;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 
 import java.util.Optional;
@@ -40,6 +40,6 @@ public interface IAnimatedBlockFactory
      */
     Optional<IAnimatedBlock> create(
         IPLocation loc, float radius, float startAngle, boolean bottom, boolean onEdge, AnimationContext context,
-        Vector3Dd finalPosition, BlockMover.MovementMethod movementMethod)
+        Vector3Dd finalPosition, Animator.MovementMethod movementMethod)
         throws Exception;
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/StopMovables.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/StopMovables.java
@@ -38,7 +38,7 @@ public class StopMovables extends BaseCommand
     @Override
     protected CompletableFuture<?> executeCommand(PermissionsStatus permissions)
     {
-        movableActivityManager.stopMovables();
+        movableActivityManager.stopAnimators();
         getCommandSender().sendSuccess(textFactory, localizer.getMessage("commands.stop_movables.success"));
         return CompletableFuture.completedFuture(null);
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/Toggle.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/commands/Toggle.java
@@ -186,6 +186,19 @@ public class Toggle extends BaseCommand
         /**
          * See {@link #newToggle(ICommandSender, MovableActionType, AnimationType, Double, MovableRetriever...)}.
          * <p>
+         * Defaults to null for the speed multiplier.
+         */
+        default Toggle newToggle(
+            ICommandSender commandSender, MovableActionType actionType, AnimationType animationType,
+            MovableRetriever... movableRetrievers)
+        {
+            return newToggle(
+                commandSender, actionType, animationType, (Double) null, movableRetrievers);
+        }
+
+        /**
+         * See {@link #newToggle(ICommandSender, MovableActionType, AnimationType, Double, MovableRetriever...)}.
+         * <p>
          * Defaults to null for the speed multiplier, to {@link Toggle#DEFAULT_MOVABLE_ACTION_TYPE} for the movable
          * action type, and to {@link Toggle#DEFAULT_ANIMATION_TYPE} for the animation type.
          */

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
@@ -7,11 +7,8 @@ import lombok.ToString;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
-import nl.pim16aap2.bigdoors.api.IMessageable;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.api.IPWorld;
-import nl.pim16aap2.bigdoors.events.movableaction.MovableActionCause;
-import nl.pim16aap2.bigdoors.events.movableaction.MovableActionType;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.Animator;
@@ -318,27 +315,16 @@ public abstract class AbstractMovable implements IMovable
      * Attempts to toggle a movable. Think twice before using this method. Instead, please look at
      * {@link MovableToggleRequestBuilder}.
      *
-     * @param cause
-     *     What caused the toggle action.
-     * @param messageReceiver
-     *     Who will receive any messages that have to be sent.
+     * @param request
+     *     The toggle request to process.
      * @param responsible
      *     Who is responsible for this movable. Either the player who directly toggled it (via a command or the GUI), or
      *     the prime owner when this data is not available.
-     * @param targetTime
-     *     The amount of time this {@link MovableBase} will try to use to move. When null, the default speed is used.
-     * @param skipAnimation
-     *     If the {@link MovableBase} should be opened instantly (i.e. skip animation) or not.
-     * @param actionType
-     *     The type of action.
      * @return The result of the attempt.
      */
-    final MovableToggleResult toggle(
-        MovableActionCause cause, IMessageable messageReceiver, IPPlayer responsible, @Nullable Double targetTime,
-        boolean skipAnimation, MovableActionType actionType)
+    final MovableToggleResult toggle(MovableToggleRequest request, IPPlayer responsible)
     {
-        return base.getMovableOpeningHelper().toggle(
-            this, cause, messageReceiver, responsible, targetTime, skipAnimation, actionType);
+        return base.getMovableOpeningHelper().toggle(this, request, responsible);
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
@@ -14,7 +14,7 @@ import nl.pim16aap2.bigdoors.events.movableaction.MovableActionCause;
 import nl.pim16aap2.bigdoors.events.movableaction.MovableActionType;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -310,7 +310,7 @@ public abstract class AbstractMovable implements IMovable
     /**
      * @param data
      *     The data for the toggle request.
-     * @return A new {@link BlockMover} for this type of movable.
+     * @return A new {@link Animator} for this type of movable.
      */
     protected abstract IAnimationComponent constructAnimationComponent(MovementRequestData data)
         throws Exception;

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
@@ -312,8 +312,7 @@ public abstract class AbstractMovable implements IMovable
      *     The data for the toggle request.
      * @return A new {@link Animator} for this type of movable.
      */
-    protected abstract IAnimationComponent constructAnimationComponent(MovementRequestData data)
-        throws Exception;
+    protected abstract IAnimationComponent constructAnimationComponent(MovementRequestData data);
 
     /**
      * Attempts to toggle a movable. Think twice before using this method. Instead, please look at

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
@@ -124,7 +124,7 @@ public final class MovableOpeningHelper
      *     Who is responsible for the action.
      * @return The result.
      */
-    MovableToggleResult abort(
+    private MovableToggleResult abort(
         AbstractMovable movable, MovableToggleResult result, MovableActionCause cause, IPPlayer responsible,
         IMessageable messageReceiver)
     {
@@ -164,7 +164,7 @@ public final class MovableOpeningHelper
      * {@link IBigDoorsEventFactory#createTogglePrepareEvent(MovableSnapshot, MovableActionCause, MovableActionType,
      * IPPlayer, double, boolean, Cuboid)}.
      */
-    IMovableEventTogglePrepare callTogglePrepareEvent(
+    private IMovableEventTogglePrepare callTogglePrepareEvent(
         MovableSnapshot snapshot, MovableActionCause cause, MovableActionType actionType, IPPlayer responsible,
         double time, boolean skipAnimation, Cuboid newCuboid)
     {
@@ -180,7 +180,7 @@ public final class MovableOpeningHelper
      * {@link IBigDoorsEventFactory#createTogglePrepareEvent(MovableSnapshot, MovableActionCause, MovableActionType,
      * IPPlayer, double, boolean, Cuboid)}.
      */
-    IMovableEventTogglePrepare callTogglePrepareEvent(MovementRequestData data)
+    private IMovableEventTogglePrepare callTogglePrepareEvent(MovementRequestData data)
     {
         return callTogglePrepareEvent(
             data.getSnapshotOfMovable(),
@@ -197,7 +197,7 @@ public final class MovableOpeningHelper
      * {@link IBigDoorsEventFactory#createToggleStartEvent(AbstractMovable, MovableSnapshot, MovableActionCause,
      * MovableActionType, IPPlayer, double, boolean, Cuboid)}.
      */
-    IMovableEventToggleStart callToggleStartEvent(
+    private IMovableEventToggleStart callToggleStartEvent(
         AbstractMovable movable, MovableSnapshot snapshot, MovableActionCause cause, MovableActionType actionType,
         IPPlayer responsible, double time, boolean skipAnimation, Cuboid newCuboid)
     {
@@ -213,7 +213,7 @@ public final class MovableOpeningHelper
      * {@link IBigDoorsEventFactory#createToggleStartEvent(AbstractMovable, MovableSnapshot, MovableActionCause,
      * MovableActionType, IPPlayer, double, boolean, Cuboid)}.
      */
-    IMovableEventToggleStart callToggleStartEvent(AbstractMovable movable, MovementRequestData data)
+    private IMovableEventToggleStart callToggleStartEvent(AbstractMovable movable, MovementRequestData data)
     {
         return callToggleStartEvent(
             movable,
@@ -234,21 +234,23 @@ public final class MovableOpeningHelper
     /**
      * Registers a new block mover. Must be called from the main thread.
      */
-    boolean registerBlockMover(AbstractMovable movable, IAnimationComponent component, MovementRequestData data)
+    private boolean registerBlockMover(
+        AbstractMovable movable, IAnimationComponent component, MovementRequestData data, @Nullable IPPlayer player)
     {
-        return registerBlockMover(movable, data, component, AnimationType.MOVE_BLOCKS);
+        return registerBlockMover(movable, data, component, player, AnimationType.MOVE_BLOCKS);
     }
 
     /**
      * Registers a new block mover. Must be called from the main thread.
      */
-    boolean registerBlockMover(
-        AbstractMovable movable, MovementRequestData data, IAnimationComponent component, AnimationType animationType)
+    private boolean registerBlockMover(
+        AbstractMovable movable, MovementRequestData data, IAnimationComponent component, @Nullable IPPlayer player,
+        AnimationType animationType)
     {
         try
         {
             final IAnimationBlockManager animationBlockManager =
-                animationBlockManagerFactory.newManager(animationType, null);
+                animationBlockManagerFactory.newManager(animationType, player);
 
             final Animator blockMover =
                 new Animator(movable, data, component, animationBlockManager, animationType.affectsWorld());
@@ -266,7 +268,7 @@ public final class MovableOpeningHelper
 
     private MovableToggleResult toggle(
         MovableSnapshot snapshot, AbstractMovable targetMovable, MovementRequestData data,
-        IAnimationComponent component, IMessageable messageReceiver)
+        IAnimationComponent component, IMessageable messageReceiver, @Nullable IPPlayer player)
     {
         if (snapshot.getOpenDir() == MovementDirection.NONE)
         {
@@ -299,7 +301,7 @@ public final class MovableOpeningHelper
             return abort(targetMovable, MovableToggleResult.NO_PERMISSION, data.getCause(), data.getResponsible(),
                          messageReceiver);
 
-        final boolean scheduled = registerBlockMover(targetMovable, component, data);
+        final boolean scheduled = registerBlockMover(targetMovable, component, data, player);
         if (!scheduled)
             return MovableToggleResult.ERROR;
 
@@ -342,7 +344,7 @@ public final class MovableOpeningHelper
         {
             movable.getLock().readLock().unlock();
         }
-        return toggle(snapshot, movable, data, component, messageReceiver);
+        return toggle(snapshot, movable, data, component, messageReceiver, responsible);
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
@@ -238,7 +238,7 @@ public final class MovableOpeningHelper
         {
             final IAnimationComponent component = movable.constructAnimationComponent(data);
             final AnimationBlockManager animationBlockManager = animationBlockManagerFactory.newManager();
-            final Animator blockMover = new Animator(movable, data, component, animationBlockManager);
+            final Animator blockMover = new Animator(movable, data, component, animationBlockManager, true);
 
             movableActivityManager.addBlockMover(blockMover);
             executor.runOnMainThread(blockMover::startAnimation);

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
@@ -26,7 +26,8 @@ import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.LimitsManager;
 import nl.pim16aap2.bigdoors.managers.MovableTypeManager;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.AnimationBlockManager;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovableActivityManager;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -66,6 +67,7 @@ public final class MovableOpeningHelper
     private final IChunkLoader chunkLoader;
     private final LimitsManager limitsManager;
     private final IBigDoorsEventCaller bigDoorsEventCaller;
+    private final AnimationBlockManager.IFactory animationBlockManagerFactory;
     private final MovementRequestData.IFactory movementRequestDataFactory;
 
     @Inject //
@@ -85,6 +87,7 @@ public final class MovableOpeningHelper
         IChunkLoader chunkLoader,
         LimitsManager limitsManager,
         IBigDoorsEventCaller bigDoorsEventCaller,
+        AnimationBlockManager.IFactory animationBlockManagerFactory,
         MovementRequestData.IFactory movementRequestDataFactory)
     {
         this.localizer = localizer;
@@ -102,6 +105,7 @@ public final class MovableOpeningHelper
         this.chunkLoader = chunkLoader;
         this.limitsManager = limitsManager;
         this.bigDoorsEventCaller = bigDoorsEventCaller;
+        this.animationBlockManagerFactory = animationBlockManagerFactory;
         this.movementRequestDataFactory = movementRequestDataFactory;
     }
 
@@ -233,7 +237,8 @@ public final class MovableOpeningHelper
         try
         {
             final IAnimationComponent component = movable.constructAnimationComponent(data);
-            final BlockMover blockMover = new BlockMover(movable, data, component);
+            final AnimationBlockManager animationBlockManager = animationBlockManagerFactory.newManager();
+            final Animator blockMover = new Animator(movable, data, component, animationBlockManager);
 
             movableActivityManager.addBlockMover(blockMover);
             executor.runOnMainThread(blockMover::startAnimation);
@@ -577,12 +582,11 @@ public final class MovableOpeningHelper
     }
 
     /**
-     * Checks if a {@link BlockMover} of a {@link IMovable} has been registered with the {@link DatabaseManager}.
+     * Checks if a {@link Animator} of a {@link IMovable} has been registered with the {@link DatabaseManager}.
      *
      * @param movableUID
      *     The UID of the {@link IMovable}.
-     * @return True if a {@link BlockMover} has been registered with the {@link DatabaseManager} for the
-     * {@link IMovable}.
+     * @return True if a {@link Animator} has been registered with the {@link DatabaseManager} for the {@link IMovable}.
      */
     @SuppressWarnings("unused")
     public boolean isBlockMoverRegistered(long movableUID)
@@ -591,13 +595,13 @@ public final class MovableOpeningHelper
     }
 
     /**
-     * Gets the {@link BlockMover} of a {@link IMovable} if it has been registered with the {@link DatabaseManager}.
+     * Gets the {@link Animator} of a {@link IMovable} if it has been registered with the {@link DatabaseManager}.
      *
      * @param movableUID
      *     The UID of the {@link IMovable}.
-     * @return The {@link BlockMover} of a {@link IMovable} if it has been registered with the {@link DatabaseManager}.
+     * @return The {@link Animator} of a {@link IMovable} if it has been registered with the {@link DatabaseManager}.
      */
-    public Optional<BlockMover> getBlockMover(long movableUID)
+    public Optional<Animator> getBlockMover(long movableUID)
     {
         return movableActivityManager.getBlockMover(movableUID);
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
@@ -27,6 +27,7 @@ import nl.pim16aap2.bigdoors.managers.LimitsManager;
 import nl.pim16aap2.bigdoors.managers.MovableTypeManager;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationBlockManager;
+import nl.pim16aap2.bigdoors.moveblocks.AnimationType;
 import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovableActivityManager;
@@ -234,11 +235,20 @@ public final class MovableOpeningHelper
      */
     boolean registerBlockMover(AbstractMovable movable, MovementRequestData data)
     {
+        return registerBlockMover(movable, data, AnimationType.MOVE_BLOCKS);
+    }
+
+    /**
+     * Registers a new block mover. Must be called from the main thread.
+     */
+    boolean registerBlockMover(AbstractMovable movable, MovementRequestData data, AnimationType animationType)
+    {
         try
         {
             final IAnimationComponent component = movable.constructAnimationComponent(data);
             final AnimationBlockManager animationBlockManager = animationBlockManagerFactory.newManager();
-            final Animator blockMover = new Animator(movable, data, component, animationBlockManager, true);
+            final Animator blockMover =
+                new Animator(movable, data, component, animationBlockManager, animationType.affectsWorld());
 
             movableActivityManager.addBlockMover(blockMover);
             executor.runOnMainThread(blockMover::startAnimation);

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
@@ -244,7 +244,7 @@ public final class MovableOpeningHelper
                 animationBlockManagerFactory.newManager(animationType, player);
 
             final Animator blockMover =
-                new Animator(movable, data, component, animationBlockManager, animationType.affectsWorld());
+                new Animator(movable, data, component, animationBlockManager);
 
             movableActivityManager.addBlockMover(blockMover);
             executor.runOnMainThread(blockMover::startAnimation);
@@ -332,7 +332,7 @@ public final class MovableOpeningHelper
 
             data = movementRequestDataFactory.newToggleRequestData(
                 snapshot, request.getCause(), animationTime, request.isSkipAnimation(), newCuboid.get(), responsible,
-                request.getActionType());
+                request.getAnimationType(), request.getActionType());
             component = movable.constructAnimationComponent(data);
         }
         finally

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
@@ -247,7 +247,9 @@ public final class MovableOpeningHelper
     {
         try
         {
-            final IAnimationBlockManager animationBlockManager = animationBlockManagerFactory.newManager(animationType);
+            final IAnimationBlockManager animationBlockManager =
+                animationBlockManagerFactory.newManager(animationType, null);
+
             final Animator blockMover =
                 new Animator(movable, data, component, animationBlockManager, animationType.affectsWorld());
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableToggleRequestBuilder.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableToggleRequestBuilder.java
@@ -8,6 +8,7 @@ import nl.pim16aap2.bigdoors.api.PPlayerData;
 import nl.pim16aap2.bigdoors.api.factories.IPPlayerFactory;
 import nl.pim16aap2.bigdoors.events.movableaction.MovableActionCause;
 import nl.pim16aap2.bigdoors.events.movableaction.MovableActionType;
+import nl.pim16aap2.bigdoors.moveblocks.AnimationType;
 import nl.pim16aap2.bigdoors.util.Util;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetrieverFactory;
@@ -66,6 +67,7 @@ public class MovableToggleRequestBuilder
         private @Nullable IMessageable messageReceiver = null;
         private @Nullable IPPlayer responsible = null;
         private @Nullable Double time = null;
+        private @Nullable AnimationType animationType = null;
         private boolean skipAnimation = false;
 
         @Override
@@ -149,12 +151,21 @@ public class MovableToggleRequestBuilder
         }
 
         @Override
+        public IBuilder animationType(AnimationType animationType)
+        {
+            this.animationType = animationType;
+            return this;
+        }
+
+        @Override
         public MovableToggleRequest build()
         {
             updateMessageReceiver();
-            return movableToggleRequestFactory.create(movableRetriever, movableActionCause,
-                                                      Util.requireNonNull(messageReceiver, "MessageReceiver"),
-                                                      responsible, time, skipAnimation, movableActionType);
+            return movableToggleRequestFactory.create(
+                movableRetriever, movableActionCause,
+                Util.requireNonNull(messageReceiver, "MessageReceiver"),
+                responsible, time, skipAnimation, movableActionType,
+                Objects.requireNonNullElse(animationType, AnimationType.MOVE_BLOCKS));
         }
 
         /**
@@ -259,6 +270,15 @@ public class MovableToggleRequestBuilder
          * Sets the server to be the message receiver.
          */
         IBuilder messageReceiverServer();
+
+        /**
+         * Sets the animation type of the animation. Defaults to {@link AnimationType#MOVE_BLOCKS}.
+         *
+         * @param animationType
+         *     The animation type to apply.
+         * @return The next step of the guided builder process.
+         */
+        IBuilder animationType(AnimationType animationType);
 
         /**
          * Constructs the new movable toggle request.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimatedPreviewBlock.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimatedPreviewBlock.java
@@ -9,6 +9,8 @@ import nl.pim16aap2.bigdoors.api.PColor;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlockData;
 import nl.pim16aap2.bigdoors.api.factories.IPLocationFactory;
+import nl.pim16aap2.bigdoors.util.MovementDirection;
+import nl.pim16aap2.bigdoors.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 
 import java.time.Duration;
@@ -19,6 +21,8 @@ public class AnimatedPreviewBlock implements IAnimatedBlock
      * We do not want to move this type every tick, so we only update it once in every MOVEMENT_RATE ticks.
      */
     private static final int MOVEMENT_RATE = 5;
+
+    private static final IAnimatedBlockData ANIMATED_BLOCK_DATA = new PreviewAnimatedBlockData();
 
     private int movementTicks = -1;
     private final IPLocationFactory locationFactory;
@@ -66,8 +70,7 @@ public class AnimatedPreviewBlock implements IAnimatedBlock
     @Override
     public IAnimatedBlockData getAnimatedBlockData()
     {
-        // TODO: Implement this
-        return null;
+        return ANIMATED_BLOCK_DATA;
     }
 
     @Override
@@ -105,6 +108,8 @@ public class AnimatedPreviewBlock implements IAnimatedBlock
     {
         if (++movementTicks % MOVEMENT_RATE != 0)
             return;
+
+        cycleTargets(target);
 
         glowingBlockSpawner
             .builder()
@@ -145,7 +150,7 @@ public class AnimatedPreviewBlock implements IAnimatedBlock
     @Override
     public int getTicksLived()
     {
-        return 0;
+        return movementTicks;
     }
 
     @Override
@@ -194,5 +199,30 @@ public class AnimatedPreviewBlock implements IAnimatedBlock
     public boolean isOnEdge()
     {
         return false;
+    }
+
+    private static final class PreviewAnimatedBlockData implements IAnimatedBlockData
+    {
+        @Override
+        public boolean canRotate()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean rotateBlock(MovementDirection movementDirection)
+        {
+            return false;
+        }
+
+        @Override
+        public void putBlock(IVector3D loc)
+        {
+        }
+
+        @Override
+        public void deleteOriginalBlock(boolean applyPhysics)
+        {
+        }
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimatedPreviewBlock.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimatedPreviewBlock.java
@@ -15,6 +15,12 @@ import java.time.Duration;
 
 public class AnimatedPreviewBlock implements IAnimatedBlock
 {
+    /**
+     * We do not want to move this type every tick, so we only update it once in every MOVEMENT_RATE ticks.
+     */
+    private static final int MOVEMENT_RATE = 5;
+
+    private int movementTicks = -1;
     private final IPLocationFactory locationFactory;
     private final GlowingBlockSpawner glowingBlockSpawner;
     @Getter
@@ -60,6 +66,7 @@ public class AnimatedPreviewBlock implements IAnimatedBlock
     @Override
     public IAnimatedBlockData getAnimatedBlockData()
     {
+        // TODO: Implement this
         return null;
     }
 
@@ -96,10 +103,13 @@ public class AnimatedPreviewBlock implements IAnimatedBlock
     @Override
     public void moveToTarget(Vector3Dd target, int ticksRemaining)
     {
+        if (++movementTicks % MOVEMENT_RATE != 0)
+            return;
+
         glowingBlockSpawner
             .builder()
             .forPlayer(player)
-            .forDuration(Duration.ofSeconds(1))
+            .forDuration(Duration.ofMillis(500))
             .inWorld(world)
             .atPosition(target)
             .withColor(color)

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimatedPreviewBlock.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimatedPreviewBlock.java
@@ -1,0 +1,188 @@
+package nl.pim16aap2.bigdoors.moveblocks;
+
+import lombok.Getter;
+import nl.pim16aap2.bigdoors.api.GlowingBlockSpawner;
+import nl.pim16aap2.bigdoors.api.IPLocation;
+import nl.pim16aap2.bigdoors.api.IPPlayer;
+import nl.pim16aap2.bigdoors.api.IPWorld;
+import nl.pim16aap2.bigdoors.api.PColor;
+import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlockData;
+import nl.pim16aap2.bigdoors.api.factories.IPLocationFactory;
+import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
+
+import java.time.Duration;
+
+public class AnimatedPreviewBlock implements IAnimatedBlock
+{
+    private final IPLocationFactory locationFactory;
+    private final GlowingBlockSpawner glowingBlockSpawner;
+    @Getter
+    private final IPWorld world;
+    private final float startAngle;
+    private final float startRadius;
+    private final PColor color;
+    private final IPPlayer player;
+    private final Vector3Dd startPosition;
+    private final Vector3Dd finalPosition;
+
+    private volatile Vector3Dd previousTarget;
+    private volatile Vector3Dd currentTarget;
+
+    public AnimatedPreviewBlock(
+        IPLocationFactory locationFactory, GlowingBlockSpawner glowingBlockSpawner, IPWorld world, IPPlayer player,
+        Vector3Dd position, Vector3Dd finalPosition, float startAngle, float startRadius, PColor color)
+    {
+        this.locationFactory = locationFactory;
+        this.glowingBlockSpawner = glowingBlockSpawner;
+        this.world = world;
+        this.player = player;
+        this.startPosition = position;
+        this.finalPosition = finalPosition;
+        this.currentTarget = previousTarget = position;
+        this.startAngle = startAngle;
+        this.startRadius = startRadius;
+        this.color = color;
+    }
+
+    private synchronized void cycleTargets(Vector3Dd newTarget)
+    {
+        previousTarget = currentTarget;
+        currentTarget = newTarget;
+    }
+
+    @Override
+    public boolean isAlive()
+    {
+        return true;
+    }
+
+    @Override
+    public IAnimatedBlockData getAnimatedBlockData()
+    {
+        return null;
+    }
+
+    @Override
+    public synchronized Vector3Dd getCurrentPosition()
+    {
+        return currentTarget;
+    }
+
+    @Override
+    public synchronized Vector3Dd getPreviousPosition()
+    {
+        return previousTarget;
+    }
+
+    @Override
+    public synchronized Vector3Dd getPreviousTarget()
+    {
+        return previousTarget;
+    }
+
+    @Override
+    public IPLocation getPLocation()
+    {
+        return getCurrentPosition().toLocation(locationFactory, getWorld());
+    }
+
+    @Override
+    public synchronized Vector3Dd getPosition()
+    {
+        return currentTarget;
+    }
+
+    @Override
+    public void moveToTarget(Vector3Dd target, int ticksRemaining)
+    {
+        glowingBlockSpawner
+            .builder()
+            .forPlayer(player)
+            .forDuration(Duration.ofSeconds(1))
+            .inWorld(world)
+            .atPosition(target)
+            .withColor(color)
+            .build();
+    }
+
+    @Override
+    public boolean teleport(Vector3Dd newPosition, Vector3Dd rotation, IAnimatedBlock.TeleportMode teleportMode)
+    {
+        return false;
+    }
+
+    @Override
+    public void setVelocity(Vector3Dd vector)
+    {
+    }
+
+    @Override
+    public void spawn()
+    {
+    }
+
+    @Override
+    public void respawn()
+    {
+    }
+
+    @Override
+    public void kill()
+    {
+    }
+
+    @Override
+    public int getTicksLived()
+    {
+        return 0;
+    }
+
+    @Override
+    public Vector3Dd getStartPosition()
+    {
+        return startPosition;
+    }
+
+    @Override
+    public Vector3Dd getFinalPosition()
+    {
+        return finalPosition;
+    }
+
+    @Override
+    public double getStartX()
+    {
+        return startPosition.x();
+    }
+
+    @Override
+    public double getStartY()
+    {
+        return startPosition.y();
+    }
+
+    @Override
+    public double getStartZ()
+    {
+        return startPosition.z();
+    }
+
+    @Override
+    public float getStartAngle()
+    {
+        return startAngle;
+    }
+
+    @Override
+    public float getRadius()
+    {
+        return startRadius;
+    }
+
+    @Override
+    public boolean isOnEdge()
+    {
+        return false;
+    }
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationBlockManager.java
@@ -1,7 +1,5 @@
 package nl.pim16aap2.bigdoors.moveblocks;
 
-import dagger.assisted.AssistedFactory;
-import dagger.assisted.AssistedInject;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -42,7 +40,7 @@ public class AnimationBlockManager implements IAnimationBlockManager
     @ToString.Include @EqualsAndHashCode.Include
     private final List<IAnimatedBlock> animatedBlocks;
 
-    @AssistedInject AnimationBlockManager(
+    AnimationBlockManager(
         IPLocationFactory locationFactory, IAnimatedBlockFactory animatedBlockFactory, IPExecutor executor)
     {
         this.locationFactory = locationFactory;
@@ -169,11 +167,5 @@ public class AnimationBlockManager implements IAnimationBlockManager
             animatedBlock.getAnimatedBlockData().putBlock(animatedBlock.getFinalPosition());
         }
         privateAnimatedBlocks.clear();
-    }
-
-    @AssistedFactory
-    public interface IFactory
-    {
-        AnimationBlockManager newManager();
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationBlockManager.java
@@ -1,0 +1,179 @@
+package nl.pim16aap2.bigdoors.moveblocks;
+
+import dagger.assisted.AssistedFactory;
+import dagger.assisted.AssistedInject;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.bigdoors.api.IPExecutor;
+import nl.pim16aap2.bigdoors.api.IPLocation;
+import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
+import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.api.factories.IAnimatedBlockFactory;
+import nl.pim16aap2.bigdoors.api.factories.IPLocationFactory;
+import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
+import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
+import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Flogger
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ToString(onlyExplicitlyIncluded = true)
+public class AnimationBlockManager implements IAnimationBlockManager
+{
+    private final IPLocationFactory locationFactory;
+    private final IAnimatedBlockFactory animatedBlockFactory;
+    private final IPExecutor executor;
+
+    /**
+     * The modifiable list of animated blocks.
+     */
+    private final List<IAnimatedBlock> privateAnimatedBlocks;
+
+    /**
+     * The (unmodifiable) list of animated blocks.
+     */
+    @Getter
+    @ToString.Include @EqualsAndHashCode.Include
+    private final List<IAnimatedBlock> animatedBlocks;
+
+    @AssistedInject AnimationBlockManager(
+        IPLocationFactory locationFactory, IAnimatedBlockFactory animatedBlockFactory, IPExecutor executor)
+    {
+        this.locationFactory = locationFactory;
+        this.animatedBlockFactory = animatedBlockFactory;
+        this.executor = executor;
+
+        privateAnimatedBlocks = new CopyOnWriteArrayList<>();
+        animatedBlocks = Collections.unmodifiableList(privateAnimatedBlocks);
+    }
+
+    @Override
+    public boolean createAnimatedBlocks(
+        MovableSnapshot snapshot, IAnimationComponent animationComponent, AnimationContext animationContext,
+        Animator.MovementMethod movementMethod)
+    {
+        final List<IAnimatedBlock> animatedBlocksTmp = new ArrayList<>(snapshot.getBlockCount());
+
+        try
+        {
+            final int xMin = snapshot.getCuboid().getMin().x();
+            final int yMin = snapshot.getCuboid().getMin().y();
+            final int zMin = snapshot.getCuboid().getMin().z();
+
+            final int xMax = snapshot.getCuboid().getMax().x();
+            final int yMax = snapshot.getCuboid().getMax().y();
+            final int zMax = snapshot.getCuboid().getMax().z();
+
+            for (int xAxis = xMin; xAxis <= xMax; ++xAxis)
+                for (int yAxis = yMax; yAxis >= yMin; --yAxis)
+                    for (int zAxis = zMin; zAxis <= zMax; ++zAxis)
+                    {
+                        final boolean onEdge =
+                            xAxis == xMin || xAxis == xMax ||
+                                yAxis == yMin || yAxis == yMax ||
+                                zAxis == zMin || zAxis == zMax;
+
+                        final IPLocation location =
+                            locationFactory.create(snapshot.getWorld(), xAxis + 0.5, yAxis, zAxis + 0.5);
+                        final boolean bottom = (yAxis == yMin);
+                        final float radius = animationComponent.getRadius(xAxis, yAxis, zAxis);
+                        final float startAngle = animationComponent.getStartAngle(xAxis, yAxis, zAxis);
+                        final Vector3Dd startPosition = new Vector3Dd(xAxis + 0.5, yAxis, zAxis + 0.5);
+                        final Vector3Dd finalPosition = animationComponent.getFinalPosition(startPosition, radius);
+
+                        animatedBlockFactory
+                            .create(location, radius, startAngle, bottom, onEdge, animationContext, finalPosition,
+                                    movementMethod)
+                            .ifPresent(animatedBlocksTmp::add);
+                    }
+
+            tryRemoveOriginalBlocks(animatedBlocksTmp, false);
+            tryRemoveOriginalBlocks(animatedBlocksTmp, true);
+        }
+        catch (Exception e)
+        {
+            log.atSevere().withCause(e).log();
+            this.privateAnimatedBlocks.addAll(animatedBlocksTmp);
+            return false;
+        }
+
+        this.privateAnimatedBlocks.addAll(animatedBlocksTmp);
+        return true;
+    }
+
+    /**
+     * Tries to remove the original blocks of a list of animated blocks.
+     *
+     * @param animatedBlocks
+     *     The animated blocks to process.
+     * @param edgePass
+     *     True to do a pass over the edges specifically.
+     * @return True if the original blocks could be spawned. If something went wrong and the process had to be aborted,
+     * false is returned instead.
+     */
+    private void tryRemoveOriginalBlocks(List<IAnimatedBlock> animatedBlocks, boolean edgePass)
+    {
+        executor.assertMainThread("Blocks must be removed on the main thread!");
+
+        for (final IAnimatedBlock animatedBlock : animatedBlocks)
+        {
+            if (edgePass && !animatedBlock.isOnEdge())
+                continue;
+            animatedBlock.getAnimatedBlockData().deleteOriginalBlock(edgePass);
+        }
+    }
+
+    @Override
+    public void restoreBlocksOnFailure()
+    {
+        executor.assertMainThread("Blocks cannot be placed asynchronously!");
+        for (final IAnimatedBlock animatedBlock : getAnimatedBlocks())
+        {
+            try
+            {
+                animatedBlock.kill();
+            }
+            catch (Exception e)
+            {
+                log.atSevere().withCause(e).log("Failed to kill animated block: %s", animatedBlock);
+            }
+            try
+            {
+                final Vector3Dd startPos = animatedBlock.getStartPosition();
+                final Vector3Di goalPos = new Vector3Di((int) startPos.x(),
+                                                        (int) Math.round(startPos.y()),
+                                                        (int) startPos.z());
+                animatedBlock.getAnimatedBlockData().putBlock(goalPos);
+            }
+            catch (Exception e)
+            {
+                log.atSevere().withCause(e).log("Failed to restore block: %s", animatedBlock);
+            }
+        }
+        privateAnimatedBlocks.clear();
+    }
+
+    @Override
+    public void handleAnimationCompletion()
+    {
+        executor.assertMainThread("Blocks cannot be placed asynchronously!");
+        for (final IAnimatedBlock animatedBlock : privateAnimatedBlocks)
+        {
+            animatedBlock.kill();
+            animatedBlock.getAnimatedBlockData().putBlock(animatedBlock.getFinalPosition());
+        }
+        privateAnimatedBlocks.clear();
+    }
+
+    @AssistedFactory
+    public interface IFactory
+    {
+        AnimationBlockManager newManager();
+    }
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationBlockManagerFactory.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationBlockManagerFactory.java
@@ -1,0 +1,45 @@
+package nl.pim16aap2.bigdoors.moveblocks;
+
+import nl.pim16aap2.bigdoors.api.IPExecutor;
+import nl.pim16aap2.bigdoors.api.factories.IAnimatedBlockFactory;
+import nl.pim16aap2.bigdoors.api.factories.IPLocationFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class AnimationBlockManagerFactory
+{
+    private final IPLocationFactory locationFactory;
+    private final IAnimatedBlockFactory animatedBlockFactory;
+    private final IPExecutor executor;
+
+    @Inject AnimationBlockManagerFactory(
+        IPLocationFactory locationFactory,
+        IAnimatedBlockFactory animatedBlockFactory,
+        IPExecutor executor)
+    {
+        this.locationFactory = locationFactory;
+        this.animatedBlockFactory = animatedBlockFactory;
+        this.executor = executor;
+    }
+
+    public IAnimationBlockManager newManager(AnimationType animationType)
+    {
+        return switch (animationType)
+            {
+                case MOVE_BLOCKS -> newMoveBlockManager();
+                case PREVIEW -> newPreviewBlockManager();
+            };
+    }
+
+    private IAnimationBlockManager newPreviewBlockManager()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    private IAnimationBlockManager newMoveBlockManager()
+    {
+        return new AnimationBlockManager(locationFactory, animatedBlockFactory, executor);
+    }
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationBlockManagerFactory.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationBlockManagerFactory.java
@@ -1,8 +1,12 @@
 package nl.pim16aap2.bigdoors.moveblocks;
 
+import nl.pim16aap2.bigdoors.api.GlowingBlockSpawner;
 import nl.pim16aap2.bigdoors.api.IPExecutor;
+import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.api.factories.IAnimatedBlockFactory;
 import nl.pim16aap2.bigdoors.api.factories.IPLocationFactory;
+import nl.pim16aap2.bigdoors.util.Util;
+import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -13,29 +17,32 @@ public class AnimationBlockManagerFactory
     private final IPLocationFactory locationFactory;
     private final IAnimatedBlockFactory animatedBlockFactory;
     private final IPExecutor executor;
+    private final GlowingBlockSpawner glowingBlockSpawner;
 
     @Inject AnimationBlockManagerFactory(
         IPLocationFactory locationFactory,
         IAnimatedBlockFactory animatedBlockFactory,
-        IPExecutor executor)
+        IPExecutor executor, GlowingBlockSpawner glowingBlockSpawner)
     {
         this.locationFactory = locationFactory;
         this.animatedBlockFactory = animatedBlockFactory;
         this.executor = executor;
+        this.glowingBlockSpawner = glowingBlockSpawner;
     }
 
-    public IAnimationBlockManager newManager(AnimationType animationType)
+    public IAnimationBlockManager newManager(AnimationType animationType, @Nullable IPPlayer player)
     {
         return switch (animationType)
             {
                 case MOVE_BLOCKS -> newMoveBlockManager();
-                case PREVIEW -> newPreviewBlockManager();
+                case PREVIEW -> newPreviewBlockManager(player);
             };
     }
 
-    private IAnimationBlockManager newPreviewBlockManager()
+    private IAnimationBlockManager newPreviewBlockManager(@Nullable IPPlayer player)
     {
-        throw new UnsupportedOperationException();
+        return new AnimationPreviewBlockManager(
+            locationFactory, glowingBlockSpawner, Util.requireNonNull(player, "Player for preview blocks"));
     }
 
     private IAnimationBlockManager newMoveBlockManager()

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationPreviewBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationPreviewBlockManager.java
@@ -74,6 +74,9 @@ public class AnimationPreviewBlockManager implements IAnimationBlockManager
                 for (int yAxis = yMax; yAxis >= yMin; --yAxis)
                     for (int zAxis = zMin; zAxis <= zMax; ++zAxis)
                     {
+                        if ((xAxis + yAxis + zAxis) % 2 == 0)
+                            continue;
+
                         final Vector3Di position = new Vector3Di(xAxis, yAxis, zAxis);
 
                         final float radius = animationComponent.getRadius(xAxis, yAxis, zAxis);

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationPreviewBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationPreviewBlockManager.java
@@ -1,0 +1,107 @@
+package nl.pim16aap2.bigdoors.moveblocks;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.bigdoors.api.GlowingBlockSpawner;
+import nl.pim16aap2.bigdoors.api.IPPlayer;
+import nl.pim16aap2.bigdoors.api.PColor;
+import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
+import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.api.factories.IPLocationFactory;
+import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
+import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Flogger
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ToString(onlyExplicitlyIncluded = true)
+public class AnimationPreviewBlockManager implements IAnimationBlockManager
+{
+    private final IPLocationFactory locationFactory;
+    private final GlowingBlockSpawner glowingBlockSpawner;
+    private final IPPlayer player;
+
+    /**
+     * The modifiable list of animated blocks.
+     */
+    private final List<IAnimatedBlock> privateAnimatedBlocks;
+
+    /**
+     * The (unmodifiable) list of animated blocks.
+     */
+    @Getter
+    @ToString.Include @EqualsAndHashCode.Include
+    private final List<IAnimatedBlock> animatedBlocks;
+
+    AnimationPreviewBlockManager(
+        IPLocationFactory locationFactory, GlowingBlockSpawner glowingBlockSpawner, IPPlayer player)
+    {
+        this.locationFactory = locationFactory;
+        this.glowingBlockSpawner = glowingBlockSpawner;
+        this.player = player;
+
+        privateAnimatedBlocks = new CopyOnWriteArrayList<>();
+        animatedBlocks = Collections.unmodifiableList(privateAnimatedBlocks);
+    }
+
+    @Override
+    public boolean createAnimatedBlocks(
+        MovableSnapshot snapshot, IAnimationComponent animationComponent, AnimationContext animationContext,
+        Animator.MovementMethod movementMethod)
+    {
+        final List<IAnimatedBlock> animatedBlocksTmp = new ArrayList<>(snapshot.getBlockCount());
+
+        try
+        {
+            final int xMin = snapshot.getCuboid().getMin().x();
+            final int yMin = snapshot.getCuboid().getMin().y();
+            final int zMin = snapshot.getCuboid().getMin().z();
+
+            final int xMax = snapshot.getCuboid().getMax().x();
+            final int yMax = snapshot.getCuboid().getMax().y();
+            final int zMax = snapshot.getCuboid().getMax().z();
+
+            for (int xAxis = xMin; xAxis <= xMax; ++xAxis)
+                for (int yAxis = yMax; yAxis >= yMin; --yAxis)
+                    for (int zAxis = zMin; zAxis <= zMax; ++zAxis)
+                    {
+                        final float radius = animationComponent.getRadius(xAxis, yAxis, zAxis);
+                        final float startAngle = animationComponent.getStartAngle(xAxis, yAxis, zAxis);
+                        final Vector3Dd startPosition = new Vector3Dd(xAxis + 0.5, yAxis, zAxis + 0.5);
+                        final Vector3Dd finalPosition = animationComponent.getFinalPosition(startPosition, radius);
+
+                        animatedBlocksTmp.add(
+                            new AnimatedPreviewBlock(
+                                locationFactory, glowingBlockSpawner, snapshot.getWorld(), player, startPosition,
+                                finalPosition, startAngle, radius, PColor.AQUA));
+                    }
+        }
+        catch (Exception e)
+        {
+            log.atSevere().withCause(e).log();
+            this.privateAnimatedBlocks.addAll(animatedBlocksTmp);
+            return false;
+        }
+
+        this.privateAnimatedBlocks.addAll(animatedBlocksTmp);
+        return true;
+    }
+
+    @Override
+    public void restoreBlocksOnFailure()
+    {
+        // No need to do anything; just wait a sec.
+    }
+
+    @Override
+    public void handleAnimationCompletion()
+    {
+        // No need to do anything; just wait a sec.
+    }
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationPreviewBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationPreviewBlockManager.java
@@ -11,7 +11,9 @@ import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.api.factories.IPLocationFactory;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
+import nl.pim16aap2.bigdoors.util.Cuboid;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
+import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,27 +61,31 @@ public class AnimationPreviewBlockManager implements IAnimationBlockManager
 
         try
         {
-            final int xMin = snapshot.getCuboid().getMin().x();
-            final int yMin = snapshot.getCuboid().getMin().y();
-            final int zMin = snapshot.getCuboid().getMin().z();
+            final Cuboid cuboid = snapshot.getCuboid();
+            final int xMin = cuboid.getMin().x();
+            final int yMin = cuboid.getMin().y();
+            final int zMin = cuboid.getMin().z();
 
-            final int xMax = snapshot.getCuboid().getMax().x();
-            final int yMax = snapshot.getCuboid().getMax().y();
-            final int zMax = snapshot.getCuboid().getMax().z();
+            final int xMax = cuboid.getMax().x();
+            final int yMax = cuboid.getMax().y();
+            final int zMax = cuboid.getMax().z();
 
             for (int xAxis = xMin; xAxis <= xMax; ++xAxis)
                 for (int yAxis = yMax; yAxis >= yMin; --yAxis)
                     for (int zAxis = zMin; zAxis <= zMax; ++zAxis)
                     {
+                        final Vector3Di position = new Vector3Di(xAxis, yAxis, zAxis);
+
                         final float radius = animationComponent.getRadius(xAxis, yAxis, zAxis);
                         final float startAngle = animationComponent.getStartAngle(xAxis, yAxis, zAxis);
+                        final PColor color = getColor(cuboid, position);
                         final Vector3Dd startPosition = new Vector3Dd(xAxis + 0.5, yAxis, zAxis + 0.5);
                         final Vector3Dd finalPosition = animationComponent.getFinalPosition(startPosition, radius);
 
                         animatedBlocksTmp.add(
                             new AnimatedPreviewBlock(
                                 locationFactory, glowingBlockSpawner, snapshot.getWorld(), player, startPosition,
-                                finalPosition, startAngle, radius, PColor.AQUA));
+                                finalPosition, startAngle, radius, color));
                     }
         }
         catch (Exception e)
@@ -91,6 +97,15 @@ public class AnimationPreviewBlockManager implements IAnimationBlockManager
 
         this.privateAnimatedBlocks.addAll(animatedBlocksTmp);
         return true;
+    }
+
+    private PColor getColor(Cuboid cuboid, Vector3Di position)
+    {
+        if (position.equals(cuboid.getMin()))
+            return PColor.RED;
+        if (position.equals(cuboid.getMax()))
+            return PColor.BLUE;
+        return PColor.AQUA;
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationPreviewBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationPreviewBlockManager.java
@@ -104,8 +104,8 @@ public class AnimationPreviewBlockManager implements IAnimationBlockManager
         if (position.equals(cuboid.getMin()))
             return PColor.RED;
         if (position.equals(cuboid.getMax()))
-            return PColor.BLUE;
-        return PColor.AQUA;
+            return PColor.GREEN;
+        return PColor.BLUE;
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
@@ -1,5 +1,7 @@
 package nl.pim16aap2.bigdoors.moveblocks;
 
+import nl.pim16aap2.bigdoors.api.IPPlayer;
+
 /**
  * Represents several types of animation.
  */
@@ -13,6 +15,8 @@ public enum AnimationType
 
     /**
      * Animates a preview of an animation. No blocks are affected in the world.
+     * <p>
+     * Note that this type requires an online {@link IPPlayer} to target.
      */
     PREVIEW(false),
     ;

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
@@ -18,7 +18,7 @@ public enum AnimationType
      * <p>
      * Note that this type requires an online {@link IPPlayer} to target.
      */
-    PREVIEW(false, false, 3, false),
+    PREVIEW(false, false, 10, false),
     ;
 
     private final boolean affectsWorld;

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
@@ -11,21 +11,25 @@ public enum AnimationType
      * Animates the movement of blocks from their starting position to their final position, which may be somewhere
      * else.
      */
-    MOVE_BLOCKS(true),
+    MOVE_BLOCKS(true, true, Double.MAX_VALUE),
 
     /**
      * Animates a preview of an animation. No blocks are affected in the world.
      * <p>
      * Note that this type requires an online {@link IPPlayer} to target.
      */
-    PREVIEW(false),
+    PREVIEW(false, false, 3),
     ;
 
     private final boolean affectsWorld;
+    private final boolean supportsPerpetualAnimation;
+    private final double animationDurationLimit;
 
-    AnimationType(boolean affectsWorld)
+    AnimationType(boolean affectsWorld, boolean supportsPerpetualAnimation, double animationDurationLimit)
     {
         this.affectsWorld = affectsWorld;
+        this.supportsPerpetualAnimation = supportsPerpetualAnimation;
+        this.animationDurationLimit = animationDurationLimit;
     }
 
     /**
@@ -35,5 +39,15 @@ public enum AnimationType
     public boolean affectsWorld()
     {
         return affectsWorld;
+    }
+
+    public boolean allowsPerpetualAnimation()
+    {
+        return supportsPerpetualAnimation;
+    }
+
+    public double getAnimationDurationLimit()
+    {
+        return animationDurationLimit;
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
@@ -11,25 +11,28 @@ public enum AnimationType
      * Animates the movement of blocks from their starting position to their final position, which may be somewhere
      * else.
      */
-    MOVE_BLOCKS(true, true, Double.MAX_VALUE),
+    MOVE_BLOCKS(true, true, Double.MAX_VALUE, true),
 
     /**
      * Animates a preview of an animation. No blocks are affected in the world.
      * <p>
      * Note that this type requires an online {@link IPPlayer} to target.
      */
-    PREVIEW(false, false, 3),
+    PREVIEW(false, false, 3, false),
     ;
 
     private final boolean affectsWorld;
     private final boolean supportsPerpetualAnimation;
     private final double animationDurationLimit;
+    private final boolean isExclusive;
 
-    AnimationType(boolean affectsWorld, boolean supportsPerpetualAnimation, double animationDurationLimit)
+    AnimationType(
+        boolean affectsWorld, boolean supportsPerpetualAnimation, double animationDurationLimit, boolean isExclusive)
     {
         this.affectsWorld = affectsWorld;
         this.supportsPerpetualAnimation = supportsPerpetualAnimation;
         this.animationDurationLimit = animationDurationLimit;
+        this.isExclusive = isExclusive;
     }
 
     /**
@@ -41,13 +44,32 @@ public enum AnimationType
         return affectsWorld;
     }
 
+    /**
+     * @return True if animations of this type support perpetual animation.
+     */
     public boolean allowsPerpetualAnimation()
     {
         return supportsPerpetualAnimation;
     }
 
+    /**
+     * @return The time limit (in seconds) for an animation of this time. This value is set to {@link Double#MAX_VALUE}
+     * for any type that has no limit.
+     */
     public double getAnimationDurationLimit()
     {
         return animationDurationLimit;
+    }
+
+    /**
+     * @return True if this is an exclusive type of animation.
+     * <p>
+     * Exclusive here means that while an animation of this type is active, no other animation can be activated.
+     * <p>
+     * When false, more than one non-exclusive type of animation can be created.
+     */
+    public boolean isExclusive()
+    {
+        return isExclusive;
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
@@ -1,0 +1,35 @@
+package nl.pim16aap2.bigdoors.moveblocks;
+
+/**
+ * Represents several types of animation.
+ */
+public enum AnimationType
+{
+    /**
+     * Animates the movement of blocks from their starting position to their final position, which may be somewhere
+     * else.
+     */
+    MOVE_BLOCKS(true),
+
+    /**
+     * Animates a preview of an animation. No blocks are affected in the world.
+     */
+    PREVIEW(false),
+    ;
+
+    private final boolean affectsWorld;
+
+    AnimationType(boolean affectsWorld)
+    {
+        this.affectsWorld = affectsWorld;
+    }
+
+    /**
+     * @return Whether this animation affects the world. When true, the coordinates of the movable and the 'isOpen'
+     * status will be updated once the animation has finished.
+     */
+    public boolean affectsWorld()
+    {
+        return affectsWorld;
+    }
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/Animator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/Animator.java
@@ -135,6 +135,9 @@ public final class Animator implements IAnimator
      */
     private final AtomicBoolean hasStarted = new AtomicBoolean(false);
 
+    @Getter
+    private final AnimationType animationType;
+
     private volatile @Nullable List<IAnimationHook<IAnimatedBlock>> hooks;
 
     /**
@@ -165,12 +168,6 @@ public final class Animator implements IAnimator
     private final Cuboid newCuboid;
 
     /**
-     * Whether this animation affects the world. When true, the coordinates of the movable and the 'isOpen' status will
-     * be updated once the animation has finished.
-     */
-    private final boolean affectsWorld;
-
-    /**
      * Constructs a {@link Animator}.
      * <p>
      * Once created, the animation does not start immediately. Use {@link #startAnimation()} to start it.
@@ -183,13 +180,10 @@ public final class Animator implements IAnimator
      *     The animation component to use for the animation. This determines the type of animation.
      * @param animationBlockManager
      *     The manager of the animated blocks. This is responsible for handling the lifecycle of the animated blocks.
-     * @param affectsWorld
-     *     Whether this animation affects the world. When true, the coordinates of the movable and the 'isOpen' status
-     *     will be updated once the animation has finished.
      */
     public Animator(
         AbstractMovable movable, MovementRequestData data, IAnimationComponent animationComponent,
-        IAnimationBlockManager animationBlockManager, boolean affectsWorld)
+        IAnimationBlockManager animationBlockManager)
     {
         executor = data.getExecutor();
         movableActivityManager = data.getMovableActivityManager();
@@ -206,9 +200,9 @@ public final class Animator implements IAnimator
         this.animationComponent = animationComponent;
         this.animationBlockManager = animationBlockManager;
         this.newCuboid = data.getNewCuboid();
-        this.affectsWorld = affectsWorld;
         this.oldCuboid = snapshot.getCuboid();
         this.cause = data.getCause();
+        this.animationType = data.getAnimationType();
         this.actionType = data.getActionType();
         this.perpetualMovement = movable instanceof IPerpetualMover perpetualMover && perpetualMover.isPerpetual();
 
@@ -480,7 +474,7 @@ public final class Animator implements IAnimator
 
         animationBlockManager.handleAnimationCompletion();
 
-        if (affectsWorld)
+        if (animationType.affectsWorld())
             // Tell the movable object it has been opened and what its new coordinates are.
             movable.withWriteLock(this::updateCoords);
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/Animator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/Animator.java
@@ -204,9 +204,22 @@ public final class Animator implements IAnimator
         this.cause = data.getCause();
         this.animationType = data.getAnimationType();
         this.actionType = data.getActionType();
-        this.perpetualMovement = movable instanceof IPerpetualMover perpetualMover && perpetualMover.isPerpetual();
 
-        this.animationDuration = AnimationUtil.getAnimationTicks(data.getAnimationTime(), data.getServerTickTime());
+        // Some animation types may place constraints on the duration of the animation.
+        // When this is the case, we limit the duration here.
+        // The components do not need to take this into account, as they use the duration
+        // to figure out how fast they need to move, which should not change because of a time limit.
+        final double animationTime = Math.min(animationType.getAnimationDurationLimit(), data.getAnimationTime());
+        this.animationDuration = AnimationUtil.getAnimationTicks(animationTime, data.getServerTickTime());
+
+        this.perpetualMovement = isPerpetualMovement();
+    }
+
+    private boolean isPerpetualMovement()
+    {
+        return this.animationType.allowsPerpetualAnimation() &&
+            movable instanceof IPerpetualMover perpetualMover &&
+            perpetualMover.isPerpetual();
     }
 
     public void abort()

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/Animator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/Animator.java
@@ -332,7 +332,7 @@ public final class Animator implements IAnimator
         }
 
         animationBlockManager.restoreBlocksOnFailure();
-        movableActivityManager.processFinishedBlockMover(this);
+        movableActivityManager.processFinishedAnimation(this);
     }
 
     /**
@@ -493,7 +493,7 @@ public final class Animator implements IAnimator
 
         forEachHook("onAnimationCompleted", IAnimationHook::onAnimationCompleted);
 
-        movableActivityManager.processFinishedBlockMover(this);
+        movableActivityManager.processFinishedAnimation(this);
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/IAnimationBlockManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/IAnimationBlockManager.java
@@ -1,0 +1,56 @@
+package nl.pim16aap2.bigdoors.moveblocks;
+
+import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
+import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
+
+import java.util.List;
+
+/**
+ * Represents a manager for animated blocks.
+ * <p>
+ * It is responsible for the creation and cleanup of animated blocks.
+ * <p>
+ * The most common example will be a manager that replaces existing blocks with animated blocks and places them in the
+ * new location after the animation ends.
+ */
+public interface IAnimationBlockManager
+{
+    /**
+     * Attempts to create and spawn the animated blocks for the given input.
+     *
+     * @param snapshot
+     *     The snapshot of the movable to create the animated blocks for.
+     * @param animationComponent
+     *     The animation component to use for retrieving additional information for the animated blocks.
+     * @param animationContext
+     *     The animation context for the animated blocks.
+     * @param movementMethod
+     *     The movement method to use for the animation.
+     * @return The result of the attempted creation of the animated blocks.
+     */
+    boolean createAnimatedBlocks(
+        MovableSnapshot snapshot, IAnimationComponent animationComponent, AnimationContext animationContext,
+        Animator.MovementMethod movementMethod);
+
+    /**
+     * @return All the animated blocks that are part of the animation. In case an error occurred during the creation,
+     * this will contain all the animated blocks that have been created up to the point that the problem occurred.
+     */
+    List<IAnimatedBlock> getAnimatedBlocks();
+
+    /**
+     * Restores all spawned animated blocks to their original positions.
+     * <p>
+     * Should be used in case something failed.
+     */
+    void restoreBlocksOnFailure();
+
+    /**
+     * Handles the blocks when the animation is completed.
+     * <p>
+     * For the most common use-case, this means that the animated blocks will be killed and the blocks they represented
+     * will be placed in their final positions.
+     */
+    void handleAnimationCompletion();
+}

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/IAnimationComponent.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/IAnimationComponent.java
@@ -45,11 +45,11 @@ public interface IAnimationComponent
      * <p>
      * Subclasses are free to override this if a different type of movement is desired for that type.
      * <p>
-     * Each animated block is moved using {@link BlockMover.MovementMethod#apply(IAnimatedBlock, Vector3Dd, int)}.
+     * Each animated block is moved using {@link Animator.MovementMethod#apply(IAnimatedBlock, Vector3Dd, int)}.
      */
-    default BlockMover.MovementMethod getMovementMethod()
+    default Animator.MovementMethod getMovementMethod()
     {
-        return BlockMover.MovementMethod.TELEPORT_VELOCITY;
+        return Animator.MovementMethod.TELEPORT_VELOCITY;
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
@@ -1,5 +1,9 @@
 package nl.pim16aap2.bigdoors.moveblocks;
 
+import com.google.common.flogger.StackSize;
+import com.google.errorprone.annotations.CheckReturnValue;
+import lombok.Getter;
+import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.api.factories.IBigDoorsEventFactory;
 import nl.pim16aap2.bigdoors.api.restartable.Restartable;
 import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
@@ -7,13 +11,21 @@ import nl.pim16aap2.bigdoors.events.IBigDoorsEventCaller;
 import nl.pim16aap2.bigdoors.managers.MovableDeletionManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.IMovableConst;
+import nl.pim16aap2.bigdoors.util.Mutable;
+import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 /**
@@ -22,12 +34,15 @@ import java.util.stream.Stream;
  * @author Pim
  */
 @Singleton
+@Flogger
 public final class MovableActivityManager extends Restartable implements MovableDeletionManager.IDeletionListener
 {
-    private final Map<Long, Optional<Animator>> busyMovables = new ConcurrentHashMap<>();
+    private final Map<Long, RegisteredAnimatorEntry> animators = new ConcurrentHashMap<>();
 
     private final IBigDoorsEventFactory eventFactory;
     private final IBigDoorsEventCaller bigDoorsEventCaller;
+
+    private volatile boolean isActive = false;
 
     /**
      * Constructs a new {@link MovableActivityManager}.
@@ -47,45 +62,104 @@ public final class MovableActivityManager extends Restartable implements Movable
     }
 
     /**
-     * Checks if a {@link AbstractMovable} is 'busy', i.e. currently being animated.
+     * Aborts an animator entry if it exists.
      *
-     * @param movableUID
-     *     The UID of the {@link AbstractMovable}.
-     * @return True if the {@link AbstractMovable} is busy.
+     * @param entryRef
+     *     A reference to an animator entry. The references object may be null, in which case nothing happens.
      */
-    @SuppressWarnings("unused")
-    public boolean isMovableBusy(long movableUID)
+    private void abort(Mutable<@Nullable RegisteredAnimatorEntry> entryRef)
     {
-        return busyMovables.containsKey(movableUID);
+        final @Nullable MovableActivityManager.RegisteredAnimatorEntry entry = entryRef.get();
+        if (entry != null)
+            entry.abort();
     }
 
     /**
-     * Attempts to register a movable (as described by its UID) as busy. If the movable was not previously registered as
-     * busy, it will be registered now and this method will return <code>true</code>. If it was already registered as
-     * busy, it will not touch it and return <code>false</code>.
+     * Attempts to register a new animation.
+     * <p>
+     * The registration attempt returns an optional long. This value is the stamp of the registry. In case the
+     * registered animation is registered with exclusive access, the stamp will be a unique, non-zero value.
+     * <p>
+     * Registrations with non-exclusive access all share a single stamp for all animators for the same movable UID. The
+     * stamp is still unique between each group of animators.
+     * <p>
+     * Once registered, the animator for the animation can be inserted using {@link #addAnimator(long, Animator)}.
      *
-     * @param movableUID
-     *     The UID of the movable to register.
-     * @return True if the movable was not registered before (but is now), otherwise false.
+     * @param uid
+     *     The UID of the movable being animated.
+     * @param exclusive
+     *     True to give the animation exclusive access to the
+     * @return The stamp of the animation entry if it was registered successfully. If the animation could not be
+     * registered, {@link OptionalLong#empty()} is returned.
      */
-    // The busyMovables map stores the values as optional and here we just want to know if a value exists for the key.
-    // If it doesn't, the value will be null, but both IntelliJ and SonarLint will complain about comparing an
-    // optional to null. Because that is _exactly_ what we want to do here, we ignore the warnings.
-    @SuppressWarnings({"OptionalAssignedToNull", "squid:S2789"})
-    public boolean attemptRegisterAsBusy(long movableUID)
+    @CheckReturnValue
+    public OptionalLong registerAnimation(long uid, boolean exclusive)
     {
-        return busyMovables.putIfAbsent(movableUID, Optional.empty()) == null;
+        @SuppressWarnings("NullAway") // NullAway doesn't see the @Nullable here
+        final Mutable<@Nullable RegisteredAnimatorEntry> abortEntryRef = new Mutable<>(null);
+        @SuppressWarnings("NullAway") // Or here
+        final Mutable<@Nullable RegisteredAnimatorEntry> newEntryRef = new Mutable<>(null);
+
+        animators.compute(uid, (key, entry)
+            ->
+        {
+            if (entry == null)
+            {
+                final RegisteredAnimatorEntry newEntry = RegisteredAnimatorEntry.newAnimatorEntry(key, exclusive);
+                newEntryRef.set(newEntry);
+                return newEntry;
+            }
+
+            // If the existing entry is exclusive, we cannot register a new animator.
+            if (entry.isExclusive())
+            {
+                log.atFine().withStackTrace(StackSize.FULL)
+                   .log("Trying to register animator with active exclusive entry: %s", entry);
+                return entry;
+            }
+
+            // If the new animator is exclusive, but the old one(s) is/are not, we have to abort the
+            // old one(s) to make space for the new one.
+            if (exclusive)
+            {
+                final RegisteredAnimatorEntry newEntry = RegisteredAnimatorEntry.newAnimatorEntry(key, true);
+                newEntryRef.set(newEntry);
+                abortEntryRef.set(entry);
+                return newEntry;
+            }
+
+            // If there's no exclusivity around, we can re-use the existing, non-exclusive registry entry.
+            newEntryRef.set(entry);
+            return entry;
+        });
+
+        abort(abortEntryRef);
+
+        final @Nullable MovableActivityManager.RegisteredAnimatorEntry newEntry = newEntryRef.get();
+        return newEntry == null ? OptionalLong.empty() : OptionalLong.of(newEntry.getStamp());
     }
 
     /**
-     * Register a movable as available.
+     * Unregisters an animation.
      *
-     * @param movableUID
-     *     The UID of the movable.
+     * @param uid
+     *     The UID of the movable for which the animation was registered.
+     * @param stamp
+     *     The stamp of the registry entry.
+     * @throws IllegalArgumentException
+     *     If an entry was found and its stamp does not match the provided stamp.
      */
-    public void setMovableAvailable(long movableUID)
+    public void unregisterAnimation(long uid, long stamp)
     {
-        busyMovables.remove(movableUID);
+        animators.compute(uid, (key, entry) ->
+        {
+            if (entry == null)
+                return null;
+            if (stamp != entry.getStamp())
+                throw new IllegalArgumentException(
+                    "Stamp mismatch: Expected stamp " + entry.getStamp() + " but got stamp: " + stamp);
+            return entry.size() > 0 ? entry : null;
+        });
     }
 
     /**
@@ -94,34 +168,58 @@ public final class MovableActivityManager extends Restartable implements Movable
      * The {@link AbstractMovable} that was being used by the {@link Animator} will be registered as inactive and any
      * scheduling that is required will be performed.
      *
-     * @param blockMover
+     * @param animator
      *     The {@link Animator} to post-process.
+     * @throws IllegalStateException
+     *     When this manager is active and no entry exists for the provided animator.
      */
-    void processFinishedBlockMover(Animator blockMover)
+    void processFinishedAnimation(Animator animator)
     {
-        handleFinishedBlockMover(blockMover);
+        processFinishedAnimation0(animator);
     }
 
-    private void handleFinishedBlockMover(Animator blockMover)
+    private void processFinishedAnimation0(Animator animator)
     {
-        setMovableAvailable(blockMover.getMovable().getUid());
+        animators.compute(animator.getMovableUID(), (key, entry) ->
+        {
+            if (entry != null)
+                return entry.remove(animator) ? null : entry;
+            // We don't care about attempts to remove non-existent entries while shut(ting) down.
+            // On shutdown, the map is cleared, so it is likely to reach this point.
+            if (isActive)
+                throw new IllegalStateException("Trying to remove unregistered animator: " + animator);
+            return null;
+        });
 
         bigDoorsEventCaller.callBigDoorsEvent(
             eventFactory.createToggleEndEvent(
-                blockMover.getMovable(), blockMover.getSnapshot(), blockMover.getCause(),
-                blockMover.getActionType(), blockMover.getPlayer(), blockMover.getTime(),
-                blockMover.isSkipAnimation()));
+                animator.getMovable(), animator.getSnapshot(), animator.getCause(),
+                animator.getActionType(), animator.getPlayer(), animator.getTime(),
+                animator.isSkipAnimation()));
     }
 
     /**
-     * Stores a {@link Animator} in the appropriate slot in {@link #busyMovables}
+     * Stores a {@link Animator} in the appropriate slot in {@link #animators}
      *
-     * @param mover
+     * @param stamp
+     *     The stamp of the entry.
+     *     <p>
+     *     The stamp is used to validate the correct
+     * @param animator
      *     The {@link Animator}.
+     * @throws IllegalStateException
+     *     When no existing entry exists for the provided animator.
      */
-    public void addBlockMover(Animator mover)
+    public void addAnimator(long stamp, Animator animator)
     {
-        busyMovables.replace(mover.getMovableUID(), Optional.of(mover));
+        animators.compute(animator.getMovableUID(), (uid, entry)
+            ->
+        {
+            if (entry == null)
+                throw new IllegalStateException("Trying to add animator to non-existent entry: " + animator);
+            entry.addAnimator(stamp, animator);
+            return entry;
+        });
     }
 
     /**
@@ -129,51 +227,333 @@ public final class MovableActivityManager extends Restartable implements Movable
      *
      * @return All the currently active {@link Animator}s.
      */
-    @SuppressWarnings("unused")
     public Stream<Animator> getBlockMovers()
     {
-        return busyMovables.values().stream().filter(Optional::isPresent).map(Optional::get);
-    }
-
-    /**
-     * Gets the {@link Animator} of a busy {@link AbstractMovable}, if it has been registered.
-     *
-     * @param movableUID
-     *     The UID of the {@link AbstractMovable}.
-     * @return The {@link Animator} of a busy {@link AbstractMovable}.
-     */
-    public Optional<Animator> getBlockMover(long movableUID)
-    {
-        return Objects.requireNonNullElse(busyMovables.get(movableUID), Optional.empty());
-    }
-
-    /**
-     * Clears all busy movables.
-     */
-    private void emptyBusyMovables()
-    {
-        busyMovables.clear();
+        return animators.values().stream().map(RegisteredAnimatorEntry::getMovables)
+                        .flatMap(Collection::stream);
     }
 
     /**
      * Stops all block movers that are currently active.
      */
-    public void stopMovables()
+    public void stopAnimators()
     {
-        busyMovables.forEach((key, value) -> value.ifPresent(Animator::abort));
-        emptyBusyMovables();
+        animators.values().forEach(RegisteredAnimatorEntry::abort);
     }
 
     @Override
     public void onMovableDeletion(IMovableConst movable)
     {
-        Objects.<Optional<Animator>>requireNonNullElse(busyMovables.remove(movable.getUid()), Optional.empty())
-               .ifPresent(Animator::abort);
+        final @Nullable MovableActivityManager.RegisteredAnimatorEntry removed = animators.remove(
+            movable.getUid());
+        if (removed == null)
+            return;
+
+        log.atFinest().log("Aborted animation:%s\nFor deleted movable: %s", removed, movable);
+
     }
 
     @Override
     public void shutDown()
     {
-        stopMovables();
+        isActive = false;
+        stopAnimators();
+    }
+
+    @Override
+    public void initialize()
+    {
+        isActive = true;
+    }
+
+    /**
+     * Represents a registered animator.
+     * <p>
+     * In case of non-exclusive animators, more than one animator may be registered per movable.
+     */
+    private sealed abstract static class RegisteredAnimatorEntry
+    {
+        /**
+         * The stamp counter used to assign stamp values to new entries.
+         */
+        private static final AtomicLong STAMP_COUNTER = new AtomicLong(1);
+
+        /**
+         * The stamp of this entry.
+         * <p>
+         * If the entry is exclusive, the stamp will have a unique, non-zero value.
+         * <p>
+         * Non-exclusive animation types will always return 0.
+         */
+        @Getter
+        private final long stamp = STAMP_COUNTER.incrementAndGet();
+
+        /**
+         * Creates a new {@link RegisteredAnimatorEntry} instance.
+         *
+         * @param key
+         *     The key of the instance.
+         * @param exclusive
+         *     True if the entry is for an exclusive animator.
+         *     <p>
+         *     See {@link AnimationType#isExclusive()}.
+         * @return The newly created entry.
+         */
+        static RegisteredAnimatorEntry newAnimatorEntry(Long key, boolean exclusive)
+        {
+            return exclusive ?
+                   new ExclusiveAnimatorEntry(key) :
+                   new NonExclusiveAnimatorEntry(key);
+        }
+
+        /**
+         * @param stamp
+         *     The stamp to verify against the stamp of this entry.
+         * @throws IllegalArgumentException
+         *     When the provided stamp does not match the stamp of this entry.
+         */
+        protected void verifyStamp(long stamp)
+        {
+            if (stamp != this.stamp)
+                throw new IllegalArgumentException("Expected stamp '" + this.stamp + "' but received '" + stamp + "'");
+        }
+
+        /**
+         * Aborts the registered animator and prevents new animators from being registered in this registry entry. If
+         * more than one is registered, all animators are aborts.
+         */
+        public abstract void abort();
+
+        /**
+         * Adds a new animator to the current entry.
+         *
+         * @param stamp
+         *     The stamp to use to verify correctness of the addition.
+         * @param animator
+         *     The animator to add.
+         * @throws IllegalArgumentException
+         *     When the provided stamp does not match the expected one.
+         * @throws IllegalStateException
+         *     When the current entry has been aborted previously.
+         */
+        public abstract void addAnimator(long stamp, Animator animator)
+            throws IllegalArgumentException, IllegalStateException;
+
+        /**
+         * @return All animators in this entry.
+         */
+        public abstract Collection<Animator> getMovables();
+
+        /**
+         * @return The key of the entry.
+         */
+        public abstract long getKey();
+
+        /**
+         * @return True if this entry describes an exclusive type of animation.
+         * <p>
+         * See {@link AnimationType#isExclusive()}.
+         */
+        public abstract boolean isExclusive();
+
+        /**
+         * Removes the animator from this entry.
+         *
+         * @return True if, after removal, the entry does <b>not</b> contain any other animators.
+         */
+        public abstract boolean remove(Animator animator);
+
+        /**
+         * @return The number of animators in this entry.
+         */
+        public abstract int size();
+
+        static final class NonExclusiveAnimatorEntry extends RegisteredAnimatorEntry
+        {
+            @Getter
+            private final long key;
+            private final Set<Animator> animators = Collections.newSetFromMap(new IdentityHashMap<>());
+            private boolean isAborted = false;
+
+            NonExclusiveAnimatorEntry(long key)
+            {
+                this.key = key;
+            }
+
+            @Override
+            public synchronized void abort()
+            {
+                isAborted = true;
+                animators.forEach(Animator::abort);
+                animators.clear();
+            }
+
+            @Override
+            public synchronized int size()
+            {
+                return animators.size();
+            }
+
+            @Override
+            public synchronized void addAnimator(long stamp, Animator animator)
+            {
+                verifyStamp(stamp);
+                if (isAborted)
+                    throw new IllegalStateException("Trying to register animator in aborted state: " + animator);
+                animators.add(animator);
+            }
+
+            @Override
+            public synchronized boolean remove(Animator animator)
+            {
+                animators.remove(animator);
+                return animators.isEmpty();
+            }
+
+            @Override
+            public synchronized Collection<Animator> getMovables()
+            {
+                return Collections.unmodifiableSet(animators);
+            }
+
+            @Override
+            public boolean isExclusive()
+            {
+                return false;
+            }
+
+            @Override
+            public synchronized boolean equals(final Object o)
+            {
+                if (o == this)
+                    return true;
+                if (!(o instanceof NonExclusiveAnimatorEntry other))
+                    return false;
+                return this.isAborted != other.isAborted ||
+                    this.key != other.key ||
+                    !this.animators.equals(other.animators);
+            }
+
+            @Override
+            public synchronized int hashCode()
+            {
+                final int prime = 31;
+                int hashCode = 1;
+                hashCode = hashCode * prime + Boolean.hashCode(this.isAborted);
+                hashCode = hashCode * prime + Long.hashCode(this.key);
+                hashCode = hashCode * prime + this.animators.hashCode();
+
+                return hashCode;
+            }
+
+            @Override
+            public synchronized String toString()
+            {
+                return "NonExclusiveAnimatorEntry(stamp=" + this.getStamp() + ", key=" + this.key + ", animators=" +
+                    this.animators + ", isAborted=" + this.isAborted + ")";
+            }
+        }
+
+        static final class ExclusiveAnimatorEntry extends RegisteredAnimatorEntry
+        {
+            @Getter
+            private final long key;
+
+            private boolean isAborted = false;
+            private @Nullable Animator animator;
+
+            ExclusiveAnimatorEntry(long key)
+            {
+                this.key = key;
+            }
+
+            @Override
+            public synchronized void abort()
+            {
+                isAborted = true;
+                if (animator != null)
+                    animator.abort();
+            }
+
+            @Override
+            public synchronized int size()
+            {
+                return animator == null ? 0 : 1;
+            }
+
+            @Override
+            public synchronized void addAnimator(long stamp, Animator animator)
+            {
+                verifyStamp(stamp);
+                if (this.animator != null)
+                    throw new IllegalStateException(
+                        "Trying to override existing exclusive animator " + this.animator + " with animator: " +
+                            animator);
+                if (isAborted)
+                    throw new IllegalStateException("Trying to register animator in aborted state: " + animator);
+                this.animator = animator;
+            }
+
+            @Override
+            public synchronized boolean remove(Animator animator)
+            {
+                if (animator != this.animator)
+                {
+                    final String logStr = "Trying to remove animator %s while the entry actually contains animator %s";
+                    if (animator.getAnimationType().isExclusive())
+                        throw new IllegalStateException(String.format(logStr, animator, this.animator));
+                    log.atFiner().log(logStr, animator, this.animator);
+                    return false;
+                }
+                isAborted = true;
+                this.animator = null;
+                return true;
+            }
+
+            @Override
+            public synchronized Collection<Animator> getMovables()
+            {
+                return animator == null ? Collections.emptyList() : List.of(animator);
+            }
+
+            @Override
+            public boolean isExclusive()
+            {
+                return true;
+            }
+
+            @Override
+            public synchronized boolean equals(final Object o)
+            {
+                if (o == this)
+                    return true;
+                if (!(o instanceof ExclusiveAnimatorEntry other))
+                    return false;
+                return this.isAborted != other.isAborted ||
+                    this.key != other.key ||
+                    this.getStamp() != other.getStamp() ||
+                    !Objects.equals(this.animator, other.animator);
+            }
+
+            @Override
+            public synchronized int hashCode()
+            {
+                final int prime = 31;
+                int hashCode = 1;
+                hashCode = hashCode * prime + Boolean.hashCode(this.isAborted);
+                hashCode = hashCode * prime + Long.hashCode(this.key);
+                hashCode = hashCode * prime + Long.hashCode(this.getStamp());
+                hashCode = hashCode * prime + Objects.hashCode(this.animator);
+
+                return hashCode;
+            }
+
+            @Override
+            public synchronized String toString()
+            {
+                return "ExclusiveAnimatorEntry(stamp=" + this.getStamp() + ", key=" + this.key + ", isAborted=" +
+                    this.isAborted + ", animator=" + this.animator + ")";
+            }
+        }
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovableActivityManager.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 @Singleton
 public final class MovableActivityManager extends Restartable implements MovableDeletionManager.IDeletionListener
 {
-    private final Map<Long, Optional<BlockMover>> busyMovables = new ConcurrentHashMap<>();
+    private final Map<Long, Optional<Animator>> busyMovables = new ConcurrentHashMap<>();
 
     private final IBigDoorsEventFactory eventFactory;
     private final IBigDoorsEventCaller bigDoorsEventCaller;
@@ -89,20 +89,20 @@ public final class MovableActivityManager extends Restartable implements Movable
     }
 
     /**
-     * Processed a finished {@link BlockMover}.
+     * Processed a finished {@link Animator}.
      * <p>
-     * The {@link AbstractMovable} that was being used by the {@link BlockMover} will be registered as inactive and any
+     * The {@link AbstractMovable} that was being used by the {@link Animator} will be registered as inactive and any
      * scheduling that is required will be performed.
      *
      * @param blockMover
-     *     The {@link BlockMover} to post-process.
+     *     The {@link Animator} to post-process.
      */
-    void processFinishedBlockMover(BlockMover blockMover)
+    void processFinishedBlockMover(Animator blockMover)
     {
         handleFinishedBlockMover(blockMover);
     }
 
-    private void handleFinishedBlockMover(BlockMover blockMover)
+    private void handleFinishedBlockMover(Animator blockMover)
     {
         setMovableAvailable(blockMover.getMovable().getUid());
 
@@ -114,35 +114,35 @@ public final class MovableActivityManager extends Restartable implements Movable
     }
 
     /**
-     * Stores a {@link BlockMover} in the appropriate slot in {@link #busyMovables}
+     * Stores a {@link Animator} in the appropriate slot in {@link #busyMovables}
      *
      * @param mover
-     *     The {@link BlockMover}.
+     *     The {@link Animator}.
      */
-    public void addBlockMover(BlockMover mover)
+    public void addBlockMover(Animator mover)
     {
         busyMovables.replace(mover.getMovableUID(), Optional.of(mover));
     }
 
     /**
-     * Gets all the currently active {@link BlockMover}s.
+     * Gets all the currently active {@link Animator}s.
      *
-     * @return All the currently active {@link BlockMover}s.
+     * @return All the currently active {@link Animator}s.
      */
     @SuppressWarnings("unused")
-    public Stream<BlockMover> getBlockMovers()
+    public Stream<Animator> getBlockMovers()
     {
         return busyMovables.values().stream().filter(Optional::isPresent).map(Optional::get);
     }
 
     /**
-     * Gets the {@link BlockMover} of a busy {@link AbstractMovable}, if it has been registered.
+     * Gets the {@link Animator} of a busy {@link AbstractMovable}, if it has been registered.
      *
      * @param movableUID
      *     The UID of the {@link AbstractMovable}.
-     * @return The {@link BlockMover} of a busy {@link AbstractMovable}.
+     * @return The {@link Animator} of a busy {@link AbstractMovable}.
      */
-    public Optional<BlockMover> getBlockMover(long movableUID)
+    public Optional<Animator> getBlockMover(long movableUID)
     {
         return Objects.requireNonNullElse(busyMovables.get(movableUID), Optional.empty());
     }
@@ -160,15 +160,15 @@ public final class MovableActivityManager extends Restartable implements Movable
      */
     public void stopMovables()
     {
-        busyMovables.forEach((key, value) -> value.ifPresent(BlockMover::abort));
+        busyMovables.forEach((key, value) -> value.ifPresent(Animator::abort));
         emptyBusyMovables();
     }
 
     @Override
     public void onMovableDeletion(IMovableConst movable)
     {
-        Objects.<Optional<BlockMover>>requireNonNullElse(busyMovables.remove(movable.getUid()), Optional.empty())
-               .ifPresent(BlockMover::abort);
+        Objects.<Optional<Animator>>requireNonNullElse(busyMovables.remove(movable.getUid()), Optional.empty())
+               .ifPresent(Animator::abort);
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovementRequestData.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovementRequestData.java
@@ -36,6 +36,7 @@ public final class MovementRequestData
     private final boolean animationSkipped;
     private final Cuboid newCuboid;
     private final IPPlayer responsible;
+    private final AnimationType animationType;
     private final MovableActionType actionType;
 
     @AssistedInject MovementRequestData(
@@ -52,6 +53,7 @@ public final class MovementRequestData
         @Assisted boolean animationSkipped,
         @Assisted Cuboid newCuboid,
         @Assisted IPPlayer responsible,
+        @Assisted AnimationType animationType,
         @Assisted MovableActionType actionType)
     {
         this.movableActivityManager = movableActivityManager;
@@ -67,6 +69,7 @@ public final class MovementRequestData
         this.animationSkipped = animationSkipped;
         this.newCuboid = newCuboid;
         this.responsible = responsible;
+        this.animationType = animationType;
         this.actionType = actionType;
     }
 
@@ -90,12 +93,15 @@ public final class MovementRequestData
          *     The cuboid that described the coordinates of the movable after the animation has concluded.
          * @param responsible
          *     The player responsible for the movement.
+         * @param animationType
+         *     The type of animation to apply.
          * @param actionType
          *     The type of movement to apply.
          * @return The new {@link MovementRequestData}.
          */
         MovementRequestData newToggleRequestData(
             MovableSnapshot movableSnapshot, MovableActionCause cause, double time,
-            boolean skipAnimation, Cuboid newCuboid, IPPlayer responsible, MovableActionType actionType);
+            boolean skipAnimation, Cuboid newCuboid, IPPlayer responsible, AnimationType animationType,
+            MovableActionType actionType);
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovementRequestData.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/MovementRequestData.java
@@ -8,8 +8,6 @@ import nl.pim16aap2.bigdoors.api.GlowingBlockSpawner;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.IPExecutor;
 import nl.pim16aap2.bigdoors.api.IPPlayer;
-import nl.pim16aap2.bigdoors.api.factories.IAnimatedBlockFactory;
-import nl.pim16aap2.bigdoors.api.factories.IPLocationFactory;
 import nl.pim16aap2.bigdoors.audio.IAudioPlayer;
 import nl.pim16aap2.bigdoors.events.movableaction.MovableActionCause;
 import nl.pim16aap2.bigdoors.events.movableaction.MovableActionType;
@@ -26,10 +24,8 @@ import javax.inject.Named;
 public final class MovementRequestData
 {
     private final MovableActivityManager movableActivityManager;
-    private final IPLocationFactory locationFactory;
     private final IAudioPlayer audioPlayer;
     private final IPExecutor executor;
-    private final IAnimatedBlockFactory animatedBlockFactory;
     private final AnimationHookManager animationHookManager;
     private final GlowingBlockSpawner glowingBlockSpawner;
     private final IConfigLoader config;
@@ -44,10 +40,8 @@ public final class MovementRequestData
 
     @AssistedInject MovementRequestData(
         MovableActivityManager movableActivityManager,
-        IPLocationFactory locationFactory,
         IAudioPlayer audioPlayer,
         IPExecutor executor,
-        IAnimatedBlockFactory animatedBlockFactory,
         AnimationHookManager animationHookManager,
         GlowingBlockSpawner glowingBlockSpawner,
         IConfigLoader config,
@@ -61,10 +55,8 @@ public final class MovementRequestData
         @Assisted MovableActionType actionType)
     {
         this.movableActivityManager = movableActivityManager;
-        this.locationFactory = locationFactory;
         this.audioPlayer = audioPlayer;
         this.executor = executor;
-        this.animatedBlockFactory = animatedBlockFactory;
         this.animationHookManager = animationHookManager;
         this.glowingBlockSpawner = glowingBlockSpawner;
         this.config = config;

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/util/Mutable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/util/Mutable.java
@@ -1,19 +1,32 @@
 package nl.pim16aap2.bigdoors.util;
 
-import org.jetbrains.annotations.Nullable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Class used to wrap immutable objects and as such make them mutable.
+ * Wrapper class with a mutable reference to an object.
+ * <p>
+ * This class makes no assumptions on the nullability of objects.
+ * <p>
+ * This class is not thread safe. When such functionality is required, use an alternative like {@link AtomicReference}
+ * instead.
  *
- * @author Pim
+ * @param <T>
+ *     The type of the object to store.
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "NullableProblems"})
+@NotThreadSafe
+@ToString
+@EqualsAndHashCode
 public class Mutable<T>
 {
     /**
      * The value stored in this {@link Mutable}.
      */
-    private @Nullable T val;
+    private T val;
 
     /**
      * Constructs a new {@link Mutable} with a given value.
@@ -21,29 +34,17 @@ public class Mutable<T>
      * @param val
      *     The value to store.
      */
-    public Mutable(@Nullable T val)
+    public Mutable(T val)
     {
         this.val = val;
     }
 
     /**
-     * Gets the value stored in this {@link Mutable}.
-     *
      * @return The value stored in this {@link Mutable}.
      */
-    public @Nullable T getVal()
+    public T get()
     {
         return val;
-    }
-
-    /**
-     * Checks if the value stored in this {@link Mutable} is null.
-     *
-     * @return True if the value stored in this {@link Mutable} is null.
-     */
-    public boolean isEmpty()
-    {
-        return val == null;
     }
 
     /**
@@ -52,7 +53,7 @@ public class Mutable<T>
      * @param val
      *     The value that will be stored in this {@link Mutable}.
      */
-    public void setVal(@Nullable T val)
+    public void set(T val)
     {
         this.val = val;
     }

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/StopMovablesTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/StopMovablesTest.java
@@ -46,6 +46,6 @@ class StopMovablesTest
     void test()
     {
         Assertions.assertDoesNotThrow(() -> factory.newStopMovables(commandSender).run().get(1, TimeUnit.SECONDS));
-        Mockito.verify(movableActivityManager).stopMovables();
+        Mockito.verify(movableActivityManager).stopAnimators();
     }
 }

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/ToggleTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/ToggleTest.java
@@ -109,7 +109,7 @@ class ToggleTest
     {
         final Toggle toggle =
             factory.newToggle(commandSender, Toggle.DEFAULT_MOVABLE_ACTION_TYPE,
-                              Toggle.DEFAULT_ANIMATION_TYPE, null, movableRetriever);
+                              Toggle.DEFAULT_ANIMATION_TYPE, movableRetriever);
 
         toggle.executeCommand(new PermissionsStatus(true, true)).get(1, TimeUnit.SECONDS);
         Mockito.verify(movableToggleRequestFactory)
@@ -185,7 +185,7 @@ class ToggleTest
 
         Assertions.assertDoesNotThrow(
             () -> factory.newToggle(commandSender, MovableActionType.CLOSE,
-                                    AnimationType.MOVE_BLOCKS, null, movableRetriever)
+                                    AnimationType.MOVE_BLOCKS, movableRetriever)
                          .run().get(1, TimeUnit.SECONDS));
         Mockito.verify(movableToggleRequestFactory, Mockito.times(1))
                .create(movableRetriever, MovableActionCause.PLAYER, commandSender, commandSender,
@@ -207,8 +207,8 @@ class ToggleTest
         final IPServer serverCommandSender = Mockito.mock(IPServer.class, Answers.CALLS_REAL_METHODS);
         Assertions.assertDoesNotThrow(
             () -> factory.newToggle(
-                             serverCommandSender, MovableActionType.TOGGLE, AnimationType.PREVIEW,
-                             null, movableRetriever).run()
+                             serverCommandSender, MovableActionType.TOGGLE,
+                             AnimationType.PREVIEW, movableRetriever).run()
                          .get(1, TimeUnit.SECONDS));
         Mockito.verify(movableToggleRequestFactory, Mockito.times(1))
                .create(movableRetriever, MovableActionCause.SERVER, messageableServer, null,
@@ -228,8 +228,8 @@ class ToggleTest
         Mockito.when(movable.isCloseable()).thenReturn(false);
 
         Assertions.assertDoesNotThrow(
-            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, AnimationType.MOVE_BLOCKS,
-                                    null, movableRetriever).run()
+            () -> factory.newToggle(commandSender, MovableActionType.CLOSE,
+                                    AnimationType.MOVE_BLOCKS, movableRetriever).run()
                          .get(1, TimeUnit.SECONDS));
         verifyNoOpenerCalls();
 
@@ -238,16 +238,14 @@ class ToggleTest
         Mockito.when(movable.getOwner(Mockito.any(IPPlayer.class))).thenReturn(Optional.empty());
 
         Assertions.assertDoesNotThrow(
-            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, AnimationType.MOVE_BLOCKS, null,
-                                    movableRetriever).run()
-                         .get(1, TimeUnit.SECONDS));
+            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, AnimationType.MOVE_BLOCKS, movableRetriever)
+                         .run().get(1, TimeUnit.SECONDS));
         verifyNoOpenerCalls();
 
         initCommandSenderPermissions(commandSender, true, false);
         Assertions.assertDoesNotThrow(
-            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, AnimationType.MOVE_BLOCKS, null,
-                                    movableRetriever).run()
-                         .get(1, TimeUnit.SECONDS));
+            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, AnimationType.MOVE_BLOCKS, movableRetriever)
+                         .run().get(1, TimeUnit.SECONDS));
         verifyNoOpenerCalls();
     }
 }

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/ToggleTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/commands/ToggleTest.java
@@ -12,6 +12,7 @@ import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableToggleRequest;
 import nl.pim16aap2.bigdoors.movable.MovableToggleRequestBuilder;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
+import nl.pim16aap2.bigdoors.moveblocks.AnimationType;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetrieverFactory;
 import org.junit.jupiter.api.Assertions;
@@ -78,24 +79,26 @@ class ToggleTest
 
         Mockito.when(movableToggleRequestFactory.create(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
                                                         Mockito.nullable(Double.class), Mockito.anyBoolean(),
-                                                        Mockito.any()))
+                                                        Mockito.any(), Mockito.any()))
                .thenReturn(movableToggleRequest);
 
         movableToggleRequestBuilder = new MovableToggleRequestBuilder(movableToggleRequestFactory, messageableServer,
                                                                       Mockito.mock(IPPlayerFactory.class));
 
         Mockito.when(factory.newToggle(Mockito.any(ICommandSender.class), Mockito.any(MovableActionType.class),
-                                       Mockito.nullable(Double.class), Mockito.any(MovableRetriever[].class)))
+                                       Mockito.any(AnimationType.class), Mockito.nullable(Double.class),
+                                       Mockito.any(MovableRetriever[].class)))
                .thenAnswer(
                    invoc ->
                    {
                        final MovableRetriever[] retrievers =
-                           UnitTestUtil.arrayFromCapturedVarArgs(MovableRetriever.class, invoc, 3);
+                           UnitTestUtil.arrayFromCapturedVarArgs(MovableRetriever.class, invoc, 4);
 
                        return new Toggle(invoc.getArgument(0, ICommandSender.class), localizer,
                                          ITextFactory.getSimpleTextFactory(),
                                          invoc.getArgument(1, MovableActionType.class),
-                                         invoc.getArgument(2, Double.class), movableToggleRequestBuilder,
+                                         invoc.getArgument(2, AnimationType.class),
+                                         invoc.getArgument(3, Double.class), movableToggleRequestBuilder,
                                          messageableServer, retrievers);
                    });
     }
@@ -104,11 +107,14 @@ class ToggleTest
     void testSuccess()
         throws Exception
     {
-        final Toggle toggle = factory.newToggle(commandSender, Toggle.DEFAULT_MOVABLE_ACTION_TYPE,
-                                                (Double) null, movableRetriever);
+        final Toggle toggle =
+            factory.newToggle(commandSender, Toggle.DEFAULT_MOVABLE_ACTION_TYPE,
+                              Toggle.DEFAULT_ANIMATION_TYPE, null, movableRetriever);
+
         toggle.executeCommand(new PermissionsStatus(true, true)).get(1, TimeUnit.SECONDS);
-        Mockito.verify(movableToggleRequestFactory).create(movableRetriever, MovableActionCause.PLAYER, commandSender,
-                                                           commandSender, null, false, MovableActionType.TOGGLE);
+        Mockito.verify(movableToggleRequestFactory)
+               .create(movableRetriever, MovableActionCause.PLAYER, commandSender, commandSender, null, false,
+                       MovableActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
 
         Mockito.when(movable.getOwner(commandSender))
                .thenReturn(Optional.of(CommandTestingUtil.movableOwnerCreator));
@@ -116,7 +122,7 @@ class ToggleTest
         Mockito.verify(movableToggleRequestFactory, Mockito.times(2))
                .create(movableRetriever, MovableActionCause.PLAYER,
                        commandSender, commandSender,
-                       null, false, MovableActionType.TOGGLE);
+                       null, false, MovableActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
     }
 
     @Test
@@ -139,8 +145,10 @@ class ToggleTest
             retrievers[idx] = MovableRetrieverFactory.ofMovable(newMovable);
         }
 
-        final Toggle toggle = factory.newToggle(commandSender, Toggle.DEFAULT_MOVABLE_ACTION_TYPE,
-                                                null, retrievers);
+        final Toggle toggle =
+            factory.newToggle(commandSender, Toggle.DEFAULT_MOVABLE_ACTION_TYPE,
+                              Toggle.DEFAULT_ANIMATION_TYPE, null, retrievers);
+
         toggle.executeCommand(new PermissionsStatus(true, true)).get(1, TimeUnit.SECONDS);
 
         final Set<MovableRetriever> toggledMovables =
@@ -163,30 +171,34 @@ class ToggleTest
             () -> factory.newToggle(commandSender, movableRetriever).run().get(1, TimeUnit.SECONDS));
         Mockito.verify(movableToggleRequestFactory, Mockito.times(1))
                .create(movableRetriever, MovableActionCause.PLAYER, commandSender, commandSender,
-                       null, false, MovableActionType.TOGGLE);
-
-
-        Assertions.assertDoesNotThrow(() -> factory.newToggle(commandSender, 3.141592653589793D, movableRetriever).run()
-                                                   .get(1, TimeUnit.SECONDS));
-        Mockito.verify(movableToggleRequestFactory, Mockito.times(1))
-               .create(movableRetriever, MovableActionCause.PLAYER, commandSender, commandSender,
-                       3.141592653589793D, false, MovableActionType.TOGGLE);
-
-
-        Assertions.assertDoesNotThrow(() ->
-                                          factory.newToggle(commandSender, MovableActionType.CLOSE, movableRetriever)
-                                                 .run().get(1, TimeUnit.SECONDS));
-        Mockito.verify(movableToggleRequestFactory, Mockito.times(1))
-               .create(movableRetriever, MovableActionCause.PLAYER, commandSender, commandSender,
-                       null, false, MovableActionType.CLOSE);
+                       null, false, MovableActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
 
 
         Assertions.assertDoesNotThrow(
-            () -> factory.newToggle(commandSender, MovableActionType.OPEN, 42D, movableRetriever).run()
+            () -> factory.newToggle(commandSender, MovableActionType.TOGGLE,
+                                    AnimationType.MOVE_BLOCKS, 3.141592653589793D, movableRetriever).run()
+                         .get(1, TimeUnit.SECONDS));
+        Mockito.verify(movableToggleRequestFactory, Mockito.times(1))
+               .create(movableRetriever, MovableActionCause.PLAYER, commandSender, commandSender,
+                       3.141592653589793D, false, MovableActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
+
+
+        Assertions.assertDoesNotThrow(
+            () -> factory.newToggle(commandSender, MovableActionType.CLOSE,
+                                    AnimationType.MOVE_BLOCKS, null, movableRetriever)
+                         .run().get(1, TimeUnit.SECONDS));
+        Mockito.verify(movableToggleRequestFactory, Mockito.times(1))
+               .create(movableRetriever, MovableActionCause.PLAYER, commandSender, commandSender,
+                       null, false, MovableActionType.CLOSE, AnimationType.MOVE_BLOCKS);
+
+
+        Assertions.assertDoesNotThrow(
+            () -> factory.newToggle(commandSender, MovableActionType.OPEN,
+                                    AnimationType.MOVE_BLOCKS, 42D, movableRetriever).run()
                          .get(1, TimeUnit.SECONDS));
         Mockito.verify(movableToggleRequestFactory, Mockito.times(1))
                .create(movableRetriever, MovableActionCause.PLAYER, commandSender,
-                       commandSender, 42D, false, MovableActionType.OPEN);
+                       commandSender, 42D, false, MovableActionType.OPEN, AnimationType.MOVE_BLOCKS);
     }
 
     @Test
@@ -194,18 +206,20 @@ class ToggleTest
     {
         final IPServer serverCommandSender = Mockito.mock(IPServer.class, Answers.CALLS_REAL_METHODS);
         Assertions.assertDoesNotThrow(
-            () -> factory.newToggle(serverCommandSender, MovableActionType.TOGGLE, movableRetriever).run()
+            () -> factory.newToggle(
+                             serverCommandSender, MovableActionType.TOGGLE, AnimationType.PREVIEW,
+                             null, movableRetriever).run()
                          .get(1, TimeUnit.SECONDS));
         Mockito.verify(movableToggleRequestFactory, Mockito.times(1))
                .create(movableRetriever, MovableActionCause.SERVER, messageableServer, null,
-                       null, false, MovableActionType.TOGGLE);
+                       null, false, MovableActionType.TOGGLE, AnimationType.PREVIEW);
     }
 
     private void verifyNoOpenerCalls()
     {
         Mockito.verify(movableToggleRequestFactory, Mockito.never())
                .create(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-                       Mockito.anyDouble(), Mockito.anyBoolean(), Mockito.any());
+                       Mockito.anyDouble(), Mockito.anyBoolean(), Mockito.any(), Mockito.any());
     }
 
     @Test
@@ -214,7 +228,8 @@ class ToggleTest
         Mockito.when(movable.isCloseable()).thenReturn(false);
 
         Assertions.assertDoesNotThrow(
-            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, movableRetriever).run()
+            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, AnimationType.MOVE_BLOCKS,
+                                    null, movableRetriever).run()
                          .get(1, TimeUnit.SECONDS));
         verifyNoOpenerCalls();
 
@@ -223,13 +238,15 @@ class ToggleTest
         Mockito.when(movable.getOwner(Mockito.any(IPPlayer.class))).thenReturn(Optional.empty());
 
         Assertions.assertDoesNotThrow(
-            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, movableRetriever).run()
+            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, AnimationType.MOVE_BLOCKS, null,
+                                    movableRetriever).run()
                          .get(1, TimeUnit.SECONDS));
         verifyNoOpenerCalls();
 
         initCommandSenderPermissions(commandSender, true, false);
         Assertions.assertDoesNotThrow(
-            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, movableRetriever).run()
+            () -> factory.newToggle(commandSender, MovableActionType.CLOSE, AnimationType.MOVE_BLOCKS, null,
+                                    movableRetriever).run()
                          .get(1, TimeUnit.SECONDS));
         verifyNoOpenerCalls();
     }

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/ClockAnimationComponent.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/ClockAnimationComponent.java
@@ -2,7 +2,7 @@ package nl.pim16aap2.bigdoors.movable.clock;
 
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.windmill.WindmillAnimationComponent;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.MathUtil;
@@ -15,7 +15,7 @@ import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 import java.util.function.Function;
 
 /**
- * Represents a {@link BlockMover} for {@link Clock}s.
+ * Represents a {@link Animator} for {@link Clock}s.
  *
  * @author Pim
  */
@@ -59,9 +59,9 @@ public final class ClockAnimationComponent extends WindmillAnimationComponent
     }
 
     @Override
-    public BlockMover.MovementMethod getMovementMethod()
+    public Animator.MovementMethod getMovementMethod()
     {
-        return BlockMover.MovementMethod.TELEPORT;
+        return Animator.MovementMethod.TELEPORT;
     }
 
     /**

--- a/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/DrawbridgeAnimationComponent.java
+++ b/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/DrawbridgeAnimationComponent.java
@@ -3,7 +3,7 @@ package nl.pim16aap2.bigdoors.movable.drawbridge;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationUtil;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -15,7 +15,7 @@ import nl.pim16aap2.bigdoors.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 
 /**
- * Represents a {@link BlockMover} for {@link Drawbridge}s.
+ * Represents a {@link Animator} for {@link Drawbridge}s.
  *
  * @author Pim
  */

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/FlagAnimationComponent.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/FlagAnimationComponent.java
@@ -4,7 +4,7 @@ import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -17,7 +17,7 @@ import nl.pim16aap2.jcalculator.JCalculator;
 import java.util.function.BiFunction;
 
 /**
- * Represents a {@link BlockMover} for {@link Flag}s.
+ * Represents a {@link Animator} for {@link Flag}s.
  *
  * @author Pim
  */
@@ -49,9 +49,9 @@ public final class FlagAnimationComponent implements IAnimationComponent
     }
 
     @Override
-    public BlockMover.MovementMethod getMovementMethod()
+    public Animator.MovementMethod getMovementMethod()
     {
-        return BlockMover.MovementMethod.TELEPORT;
+        return Animator.MovementMethod.TELEPORT;
     }
 
     private double getOffset(int counter, IAnimatedBlock animatedBlock)

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoorAnimationComponent.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoorAnimationComponent.java
@@ -3,7 +3,7 @@ package nl.pim16aap2.bigdoors.movable.garagedoor;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationUtil;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -17,7 +17,7 @@ import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
 import java.util.function.BiFunction;
 
 /**
- * Represents a {@link BlockMover} for {@link GarageDoor}s.
+ * Represents a {@link Animator} for {@link GarageDoor}s.
  *
  * @author Pim
  */

--- a/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/VerticalAnimationComponent.java
+++ b/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/VerticalAnimationComponent.java
@@ -2,7 +2,7 @@ package nl.pim16aap2.bigdoors.movable.portcullis;
 
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationUtil;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -10,7 +10,7 @@ import nl.pim16aap2.bigdoors.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 
 /**
- * Represents a {@link BlockMover} for {@link Portcullis}'s.
+ * Represents a {@link Animator} for {@link Portcullis}'s.
  *
  * @author Pim
  */

--- a/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoorAnimationComponent.java
+++ b/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoorAnimationComponent.java
@@ -3,7 +3,7 @@ package nl.pim16aap2.bigdoors.movable.revolvingdoor;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.MovableSnapshot;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationUtil;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -15,7 +15,7 @@ import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 import java.util.function.BiFunction;
 
 /**
- * Represents a {@link BlockMover} for {@link RevolvingDoor}s.
+ * Represents a {@link Animator} for {@link RevolvingDoor}s.
  *
  * @author Pim
  */

--- a/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoorAnimationComponent.java
+++ b/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoorAnimationComponent.java
@@ -2,7 +2,7 @@ package nl.pim16aap2.bigdoors.movable.slidingdoor;
 
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.moveblocks.AnimationUtil;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -12,7 +12,7 @@ import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Represents a {@link BlockMover} for {@link SlidingDoor}.
+ * Represents a {@link Animator} for {@link SlidingDoor}.
  *
  * @author Pim
  */

--- a/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/WindmillAnimationComponent.java
+++ b/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/WindmillAnimationComponent.java
@@ -2,7 +2,7 @@ package nl.pim16aap2.bigdoors.movable.windmill;
 
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.movable.drawbridge.DrawbridgeAnimationComponent;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.MathUtil;
@@ -12,7 +12,7 @@ import nl.pim16aap2.bigdoors.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.util.vector.Vector3Dd;
 
 /**
- * Represents a {@link BlockMover} for {@link Windmill}s.
+ * Represents a {@link Animator} for {@link Windmill}s.
  *
  * @author Pim
  */

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/comands/CommandExecutor.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/comands/CommandExecutor.java
@@ -201,7 +201,7 @@ class CommandExecutor
     void preview(CommandContext<ICommandSender> context)
     {
         commandFactory.newToggle(
-            context.getSender(), MovableActionType.TOGGLE, AnimationType.PREVIEW, null,
+            context.getSender(), MovableActionType.TOGGLE, AnimationType.PREVIEW,
             context.<MovableRetriever>get("movableRetriever")).run();
     }
 

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/comands/CommandExecutor.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/comands/CommandExecutor.java
@@ -6,8 +6,10 @@ import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.commands.AddOwnerDelayed;
 import nl.pim16aap2.bigdoors.commands.CommandFactory;
 import nl.pim16aap2.bigdoors.commands.ICommandSender;
+import nl.pim16aap2.bigdoors.events.movableaction.MovableActionType;
 import nl.pim16aap2.bigdoors.movable.PermissionLevel;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
+import nl.pim16aap2.bigdoors.moveblocks.AnimationType;
 import nl.pim16aap2.bigdoors.spigot.util.SpigotAdapter;
 import nl.pim16aap2.bigdoors.util.MovementDirection;
 import nl.pim16aap2.bigdoors.util.movableretriever.MovableRetriever;
@@ -194,6 +196,13 @@ class CommandExecutor
     void toggle(CommandContext<ICommandSender> context)
     {
         commandFactory.newToggle(context.getSender(), context.<MovableRetriever>get("movableRetriever")).run();
+    }
+
+    void preview(CommandContext<ICommandSender> context)
+    {
+        commandFactory.newToggle(
+            context.getSender(), MovableActionType.TOGGLE, AnimationType.PREVIEW, null,
+            context.<MovableRetriever>get("movableRetriever")).run();
     }
 
     void version(CommandContext<ICommandSender> context)

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/comands/CommandManager.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/comands/CommandManager.java
@@ -140,6 +140,7 @@ public final class CommandManager
         initCmdSpecify(manager, builder);
         initCmdStopMovables(manager, builder);
         initCmdToggle(manager, builder);
+        initCmdPreview(manager, builder);
         initCmdVersion(manager, builder);
 
         builder.build();
@@ -387,6 +388,21 @@ public final class CommandManager
             baseInit(builder, CommandDefinition.TOGGLE, "commands.toggle.description")
                 .argument(defaultMovableArgument(true, PermissionLevel.USER).build())
                 .handler(executor::toggle)
+        );
+    }
+
+    private void initCmdPreview(
+        BukkitCommandManager<ICommandSender> manager, Command.Builder<ICommandSender> builder)
+    {
+        final CommandDefinition previewDefinition =
+            new CommandDefinition("PREVIEW",
+                                  CommandDefinition.PREFIX_USER + "preview",
+                                  CommandDefinition.PREFIX_ADMIN + "bypass.preview");
+
+        manager.command(
+            baseInit(builder, previewDefinition, "commands.preview.description")
+                .argument(defaultMovableArgument(true, PermissionLevel.USER).build())
+                .handler(executor::preview)
         );
     }
 

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/AttributeButtonFactory.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/gui/AttributeButtonFactory.java
@@ -7,6 +7,7 @@ import nl.pim16aap2.bigdoors.api.IConfigLoader;
 import nl.pim16aap2.bigdoors.api.IPExecutor;
 import nl.pim16aap2.bigdoors.api.factories.ITextFactory;
 import nl.pim16aap2.bigdoors.commands.CommandFactory;
+import nl.pim16aap2.bigdoors.commands.Toggle;
 import nl.pim16aap2.bigdoors.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableAttribute;
@@ -82,8 +83,12 @@ class AttributeButtonFactory
             new ItemStack(Material.LEVER),
             click ->
             {
-                commandFactory.newToggle(player, config.getAnimationSpeedMultiplier(movable.getType()),
-                                         movableRetrieverFactory.of(movable)).run();
+                commandFactory.newToggle(
+                    player,
+                    Toggle.DEFAULT_MOVABLE_ACTION_TYPE,
+                    Toggle.DEFAULT_ANIMATION_TYPE,
+                    config.getAnimationSpeedMultiplier(movable.getType()),
+                    movableRetrieverFactory.of(movable)).run();
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.toggle",

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/listeners/ChunkListener.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/listeners/ChunkListener.java
@@ -6,7 +6,7 @@ import nl.pim16aap2.bigdoors.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.managers.PowerBlockManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.moveblocks.MovableActivityManager;
 import nl.pim16aap2.bigdoors.spigot.util.SpigotAdapter;
 import nl.pim16aap2.bigdoors.util.Rectangle;
@@ -77,7 +77,7 @@ public class ChunkListener extends AbstractListener
                 .getBlockMovers()
                 .filter(mover -> mover.getSnapshot().getWorld().equals(world))
                 .filter(mover -> chunkInsideAnimationRange(chunkCoords, mover.getSnapshot().getAnimationRange()))
-                .forEach(BlockMover::abort);
+                .forEach(Animator::abort);
         }
         catch (Exception e)
         {

--- a/bigdoors-spigot/spigot-core/src/main/resources/SpigotCore.properties
+++ b/bigdoors-spigot/spigot-core/src/main/resources/SpigotCore.properties
@@ -22,3 +22,6 @@ gui.delete_page.title=Delete {0} "{1}"
 gui.delete_page.confirm=Yes, delete this {0}
 gui.delete_page.cancel=No, keep this {0}
 gui.notification.movable_inaccessible=You no longer have access to movable: {0}!
+#
+#
+commands.preview.description=Previews an animation using glowing blocks.

--- a/bigdoors-spigot/spigot-v1_19_R2/src/main/java/nl/pim16aap2/bigdoors/spigot/v1_19_R2/AnimatedBlockFactory_V1_19_R2.java
+++ b/bigdoors-spigot/spigot-v1_19_R2/src/main/java/nl/pim16aap2/bigdoors/spigot/v1_19_R2/AnimatedBlockFactory_V1_19_R2.java
@@ -6,7 +6,7 @@ import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.api.factories.IAnimatedBlockFactory;
 import nl.pim16aap2.bigdoors.managers.AnimatedBlockHookManager;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.spigot.util.SpigotAdapter;
 import nl.pim16aap2.bigdoors.util.Constants;
 import nl.pim16aap2.bigdoors.util.Util;
@@ -40,7 +40,7 @@ public final class AnimatedBlockFactory_V1_19_R2 implements IAnimatedBlockFactor
     @Override
     public Optional<IAnimatedBlock> create(
         IPLocation loc, float radius, float startAngle, boolean bottom, boolean onEdge, AnimationContext context,
-        Vector3Dd finalPosition, BlockMover.MovementMethod movementMethod)
+        Vector3Dd finalPosition, Animator.MovementMethod movementMethod)
         throws Exception
     {
         final Location spigotLocation = SpigotAdapter.getBukkitLocation(loc);

--- a/bigdoors-spigot/spigot-v1_19_R2/src/main/java/nl/pim16aap2/bigdoors/spigot/v1_19_R2/CustomEntityFallingBlock_V1_19_R2.java
+++ b/bigdoors-spigot/spigot-v1_19_R2/src/main/java/nl/pim16aap2/bigdoors/spigot/v1_19_R2/CustomEntityFallingBlock_V1_19_R2.java
@@ -506,7 +506,7 @@ public class CustomEntityFallingBlock_V1_19_R2 extends EntityFallingBlock implem
     }
 
     @Override
-    public IPWorld getPWorld()
+    public IPWorld getWorld()
     {
         return pWorld;
     }

--- a/bigdoors-spigot/spigot-v1_19_R2/src/main/java/nl/pim16aap2/bigdoors/spigot/v1_19_R2/CustomEntityFallingBlock_V1_19_R2.java
+++ b/bigdoors-spigot/spigot-v1_19_R2/src/main/java/nl/pim16aap2/bigdoors/spigot/v1_19_R2/CustomEntityFallingBlock_V1_19_R2.java
@@ -33,7 +33,7 @@ import nl.pim16aap2.bigdoors.api.animatedblock.AnimationContext;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.api.animatedblock.IAnimatedBlockHook;
 import nl.pim16aap2.bigdoors.managers.AnimatedBlockHookManager;
-import nl.pim16aap2.bigdoors.moveblocks.BlockMover;
+import nl.pim16aap2.bigdoors.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.spigot.util.SpigotAdapter;
 import nl.pim16aap2.bigdoors.spigot.util.api.IAnimatedBlockSpigot;
 import nl.pim16aap2.bigdoors.spigot.util.implementations.PLocationSpigot;
@@ -85,7 +85,7 @@ public class CustomEntityFallingBlock_V1_19_R2 extends EntityFallingBlock implem
     @Getter
     private final float startAngle;
 
-    private final BlockMover.MovementMethod movementMethod;
+    private final Animator.MovementMethod movementMethod;
 
     @Getter
     private final boolean onEdge;
@@ -133,7 +133,7 @@ public class CustomEntityFallingBlock_V1_19_R2 extends EntityFallingBlock implem
 
     public CustomEntityFallingBlock_V1_19_R2(
         IPExecutor executor, IPWorld pWorld, World world, double posX, double posY, double posZ, float radius,
-        float startAngle, BlockMover.MovementMethod movementMethod,
+        float startAngle, Animator.MovementMethod movementMethod,
         boolean onEdge, AnimationContext context, AnimatedBlockHookManager animatedBlockHookManager,
         Vector3Dd finalPosition)
     {


### PR DESCRIPTION
This PR changes the way animations are handled. This was done to allow for different types of animated blocks to be used.

In addition to the regular animation, a new type of animation was added: `PREVIEW`. This type of animation uses glowing blocks to visualize an animation without moving any blocks. Multiple preview animations can be active at any time, but if a normal animation is requested, all preview animations are canceled.

The preview system can be used with the new `/BigDoors preview <movable0> [movable1] ... [movableX]` command. This command only exists in the Spigot module. It simply uses the Toggle command with a different animation type.