### PR TITLE
Get rid of 1.15-related stuff in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,21 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # First use J8 for BuildTools, as older versions don't like being compiled
-      # With newer versions of Java. Generally, up until MC1.16, Java 8 will be fine.
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '8'
-          cache: 'maven'
-
-      - name: Compile 1.15.2 Minecraft Spigot
-        uses: SpraxDev/Action-SpigotMC@v4.1.0
-        with:
-          # Comma-separated list of MC versions to compile.
-          versions: 1.15.2
-
       # Now set up the actual JDK we'll use for the project itself.
       - name: Set up JDK 19
         uses: actions/setup-java@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Build the documentation site
         run: mvn --batch-mode site
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
 
       - name: Upload doortypes
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
MC 1.15 is no longer supported, so we can get rid of the compilation step for the version, as well as the Java 8 setup.