### PR TITLE
Rename affectsWorld/isExclusive to requiresWriteAccess

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableBase.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableBase.java
@@ -230,7 +230,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
             movable instanceof IPerpetualMover perpetualMover &&
             perpetualMover.isPerpetual())
         {
-            movableActivityManager.stopExclusiveAnimators(movable.getUid());
+            movableActivityManager.stopAnimatorsWithWriteAccess(movable.getUid());
             return;
         }
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableOpeningHelper.java
@@ -276,7 +276,7 @@ public final class MovableOpeningHelper
                          data.getResponsible(), messageReceiver, null);
 
         final OptionalLong registrationResult =
-            movableActivityManager.registerAnimation(snapshot.getUid(), animationType.isExclusive());
+            movableActivityManager.registerAnimation(snapshot.getUid(), animationType.requiresWriteAccess());
         if (registrationResult.isEmpty())
             return MovableToggleResult.BUSY;
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/Animation.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/Animation.java
@@ -28,15 +28,19 @@ public class Animation<T extends IAnimatedBlock> implements IAnimation<T>
     private volatile AnimationState state = AnimationState.PENDING;
     @Setter(AccessLevel.PACKAGE)
     private volatile int stepsExecuted = 0;
+    @Getter
+    private final AnimationType animationType;
 
     Animation(
-        int duration, Cuboid region, List<T> animatedBlocks, MovableSnapshot movableSnapshot, MovableType movableType)
+        int duration, Cuboid region, List<T> animatedBlocks, MovableSnapshot movableSnapshot, MovableType movableType,
+        AnimationType animationType)
     {
         this.duration = duration;
         this.region = region;
         this.animatedBlocks = Collections.unmodifiableList(animatedBlocks);
         this.movableSnapshot = movableSnapshot;
         this.movableType = movableType;
+        this.animationType = animationType;
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/AnimationType.java
@@ -11,37 +11,35 @@ public enum AnimationType
      * Animates the movement of blocks from their starting position to their final position, which may be somewhere
      * else.
      */
-    MOVE_BLOCKS(true, true, Double.MAX_VALUE, true),
+    MOVE_BLOCKS(true, true, Double.MAX_VALUE),
 
     /**
      * Animates a preview of an animation. No blocks are affected in the world.
      * <p>
      * Note that this type requires an online {@link IPPlayer} to target.
      */
-    PREVIEW(false, false, 10, false),
+    PREVIEW(false, false, 10),
     ;
 
-    private final boolean affectsWorld;
+    private final boolean requiresWriteAccess;
     private final boolean supportsPerpetualAnimation;
     private final double animationDurationLimit;
-    private final boolean isExclusive;
 
     AnimationType(
-        boolean affectsWorld, boolean supportsPerpetualAnimation, double animationDurationLimit, boolean isExclusive)
+        boolean requiresWriteAccess, boolean supportsPerpetualAnimation, double animationDurationLimit)
     {
-        this.affectsWorld = affectsWorld;
+        this.requiresWriteAccess = requiresWriteAccess;
         this.supportsPerpetualAnimation = supportsPerpetualAnimation;
         this.animationDurationLimit = animationDurationLimit;
-        this.isExclusive = isExclusive;
     }
 
     /**
-     * @return Whether this animation affects the world. When true, the coordinates of the movable and the 'isOpen'
-     * status will be updated once the animation has finished.
+     * @return Whether this animation needs write access. When true, the state of the world or the movable will be
+     * affected by the animation. When false, the animation is side effect free.
      */
-    public boolean affectsWorld()
+    public boolean requiresWriteAccess()
     {
-        return affectsWorld;
+        return requiresWriteAccess;
     }
 
     /**
@@ -59,17 +57,5 @@ public enum AnimationType
     public double getAnimationDurationLimit()
     {
         return animationDurationLimit;
-    }
-
-    /**
-     * @return True if this is an exclusive type of animation.
-     * <p>
-     * Exclusive here means that while an animation of this type is active, no other animation can be activated.
-     * <p>
-     * When false, more than one non-exclusive type of animation can be created.
-     */
-    public boolean isExclusive()
-    {
-        return isExclusive;
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/Animator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/moveblocks/Animator.java
@@ -309,7 +309,7 @@ public final class Animator implements IAnimator
             throw new IllegalStateException("Trying to start an animation again!");
 
         final Animation<IAnimatedBlock> animation = new Animation<>(
-            animationDuration, oldCuboid, getAnimatedBlocks(), snapshot, movable.getType());
+            animationDuration, oldCuboid, getAnimatedBlocks(), snapshot, movable.getType(), animationType);
         this.animationData = animation;
 
         final AnimationContext animationContext = new AnimationContext(movable.getType(), snapshot, animation);
@@ -496,7 +496,7 @@ public final class Animator implements IAnimator
 
         animationBlockManager.handleAnimationCompletion();
 
-        if (animationType.affectsWorld())
+        if (animationType.requiresWriteAccess())
             // Tell the movable object it has been opened and what its new coordinates are.
             movable.withWriteLock(this::updateCoords);
 


### PR DESCRIPTION
- The affectsWorld and isExclusive booleans in the AnimationType class have been merged into a single value: requiresWriteAccess. When true, only 1 animator can be active per movable and the coordinates of the movable will be updated when the animation ends. When false, no data is updated when the animation ends and there can be any number of active animators per movable; it's read-only anyway.