### PR TITLE
Serialize type-specific data to json

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/managers/DatabaseManager.java
@@ -669,10 +669,10 @@ public final class DatabaseManager extends Restartable implements IDebuggable
      * @param snapshot
      *     The {@link AbstractMovable} that describes the base data of movable.
      * @param typeData
-     *     The type-specific data of this movable.
+     *     The type-specific data of this movable represented as a json String.
      * @return The result of the operation.
      */
-    public CompletableFuture<DatabaseManager.ActionResult> syncMovableData(MovableSnapshot snapshot, byte[] typeData)
+    public CompletableFuture<DatabaseManager.ActionResult> syncMovableData(MovableSnapshot snapshot, String typeData)
     {
         return CompletableFuture
             .supplyAsync(() -> db.syncMovableData(snapshot, typeData) ? ActionResult.SUCCESS : ActionResult.FAIL,

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
@@ -497,9 +497,18 @@ public abstract class AbstractMovable implements IMovable
     {
         String ret = base + "\n"
             + "Type-specific data:\n"
-            + "type: " + getType() + "\n";
+            + "type: " + getType() + "\n"
+            + "Type data: ";
 
-        ret += serializer.toString(this);
+        try
+        {
+            ret += serializer.serialize(this);
+        }
+        catch (Exception e)
+        {
+            ret += "NULL";
+            log.atSevere().withCause(e).log("Failed to get serialized data for movable %d", getUid());
+        }
 
         return ret;
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/IStorage.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/IStorage.java
@@ -252,7 +252,7 @@ public interface IStorage
      *     The type-specific data of this movable.
      * @return True if the update was successful.
      */
-    boolean syncMovableData(IMovableConst movable, byte[] typeData);
+    boolean syncMovableData(IMovableConst movable, String typeData);
 
     /**
      * Retrieves all {@link DatabaseManager.MovableIdentifier}s that start with the provided input.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/SQLStatement.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/SQLStatement.java
@@ -351,7 +351,7 @@ public enum SQLStatement
         powerBlockChunkId     INTEGER    NOT NULL,
         openDirection         INTEGER    NOT NULL,
         movableType           TEXT       NOT NULL,
-        typeData              BLOB       NOT NULL,
+        typeData              TEXT       NOT NULL,
         bitflag               INTEGER    NOT NULL);
         """
     ),

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/sqlite/SQLiteJDBCDriverConnection.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/sqlite/SQLiteJDBCDriverConnection.java
@@ -383,7 +383,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
                               .ownersOfMovable(ownersOfMovable)
                               .build();
 
-        final byte[] rawTypeData = movableBaseRS.getBytes("typeData");
+        final String rawTypeData = movableBaseRS.getString("typeData");
         return Optional.of(serializer.deserialize(movableRegistry, movableData, rawTypeData));
     }
 
@@ -400,34 +400,34 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
         return removed;
     }
 
-    private Long insert(Connection conn, AbstractMovable movable, String movableType, byte[] typeSpecificData)
+    private Long insert(Connection conn, AbstractMovable movable, String movableType, String typeSpecificData)
     {
         final PPlayerData playerData = movable.getPrimeOwner().pPlayerData();
         insertOrIgnorePlayer(conn, playerData);
 
         final String worldName = movable.getWorld().worldName();
-        executeUpdate(conn, SQLStatement.INSERT_MOVABLE_BASE.constructPPreparedStatement()
-                                                            .setNextString(movable.getName())
-                                                            .setNextString(worldName)
-                                                            .setNextInt(movable.getMinimum().x())
-                                                            .setNextInt(movable.getMinimum().y())
-                                                            .setNextInt(movable.getMinimum().z())
-                                                            .setNextInt(movable.getMaximum().x())
-                                                            .setNextInt(movable.getMaximum().y())
-                                                            .setNextInt(movable.getMaximum().z())
-                                                            .setNextInt(movable.getRotationPoint().x())
-                                                            .setNextInt(movable.getRotationPoint().y())
-                                                            .setNextInt(movable.getRotationPoint().z())
-                                                            .setNextLong(Util.getChunkId(movable.getRotationPoint()))
-                                                            .setNextInt(movable.getPowerBlock().x())
-                                                            .setNextInt(movable.getPowerBlock().y())
-                                                            .setNextInt(movable.getPowerBlock().z())
-                                                            .setNextLong(Util.getChunkId(movable.getPowerBlock()))
-                                                            .setNextInt(
-                                                                MovementDirection.getValue(movable.getOpenDir()))
-                                                            .setNextLong(getFlag(movable))
-                                                            .setNextString(movableType)
-                                                            .setNextBytes(typeSpecificData));
+        executeUpdate(conn, SQLStatement.INSERT_MOVABLE_BASE
+            .constructPPreparedStatement()
+            .setNextString(movable.getName())
+            .setNextString(worldName)
+            .setNextInt(movable.getMinimum().x())
+            .setNextInt(movable.getMinimum().y())
+            .setNextInt(movable.getMinimum().z())
+            .setNextInt(movable.getMaximum().x())
+            .setNextInt(movable.getMaximum().y())
+            .setNextInt(movable.getMaximum().z())
+            .setNextInt(movable.getRotationPoint().x())
+            .setNextInt(movable.getRotationPoint().y())
+            .setNextInt(movable.getRotationPoint().z())
+            .setNextLong(Util.getChunkId(movable.getRotationPoint()))
+            .setNextInt(movable.getPowerBlock().x())
+            .setNextInt(movable.getPowerBlock().y())
+            .setNextInt(movable.getPowerBlock().z())
+            .setNextLong(Util.getChunkId(movable.getPowerBlock()))
+            .setNextInt(MovementDirection.getValue(movable.getOpenDir()))
+            .setNextLong(getFlag(movable))
+            .setNextString(movableType)
+            .setNextString(typeSpecificData));
 
         // TODO: Just use the fact that the last-inserted movable has the current UID (that fact is already used by
         //       getTypeSpecificDataInsertStatement(MovableType)), so it can be done in a single statement.
@@ -449,7 +449,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
         final String typeName = movable.getType().getFullName();
         try
         {
-            final byte[] typeData = serializer.serialize(movable);
+            final String typeData = serializer.serialize(movable);
 
             final long movableUID = executeTransaction(conn -> insert(conn, movable, typeName, typeData), -1L);
             if (movableUID > 0)
@@ -492,7 +492,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    public boolean syncMovableData(IMovableConst movable, byte[] typeData)
+    public boolean syncMovableData(IMovableConst movable, String typeData)
     {
         return executeUpdate(SQLStatement.UPDATE_MOVABLE_BASE
                                  .constructPPreparedStatement()
@@ -519,7 +519,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
 
                                  .setNextInt(MovementDirection.getValue(movable.getOpenDir()))
                                  .setNextLong(getFlag(movable.isOpen(), movable.isLocked()))
-                                 .setNextBytes(typeData)
+                                 .setNextString(typeData)
 
                                  .setNextLong(movable.getUid())) > 0;
     }

--- a/bigdoors-spigot/spigot-core/src/main/resources/plugin.yml
+++ b/bigdoors-spigot/spigot-core/src/main/resources/plugin.yml
@@ -5,3 +5,4 @@ author: pim16aap2
 api-version: 1.19
 libraries:
   - it.unimi.dsi:fastutil:${dependency.version.fastutil}
+  - com.alibaba:fastjson:${dependency.version.fastjson}

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/movable/MovableSerializerTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/movable/MovableSerializerTest.java
@@ -84,7 +84,7 @@ class MovableSerializerTest
             Assertions.assertDoesNotThrow(() -> new MovableSerializer<>(TestMovableType.class));
         final TestMovableType testMovableType = new TestMovableType(movableBase, "test", true, 42);
 
-        final byte[] serialized = Assertions.assertDoesNotThrow(() -> instantiator.serialize(testMovableType));
+        final String serialized = Assertions.assertDoesNotThrow(() -> instantiator.serialize(testMovableType));
         Assertions.assertEquals(testMovableType,
                                 Assertions.assertDoesNotThrow(() -> instantiator.deserialize(movableBase, serialized)));
     }
@@ -96,7 +96,7 @@ class MovableSerializerTest
             () -> new MovableSerializer<>(TestMovableSubType.class));
         final TestMovableSubType testMovableSubType1 = new TestMovableSubType(movableBase, "testSubClass", 6, true, 42);
 
-        final byte[] serialized = Assertions.assertDoesNotThrow(() -> instantiator.serialize(testMovableSubType1));
+        final String serialized = Assertions.assertDoesNotThrow(() -> instantiator.serialize(testMovableSubType1));
         final var testMovableSubType2 = Assertions.assertDoesNotThrow(
             () -> instantiator.deserialize(movableBase, serialized));
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <dependency.version.jcalculator>1.10</dependency.version.jcalculator>
         <dependency.version.gson>2.10.1</dependency.version.gson>
         <dependency.version.fastutil>8.5.11</dependency.version.fastutil>
+        <dependency.version.fastjson>2.0.23</dependency.version.fastjson>
         <dependency.version.cloud>1.8.0</dependency.version.cloud>
         <dependency.version.adventure-api>4.12.0</dependency.version.adventure-api>
         <dependency.version.adventure-bukkit>4.2.0</dependency.version.adventure-bukkit>
@@ -235,6 +236,13 @@
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
             <version>${dependency.version.checkstyle}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>${dependency.version.fastjson}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The type-specific data of the movable types are now serialized to JSON Strings instead of byte arrays. This is faster, smaller (when there are few entries, as is the case for most current types), and easier to manage.

After running some benchmarks between Gson, Jackson, Moshi, fastjson, and native serialization, fastjson was found to be much faster than the alternatives for our use-case:
```
Benchmark                                  Mode  Cnt       Score      Error  Units
BenchmarkRunner.deserialization_fastjson  thrpt  200  129360,193 ± 1634,087  ops/s
BenchmarkRunner.deserialization_gson      thrpt  200   70859,038 ±  514,139  ops/s
BenchmarkRunner.deserialization_jackson   thrpt  200   94219,281 ±  603,562  ops/s
BenchmarkRunner.deserialization_moshi     thrpt  200   48513,322 ±  368,337  ops/s
BenchmarkRunner.deserialization_native    thrpt  200   26987,703 ±  159,633  ops/s
BenchmarkRunner.serialization_fastjson    thrpt  200  156216,026 ± 1646,571  ops/s
BenchmarkRunner.serialization_gson        thrpt  200   69759,517 ±  395,680  ops/s
BenchmarkRunner.serialization_jackson     thrpt  200  137857,088 ± 1241,918  ops/s
BenchmarkRunner.serialization_moshi       thrpt  200   46917,783 ±  236,936  ops/s
BenchmarkRunner.serialization_native      thrpt  200   44789,532 ±  249,630  ops/s
```

For the benchmark, a `HashMap<String, Object>` was (de)serialized.
The map contained 100 entries with the following distribution:
- 40% random Strings.
- 20% random UUIDs.
- 10% Lists with two random Strings.
- 10% Doubles.
- 10% Booleans.
- 10% Integers.

The keys of the map were random Strings.

All random Strings for this benchmark had a random length between 5 and 15 characters.