### PR TITLE
Implement chunk load response

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/IChunkLoader.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/api/IChunkLoader.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.bigdoors.api;
 
 import nl.pim16aap2.bigdoors.util.Cuboid;
+import nl.pim16aap2.bigdoors.util.vector.IVector3D;
 
 /**
  * Tool that can be used to load chunks or check if they are already loaded.
@@ -18,10 +19,23 @@ public interface IChunkLoader
      * @param cuboid
      *     The region to check. All chunks that are at least partially inside this cuboid will be checked.
      * @param chunkLoadMode
-     *     The
+     *     The type of chunk loading to use if the chunk is not loaded.
      * @return The result of the action.
      */
     ChunkLoadResult checkChunks(IPWorld world, Cuboid cuboid, ChunkLoadMode chunkLoadMode);
+
+    /**
+     * Checks if the chunk a position exists in is loaded.
+     *
+     * @param world
+     *     The world whose chunks to check.
+     * @param position
+     *     The coordinates to check.
+     * @param chunkLoadMode
+     *     The type of chunk loading to use if the chunk is not loaded.
+     * @return The result of the action.
+     */
+    ChunkLoadResult checkChunk(IPWorld world, IVector3D position, ChunkLoadMode chunkLoadMode);
 
     /**
      * Represents the different modes of checking chunks.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
@@ -332,7 +332,7 @@ public abstract class AbstractMovable implements IMovable
      */
     public void onChunkLoad()
     {
-        // TODO: Implement this
+        base.onChunkLoad(this);
     }
 
     public void verifyRedstoneState()

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/sqlite/SQLiteJDBCDriverConnection.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/sqlite/SQLiteJDBCDriverConnection.java
@@ -803,7 +803,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
                                         movables.put(locationHash, new LongArrayList());
                                     movables.get(locationHash).add(resultSet.getLong("id"));
                                 }
-                                return movables;
+                                return Int2ObjectMaps.unmodifiable(movables);
                             }, Int2ObjectMaps.emptyMap());
     }
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/util/Util.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/util/Util.java
@@ -770,16 +770,19 @@ public final class Util
     }
 
     /**
-     * Gets a completable future that contains a list of results obtained from the input futures.
+     * Maps a group of CompletableFutures to a single CompletableFuture with a list of results.
      * <p>
      * The result will wait for each of the futures to complete and once all of them have completed gather the results
      * and return the list.
+     * <p>
+     * Each entry in the list maps to the result of a single future.
      *
      * @param futures
      *     The completable futures whose results to collect into a list.
      * @param <T>
      *     The type of data.
-     * @return The list of results obtained from the completable futures in the same order as provided.
+     * @return The list of results obtained from the CompletableFutures in the same order as provided. The list will
+     * have a size that matches the number of input futures.
      */
     @SafeVarargs
     public static <T> CompletableFuture<List<T>> getAllCompletableFutureResults(CompletableFuture<T>... futures)
@@ -792,6 +795,44 @@ public final class Util
                                     {
                                         ret.add(future.join());
                                     }
+                                    return ret;
+                                }).exceptionally(throwable -> exceptionally(throwable, Collections.emptyList()));
+    }
+
+    /**
+     * See {@link #getAllCompletableFutureResultsFlatMap(CompletableFuture[])}.
+     */
+    public static <T> CompletableFuture<List<T>> getAllCompletableFutureResultsFlatMap(
+        Collection<CompletableFuture<? extends Collection<T>>> futures)
+    {
+        //noinspection unchecked
+        return getAllCompletableFutureResultsFlatMap(futures.toArray(new CompletableFuture[0]));
+    }
+
+    /**
+     * Maps a group of CompletableFutures that each have a list as result to a single CompletableFuture with a list.
+     * <p>
+     * The result will wait for each of the futures to complete and once all of them have completed gather the results
+     * and return the list.
+     * <p>
+     * The results of the futures are flatMapped into a single list.
+     *
+     * @param futures
+     *     The completable futures whose results to flatMap into a list.
+     * @param <T>
+     *     The type of data in the lists.
+     * @return The list of results obtained from the CompletableFutures.
+     */
+    @SafeVarargs
+    public static <T> CompletableFuture<List<T>> getAllCompletableFutureResultsFlatMap(
+        CompletableFuture<? extends Collection<T>>... futures)
+    {
+        final CompletableFuture<Void> result = CompletableFuture.allOf(futures);
+        return result.thenApply(ignored ->
+                                {
+                                    final List<T> ret = new ArrayList<>();
+                                    for (final CompletableFuture<? extends Collection<T>> future : futures)
+                                        ret.addAll(future.join());
                                     return ret;
                                 }).exceptionally(throwable -> exceptionally(throwable, Collections.emptyList()));
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/util/Util.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/util/Util.java
@@ -523,7 +523,7 @@ public final class Util
      */
     public static long getChunkId(Vector3Di position)
     {
-        return getChunkId(position.x() << 4, position.z() << 4);
+        return getChunkId(position.x() >> 4, position.z() >> 4);
     }
 
     /**
@@ -539,7 +539,7 @@ public final class Util
      */
     public static long getChunkId(int x, int y, int z)
     {
-        return getChunkId(x << 4, z << 4);
+        return getChunkId(x >> 4, z >> 4);
     }
 
     /**
@@ -556,6 +556,8 @@ public final class Util
 
     /**
      * Gets the ID of the chunk from its coordinates.
+     * <p>
+     * The upper 32 bits store the x-coordinate of the chunk, and the lower 32 bits store the z coordinate.
      *
      * @param chunkX
      *     The x-coordinate of the chunk.
@@ -591,7 +593,7 @@ public final class Util
      */
     public static Vector2Di getChunkCoords(Vector3Di position)
     {
-        return new Vector2Di(position.x() << 4, position.z() << 4);
+        return new Vector2Di(position.x() >> 4, position.z() >> 4);
     }
 
     /**

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/util/UtilTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/util/UtilTest.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.bigdoors.util;
 
 import nl.pim16aap2.bigdoors.util.vector.Vector2Di;
+import nl.pim16aap2.bigdoors.util.vector.Vector3Di;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,12 @@ class UtilTest
     {
         final long chunkId = Util.getChunkId(chunkCoords);
         Assertions.assertEquals(chunkCoords, Util.getChunkFromId(chunkId));
+    }
+
+    @Test
+    void testChunkCoords()
+    {
+        Assertions.assertEquals(new Vector2Di(7, 13), Util.getChunkCoords(new Vector3Di(126, 9999, 223)));
     }
 
     @Test


### PR DESCRIPTION
- On chunk load, all movables for which the chunks for both their powerblock and their rotation point are loaded will verify their redstone status.