### PR TITLE
Implement versioned deserialization

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/AbstractMovable.java
@@ -50,12 +50,15 @@ public abstract class AbstractMovable implements IMovable
     @EqualsAndHashCode.Include
     private final MovableBase base;
 
+    private final MovableType type;
+
     private final LazyValue<Rectangle> lazyAnimationRange;
     private final LazyValue<Double> lazyAnimationCycleDistance;
     private final LazyValue<MovableSnapshot> lazyMovableSnapshot;
 
-    private AbstractMovable(MovableBase base)
+    private AbstractMovable(MovableBase base, MovableType type)
     {
+        this.type = type;
         serializer = getType().getMovableSerializer();
         this.lock = base.getLock();
         this.base = Objects.requireNonNull(base);
@@ -65,15 +68,16 @@ public abstract class AbstractMovable implements IMovable
         lazyMovableSnapshot = new LazyValue<>(this::createNewSnapshot);
     }
 
-    protected AbstractMovable(MovableBaseHolder holder)
+    protected AbstractMovable(MovableBaseHolder holder, MovableType type)
     {
-        this(holder.base);
+        this(holder.base, type);
     }
 
-    /**
-     * @return The {@link MovableType} of this movable.
-     */
-    public abstract MovableType getType();
+    @Override
+    public final MovableType getType()
+    {
+        return type;
+    }
 
     /**
      * Gets the animation time of this movable.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/IMovableConst.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/IMovableConst.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.bigdoors.movable;
 
 import nl.pim16aap2.bigdoors.api.IPPlayer;
 import nl.pim16aap2.bigdoors.api.IPWorld;
+import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.util.Cuboid;
 import nl.pim16aap2.bigdoors.util.MovementDirection;
 import nl.pim16aap2.bigdoors.util.Rectangle;
@@ -24,6 +25,11 @@ public interface IMovableConst
      * @return A {@link MovableSnapshot} of this {@link MovableBase}.
      */
     MovableSnapshot getSnapshot();
+
+    /**
+     * @return The {@link MovableType} of this movable.
+     */
+    MovableType getType();
 
     /**
      * Checks if this movable can be opened right now.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSerializer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSerializer.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson2.JSON;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
+import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.reflection.ReflectionBuilder;
 import nl.pim16aap2.util.SafeStringBuilder;
 import org.jetbrains.annotations.Nullable;
@@ -218,11 +219,13 @@ public final class MovableSerializer<T extends AbstractMovable>
      *     The registry to use for any potential registration.
      * @param movable
      *     The base movable data.
+     * @param version
+     *     The version of the type to deserialize. See {@link MovableType#getVersion()}.
      * @param json
      *     The serialized type-specific data represented as a json string.
      * @return The newly created instance.
      */
-    public T deserialize(MovableRegistry registry, AbstractMovable.MovableBaseHolder movable, String json)
+    public T deserialize(MovableRegistry registry, AbstractMovable.MovableBaseHolder movable, int version, String json)
     {
         //noinspection unchecked
         return (T) registry.computeIfAbsent(movable.get().getUid(), () -> deserialize(movable, json));

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSerializer.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSerializer.java
@@ -101,7 +101,7 @@ public final class MovableSerializer<T extends AbstractMovable>
         this.movableClass = movableClass;
 
         if (Modifier.isAbstract(movableClass.getModifiers()))
-            throw new IllegalArgumentException("THe MovableSerializer only works for concrete classes!");
+            throw new IllegalArgumentException("The MovableSerializer only works for concrete classes!");
 
         this.fields = findAnnotatedFields(movableClass);
         this.constructors = getConstructors(movableClass);
@@ -275,8 +275,7 @@ public final class MovableSerializer<T extends AbstractMovable>
         }
     }
 
-    @VisibleForTesting
-    DeserializationConstructor getDeserializationConstructor(int version)
+    private DeserializationConstructor getDeserializationConstructor(int version)
     {
         final @Nullable DeserializationConstructor ctor = constructors.get(version);
         //noinspection ConstantValue

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSnapshot.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/MovableSnapshot.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import nl.pim16aap2.bigdoors.api.IPWorld;
+import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.util.Cuboid;
 import nl.pim16aap2.bigdoors.util.MovementDirection;
 import nl.pim16aap2.bigdoors.util.Rectangle;
@@ -37,6 +38,7 @@ public final class MovableSnapshot implements IMovableConst
     private boolean isLocked;
     private final MovableOwner primeOwner;
     private final Map<UUID, MovableOwner> owners;
+    private final MovableType type;
 
     MovableSnapshot(AbstractMovable movable)
     {
@@ -52,7 +54,8 @@ public final class MovableSnapshot implements IMovableConst
             movable.getOpenDir(),
             movable.isLocked(),
             movable.getPrimeOwner(),
-            Map.copyOf(movable.getOwnersView())
+            Map.copyOf(movable.getOwnersView()),
+            movable.getType()
         );
     }
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/serialization/Deserialization.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/serialization/Deserialization.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.CONSTRUCTOR)
-public @interface DeserializationConstructor
+public @interface Deserialization
 {
     /**
      * @return The version of the data being deserialized.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/serialization/DeserializationConstructor.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movable/serialization/DeserializationConstructor.java
@@ -5,8 +5,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Indicates that a constructor can be used for deserialization.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.CONSTRUCTOR)
 public @interface DeserializationConstructor
 {
+    /**
+     * @return The version of the data being deserialized.
+     */
+    int version() default -1;
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movabletypes/MovableType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movabletypes/MovableType.java
@@ -45,7 +45,7 @@ public abstract class MovableType
      * @return The version of this {@link MovableType}.
      */
     @Getter
-    protected final int typeVersion;
+    protected final int version;
 
     /**
      * Obtains the value of this type that represents the key in the translation system.
@@ -56,7 +56,7 @@ public abstract class MovableType
     protected final String localizationKey;
 
     /**
-     * The fully-qualified name of this {@link MovableType}.
+     * The fully-qualified name of this {@link MovableType} formatted as "pluginName_simpleName".
      */
     @Getter
     private final String fullName;
@@ -81,24 +81,21 @@ public abstract class MovableType
      *     The name of the plugin that owns this {@link MovableType}.
      * @param simpleName
      *     The 'simple' name of this {@link MovableType}. E.g. "Flag", or "Windmill".
-     * @param typeVersion
-     *     The version of this {@link MovableType}. Note that changing the version results in a completely new
-     *     {@link MovableType}, as far as the database is concerned. This fact can be used if the parameters of the
-     *     constructor for this type need to be changed.
+     * @param version
+     *     The version of this {@link MovableType}.
      */
     protected MovableType(
-        String pluginName, String simpleName, int typeVersion, List<MovementDirection> validOpenDirections,
+        String pluginName, String simpleName, int version, List<MovementDirection> validOpenDirections,
         String localizationKey)
     {
         this.pluginName = pluginName;
         this.simpleName = simpleName.toLowerCase(Locale.ENGLISH);
-        this.typeVersion = typeVersion;
+        this.version = version;
         this.validOpenDirections =
             validOpenDirections.isEmpty() ? EnumSet.noneOf(MovementDirection.class) :
             EnumSet.copyOf(validOpenDirections);
         this.localizationKey = localizationKey;
-        fullName = String.format("%s_%s_%d", getPluginName(), getSimpleName(), getTypeVersion())
-                         .toLowerCase(Locale.ENGLISH);
+        fullName = String.format("%s_%s", getPluginName(), getSimpleName()).toLowerCase(Locale.ENGLISH);
     }
 
     /**
@@ -173,7 +170,7 @@ public abstract class MovableType
     @Override
     public final String toString()
     {
-        return getPluginName() + ":" + getSimpleName() + ":" + getTypeVersion();
+        return getPluginName() + ":" + getSimpleName() + ":" + getVersion();
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movabletypes/MovableType.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/movabletypes/MovableType.java
@@ -7,6 +7,7 @@ import nl.pim16aap2.bigdoors.managers.MovableTypeManager;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.MovableSerializer;
 import nl.pim16aap2.bigdoors.tooluser.creator.Creator;
+import nl.pim16aap2.bigdoors.util.LazyValue;
 import nl.pim16aap2.bigdoors.util.MovementDirection;
 import org.jetbrains.annotations.Nullable;
 
@@ -71,7 +72,7 @@ public abstract class MovableType
     @Getter
     private final Set<MovementDirection> validOpenDirections;
 
-    private volatile @Nullable MovableSerializer<?> movableSerializer;
+    private final LazyValue<MovableSerializer<?>> lazyMovableSerializer;
 
     /**
      * Constructs a new {@link MovableType}. Don't forget to also register it using
@@ -96,6 +97,8 @@ public abstract class MovableType
             EnumSet.copyOf(validOpenDirections);
         this.localizationKey = localizationKey;
         fullName = String.format("%s_%s", getPluginName(), getSimpleName()).toLowerCase(Locale.ENGLISH);
+
+        lazyMovableSerializer = new LazyValue<>(() -> new MovableSerializer<>(this));
     }
 
     /**
@@ -103,17 +106,9 @@ public abstract class MovableType
      *
      * @return The {@link MovableSerializer}.
      */
-    @SuppressWarnings("ConstantConditions")
     public final MovableSerializer<?> getMovableSerializer()
     {
-        if (movableSerializer != null)
-            return movableSerializer;
-        synchronized (this)
-        {
-            if (movableSerializer == null)
-                movableSerializer = new MovableSerializer<>(getMovableClass());
-            return movableSerializer;
-        }
+        return lazyMovableSerializer.get();
     }
 
     /**
@@ -170,7 +165,8 @@ public abstract class MovableType
     @Override
     public final String toString()
     {
-        return getPluginName() + ":" + getSimpleName() + ":" + getVersion();
+        return "MovableType[@" + Integer.toHexString(hashCode()) + "] " +
+            getPluginName() + ":" + getSimpleName() + ":" + getVersion();
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/SQLStatement.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/SQLStatement.java
@@ -31,6 +31,7 @@ public enum SQLStatement
         powerBlockChunkId = ?,
         openDirection  = ?,
         bitflag        = ?,
+        typeVersion    = ?,
         typeData       = ?
         WHERE id       = ?;
         """
@@ -56,7 +57,7 @@ public enum SQLStatement
     ),
 
     DELETE_MOVABLE_TYPE(
-        "DELETE FROM Movables WHERE Movables.movableType = ?;"
+        "DELETE FROM Movables WHERE Movables.type = ?;"
     ),
 
     GET_LATEST_ROW_ADDITION(
@@ -257,8 +258,8 @@ public enum SQLStatement
         INSERT INTO Movables
         (name, world, xMin, yMin, zMin, xMax, yMax, zMax, rotationPointX, rotationPointY, rotationPointZ,
          rotationPointChunkId, powerBlockX, powerBlockY, powerBlockZ, powerBlockChunkId, openDirection,
-         bitflag, movableType, typeData)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+         bitflag, type, typeVersion, typeData)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         """
     ),
 
@@ -350,7 +351,8 @@ public enum SQLStatement
         powerBlockZ           INTEGER    NOT NULL,
         powerBlockChunkId     INTEGER    NOT NULL,
         openDirection         INTEGER    NOT NULL,
-        movableType           TEXT       NOT NULL,
+        type                  TEXT       NOT NULL,
+        typeVersion           INTEGER    NOT NULL,
         typeData              TEXT       NOT NULL,
         bitflag               INTEGER    NOT NULL);
         """

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/sqlite/SQLiteJDBCDriverConnection.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/storage/sqlite/SQLiteJDBCDriverConnection.java
@@ -384,7 +384,8 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
                               .build();
 
         final String rawTypeData = movableBaseRS.getString("typeData");
-        return Optional.of(serializer.deserialize(movableRegistry, movableData, rawTypeData));
+        final int typeVersion = movableBaseRS.getInt("typeVersion");
+        return Optional.of(serializer.deserialize(movableRegistry, movableData, typeVersion, rawTypeData));
     }
 
     @Override
@@ -470,7 +471,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
                         .primeOwner(remapMovableOwner(movable.getPrimeOwner(), movableUID))
                         .ownersOfMovable(remapMovableOwners(movable.getOwners(), movableUID))
                         .build(),
-                    typeData));
+                    movable.getType().getVersion(), typeData));
             }
         }
         catch (Exception t)

--- a/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/BigDoor.java
+++ b/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/BigDoor.java
@@ -6,7 +6,6 @@ import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
-import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -30,8 +29,6 @@ import java.util.stream.Stream;
 @Flogger
 public class BigDoor extends AbstractMovable
 {
-    private static final MovableType MOVABLE_TYPE = MovableBigDoor.get();
-
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
@@ -39,14 +36,8 @@ public class BigDoor extends AbstractMovable
     @DeserializationConstructor
     public BigDoor(AbstractMovable.MovableBaseHolder base)
     {
-        super(base);
+        super(base, MovableBigDoor.get());
         this.lock = getLock();
-    }
-
-    @Override
-    public MovableType getType()
-    {
-        return MOVABLE_TYPE;
     }
 
     @Override

--- a/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/BigDoor.java
+++ b/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/BigDoor.java
@@ -5,7 +5,7 @@ import lombok.ToString;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -33,7 +33,7 @@ public class BigDoor extends AbstractMovable
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
-    @DeserializationConstructor
+    @Deserialization
     public BigDoor(AbstractMovable.MovableBaseHolder base)
     {
         super(base, MovableBigDoor.get());

--- a/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/MovableBigDoor.java
+++ b/bigdoors-doors/doors-bigdoor/src/main/java/nl/pim16aap2/bigdoors/movable/bigdoor/MovableBigDoor.java
@@ -29,8 +29,6 @@ public final class MovableBigDoor extends MovableType
     }
 
     /**
-     * Obtains the instance of this type.
-     *
      * @return The instance of this type.
      */
     public static MovableBigDoor get()

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/Clock.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/Clock.java
@@ -6,7 +6,7 @@ import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -60,7 +60,7 @@ public class Clock extends AbstractMovable implements IHorizontalAxisAligned
     @Getter
     protected final PBlockFace hourArmSide;
 
-    @DeserializationConstructor
+    @Deserialization
     public Clock(
         AbstractMovable.MovableBaseHolder base,
         @PersistentVariable("northSouthAligned") boolean northSouthAligned,

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/Clock.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/Clock.java
@@ -8,7 +8,6 @@ import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
-import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -28,8 +27,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @EqualsAndHashCode(callSuper = true)
 public class Clock extends AbstractMovable implements IHorizontalAxisAligned
 {
-    private static final MovableType MOVABLE_TYPE = MovableTypeClock.get();
-
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
@@ -65,10 +62,11 @@ public class Clock extends AbstractMovable implements IHorizontalAxisAligned
 
     @DeserializationConstructor
     public Clock(
-        AbstractMovable.MovableBaseHolder base, @PersistentVariable("northSouthAligned") boolean northSouthAligned,
+        AbstractMovable.MovableBaseHolder base,
+        @PersistentVariable("northSouthAligned") boolean northSouthAligned,
         @PersistentVariable("hourArmSide") PBlockFace hourArmSide)
     {
-        super(base);
+        super(base, MovableTypeClock.get());
         this.lock = getLock();
         this.northSouthAligned = northSouthAligned;
         this.hourArmSide = hourArmSide;
@@ -77,12 +75,6 @@ public class Clock extends AbstractMovable implements IHorizontalAxisAligned
     public Clock(AbstractMovable.MovableBaseHolder base)
     {
         this(base, false, PBlockFace.NONE);
-    }
-
-    @Override
-    public MovableType getType()
-    {
-        return MOVABLE_TYPE;
     }
 
     @Override

--- a/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/MovableTypeClock.java
+++ b/bigdoors-doors/doors-clock/src/main/java/nl/pim16aap2/bigdoors/movable/clock/MovableTypeClock.java
@@ -24,8 +24,6 @@ public final class MovableTypeClock extends MovableType
     }
 
     /**
-     * Obtains the instance of this type.
-     *
      * @return The instance of this type.
      */
     public static MovableTypeClock get()

--- a/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/Drawbridge.java
+++ b/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/Drawbridge.java
@@ -7,7 +7,7 @@ import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -47,7 +47,7 @@ public class Drawbridge extends AbstractMovable implements IHorizontalAxisAligne
     @Setter(onMethod_ = @Locked.Write)
     protected boolean modeUp;
 
-    @DeserializationConstructor
+    @Deserialization
     public Drawbridge(AbstractMovable.MovableBaseHolder base, @PersistentVariable("modeUp") boolean modeUp)
     {
         super(base, MovableTypeDrawbridge.get());

--- a/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/Drawbridge.java
+++ b/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/Drawbridge.java
@@ -9,7 +9,6 @@ import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
-import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -32,8 +31,6 @@ import java.util.stream.Stream;
 @Flogger
 public class Drawbridge extends AbstractMovable implements IHorizontalAxisAligned
 {
-    private static final MovableType MOVABLE_TYPE = MovableTypeDrawbridge.get();
-
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
@@ -53,15 +50,9 @@ public class Drawbridge extends AbstractMovable implements IHorizontalAxisAligne
     @DeserializationConstructor
     public Drawbridge(AbstractMovable.MovableBaseHolder base, @PersistentVariable("modeUp") boolean modeUp)
     {
-        super(base);
+        super(base, MovableTypeDrawbridge.get());
         this.lock = getLock();
         this.modeUp = modeUp;
-    }
-
-    @Override
-    public MovableType getType()
-    {
-        return MOVABLE_TYPE;
     }
 
     @Override

--- a/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/MovableTypeDrawbridge.java
+++ b/bigdoors-doors/doors-drawbridge/src/main/java/nl/pim16aap2/bigdoors/movable/drawbridge/MovableTypeDrawbridge.java
@@ -36,8 +36,6 @@ public final class MovableTypeDrawbridge extends MovableType
     }
 
     /**
-     * Obtains the instance of this type.
-     *
      * @return The instance of this type.
      */
     public static MovableTypeDrawbridge get()

--- a/bigdoors-doors/doors-elevator/src/main/java/nl/pim16aap2/bigdoors/movable/elevator/Elevator.java
+++ b/bigdoors-doors/doors-elevator/src/main/java/nl/pim16aap2/bigdoors/movable/elevator/Elevator.java
@@ -4,7 +4,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.portcullis.Portcullis;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 
 /**
@@ -17,7 +17,7 @@ import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 @EqualsAndHashCode(callSuper = true)
 public class Elevator extends Portcullis
 {
-    @DeserializationConstructor
+    @Deserialization
     public Elevator(AbstractMovable.MovableBaseHolder base, @PersistentVariable("blocksToMove") int blocksToMove)
     {
         super(base, MovableTypeElevator.get(), blocksToMove);

--- a/bigdoors-doors/doors-elevator/src/main/java/nl/pim16aap2/bigdoors/movable/elevator/Elevator.java
+++ b/bigdoors-doors/doors-elevator/src/main/java/nl/pim16aap2/bigdoors/movable/elevator/Elevator.java
@@ -6,7 +6,6 @@ import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.portcullis.Portcullis;
 import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
-import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 
 /**
  * Represents an Elevator movable type.
@@ -18,17 +17,9 @@ import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 @EqualsAndHashCode(callSuper = true)
 public class Elevator extends Portcullis
 {
-    private static final MovableType MOVABLE_TYPE = MovableTypeElevator.get();
-
     @DeserializationConstructor
     public Elevator(AbstractMovable.MovableBaseHolder base, @PersistentVariable("blocksToMove") int blocksToMove)
     {
-        super(base, blocksToMove);
-    }
-
-    @Override
-    public MovableType getType()
-    {
-        return MOVABLE_TYPE;
+        super(base, MovableTypeElevator.get(), blocksToMove);
     }
 }

--- a/bigdoors-doors/doors-elevator/src/main/java/nl/pim16aap2/bigdoors/movable/elevator/MovableTypeElevator.java
+++ b/bigdoors-doors/doors-elevator/src/main/java/nl/pim16aap2/bigdoors/movable/elevator/MovableTypeElevator.java
@@ -29,8 +29,6 @@ public final class MovableTypeElevator extends MovableType
     }
 
     /**
-     * Obtains the instance of this type.
-     *
      * @return The instance of this type.
      */
     public static MovableTypeElevator get()

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/Flag.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/Flag.java
@@ -7,7 +7,7 @@ import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IPerpetualMover;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -45,7 +45,7 @@ public class Flag extends AbstractMovable implements IHorizontalAxisAligned, IPe
     @PersistentVariable("northSouthAligned")
     protected final boolean northSouthAligned;
 
-    @DeserializationConstructor
+    @Deserialization
     public Flag(
         AbstractMovable.MovableBaseHolder base, @PersistentVariable("northSouthAligned") boolean northSouthAligned)
     {

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/Flag.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/Flag.java
@@ -9,7 +9,6 @@ import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IPerpetualMover;
 import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
-import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -29,8 +28,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @EqualsAndHashCode(callSuper = true)
 public class Flag extends AbstractMovable implements IHorizontalAxisAligned, IPerpetualMover
 {
-    private static final MovableType MOVABLE_TYPE = MovableTypeFlag.get();
-
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
@@ -52,15 +49,9 @@ public class Flag extends AbstractMovable implements IHorizontalAxisAligned, IPe
     public Flag(
         AbstractMovable.MovableBaseHolder base, @PersistentVariable("northSouthAligned") boolean northSouthAligned)
     {
-        super(base);
+        super(base, MovableTypeFlag.get());
         this.lock = getLock();
         this.northSouthAligned = northSouthAligned;
-    }
-
-    @Override
-    public MovableType getType()
-    {
-        return MOVABLE_TYPE;
     }
 
     @Override

--- a/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/MovableTypeFlag.java
+++ b/bigdoors-doors/doors-flag/src/main/java/nl/pim16aap2/bigdoors/movable/flag/MovableTypeFlag.java
@@ -21,8 +21,6 @@ public final class MovableTypeFlag extends MovableType
     }
 
     /**
-     * Obtains the instance of this type.
-     *
      * @return The instance of this type.
      */
     public static MovableTypeFlag get()

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoor.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoor.java
@@ -10,7 +10,6 @@ import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
-import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -33,8 +32,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @Flogger
 public class GarageDoor extends AbstractMovable implements IHorizontalAxisAligned
 {
-    private static final MovableType MOVABLE_TYPE = MovableGarageDoor.get();
-
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
@@ -58,15 +55,9 @@ public class GarageDoor extends AbstractMovable implements IHorizontalAxisAligne
     public GarageDoor(
         AbstractMovable.MovableBaseHolder base, @PersistentVariable("northSouthAligned") boolean northSouthAligned)
     {
-        super(base);
+        super(base, MovableGarageDoor.get());
         this.lock = getLock();
         this.northSouthAligned = northSouthAligned;
-    }
-
-    @Override
-    public MovableType getType()
-    {
-        return MOVABLE_TYPE;
     }
 
     @Override

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoor.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/GarageDoor.java
@@ -8,7 +8,7 @@ import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -51,7 +51,7 @@ public class GarageDoor extends AbstractMovable implements IHorizontalAxisAligne
     @PersistentVariable("northSouthAligned")
     protected final boolean northSouthAligned;
 
-    @DeserializationConstructor
+    @Deserialization
     public GarageDoor(
         AbstractMovable.MovableBaseHolder base, @PersistentVariable("northSouthAligned") boolean northSouthAligned)
     {

--- a/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/MovableGarageDoor.java
+++ b/bigdoors-doors/doors-garagedoor/src/main/java/nl/pim16aap2/bigdoors/movable/garagedoor/MovableGarageDoor.java
@@ -30,8 +30,6 @@ public final class MovableGarageDoor extends MovableType
     }
 
     /**
-     * Obtains the instance of this type.
-     *
      * @return The instance of this type.
      */
     public static MovableGarageDoor get()

--- a/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/MovableTypePortcullis.java
+++ b/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/MovableTypePortcullis.java
@@ -29,8 +29,6 @@ public final class MovableTypePortcullis extends MovableType
     }
 
     /**
-     * Obtains the instance of this type.
-     *
      * @return The instance of this type.
      */
     public static MovableTypePortcullis get()

--- a/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
+++ b/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
@@ -6,7 +6,7 @@ import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IDiscreteMovement;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
@@ -48,7 +48,7 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
         this.blocksToMove = blocksToMove;
     }
 
-    @DeserializationConstructor
+    @Deserialization
     public Portcullis(AbstractMovable.MovableBaseHolder base, @PersistentVariable("blocksToMove") int blocksToMove)
     {
         this(base, MovableTypePortcullis.get(), blocksToMove);

--- a/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
+++ b/bigdoors-doors/doors-portcullis/src/main/java/nl/pim16aap2/bigdoors/movable/portcullis/Portcullis.java
@@ -29,8 +29,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @EqualsAndHashCode(callSuper = true)
 public class Portcullis extends AbstractMovable implements IDiscreteMovement
 {
-    private static final MovableType MOVABLE_TYPE = MovableTypePortcullis.get();
-
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
@@ -40,12 +38,20 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
     @Getter(onMethod_ = @Locked.Read)
     protected int blocksToMove;
 
+    protected Portcullis(
+        AbstractMovable.MovableBaseHolder base,
+        MovableType type,
+        @PersistentVariable("blocksToMove") int blocksToMove)
+    {
+        super(base, type);
+        this.lock = getLock();
+        this.blocksToMove = blocksToMove;
+    }
+
     @DeserializationConstructor
     public Portcullis(AbstractMovable.MovableBaseHolder base, @PersistentVariable("blocksToMove") int blocksToMove)
     {
-        super(base);
-        this.lock = getLock();
-        this.blocksToMove = blocksToMove;
+        this(base, MovableTypePortcullis.get(), blocksToMove);
     }
 
     @Override
@@ -70,12 +76,6 @@ public class Portcullis extends AbstractMovable implements IDiscreteMovement
         final Vector3Di max = cuboid.getMax();
 
         return new Cuboid(min.add(0, -blocksToMove, 0), max.add(0, blocksToMove, 0)).asFlatRectangle();
-    }
-
-    @Override
-    public MovableType getType()
-    {
-        return MOVABLE_TYPE;
     }
 
     @Override

--- a/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoor.java
+++ b/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoor.java
@@ -8,7 +8,7 @@ import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.bigdoor.BigDoor;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -46,7 +46,7 @@ public class RevolvingDoor extends AbstractMovable
     @Setter(onMethod_ = @Locked.Write)
     private int quarterCircles;
 
-    @DeserializationConstructor
+    @Deserialization
     public RevolvingDoor(
         AbstractMovable.MovableBaseHolder base,
         @PersistentVariable("quarterCircles") int quarterCircles)

--- a/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoor.java
+++ b/bigdoors-doors/doors-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/revolvingdoor/RevolvingDoor.java
@@ -10,7 +10,6 @@ import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.bigdoor.BigDoor;
 import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
-import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -32,8 +31,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @Flogger
 public class RevolvingDoor extends AbstractMovable
 {
-    private static final MovableType MOVABLE_TYPE = MovableRevolvingDoor.get();
-
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
@@ -51,9 +48,10 @@ public class RevolvingDoor extends AbstractMovable
 
     @DeserializationConstructor
     public RevolvingDoor(
-        AbstractMovable.MovableBaseHolder base, @PersistentVariable("quarterCircles") int quarterCircles)
+        AbstractMovable.MovableBaseHolder base,
+        @PersistentVariable("quarterCircles") int quarterCircles)
     {
-        super(base);
+        super(base, MovableRevolvingDoor.get());
         this.lock = getLock();
         this.quarterCircles = quarterCircles;
     }
@@ -76,12 +74,6 @@ public class RevolvingDoor extends AbstractMovable
     {
         final double maxRadius = BigDoor.getMaxRadius(getCuboid(), getRotationPoint());
         return BigDoor.calculateAnimationRange(maxRadius, getCuboid());
-    }
-
-    @Override
-    public MovableType getType()
-    {
-        return MOVABLE_TYPE;
     }
 
     @Override

--- a/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/MovableSlidingDoor.java
+++ b/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/MovableSlidingDoor.java
@@ -30,8 +30,6 @@ public final class MovableSlidingDoor extends MovableType
     }
 
     /**
-     * Obtains the instance of this type.
-     *
      * @return The instance of this type.
      */
     public static MovableSlidingDoor get()

--- a/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
+++ b/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
@@ -6,7 +6,7 @@ import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IDiscreteMovement;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -39,7 +39,7 @@ public class SlidingDoor extends AbstractMovable implements IDiscreteMovement
     @Getter(onMethod_ = @Locked.Read)
     protected int blocksToMove;
 
-    @DeserializationConstructor
+    @Deserialization
     public SlidingDoor(AbstractMovable.MovableBaseHolder base, @PersistentVariable("blocksToMove") int blocksToMove)
     {
         super(base, MovableSlidingDoor.get());

--- a/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
+++ b/bigdoors-doors/doors-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/movable/slidingdoor/SlidingDoor.java
@@ -8,7 +8,6 @@ import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IDiscreteMovement;
 import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
-import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -31,8 +30,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @EqualsAndHashCode(callSuper = true)
 public class SlidingDoor extends AbstractMovable implements IDiscreteMovement
 {
-    private static final MovableType MOVABLE_TYPE = MovableSlidingDoor.get();
-
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
@@ -45,15 +42,9 @@ public class SlidingDoor extends AbstractMovable implements IDiscreteMovement
     @DeserializationConstructor
     public SlidingDoor(AbstractMovable.MovableBaseHolder base, @PersistentVariable("blocksToMove") int blocksToMove)
     {
-        super(base);
+        super(base, MovableSlidingDoor.get());
         this.lock = getLock();
         this.blocksToMove = blocksToMove;
-    }
-
-    @Override
-    public MovableType getType()
-    {
-        return MOVABLE_TYPE;
     }
 
     @Override

--- a/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/MovableTypeWindmill.java
+++ b/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/MovableTypeWindmill.java
@@ -30,8 +30,6 @@ public final class MovableTypeWindmill extends MovableType
     }
 
     /**
-     * Obtains the instance of this type.
-     *
      * @return The instance of this type.
      */
     public static MovableTypeWindmill get()

--- a/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/Windmill.java
+++ b/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/Windmill.java
@@ -11,7 +11,6 @@ import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IPerpetualMover;
 import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
-import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
 import nl.pim16aap2.bigdoors.util.Cuboid;
@@ -32,8 +31,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @EqualsAndHashCode(callSuper = true)
 public class Windmill extends AbstractMovable implements IHorizontalAxisAligned, IPerpetualMover
 {
-    private static final MovableType MOVABLE_TYPE = MovableTypeWindmill.get();
-
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
@@ -52,7 +49,7 @@ public class Windmill extends AbstractMovable implements IHorizontalAxisAligned,
     @DeserializationConstructor
     public Windmill(AbstractMovable.MovableBaseHolder base, @PersistentVariable("quarterCircles") int quarterCircles)
     {
-        super(base);
+        super(base, MovableTypeWindmill.get());
         this.lock = getLock();
         this.quarterCircles = quarterCircles;
     }
@@ -60,12 +57,6 @@ public class Windmill extends AbstractMovable implements IHorizontalAxisAligned,
     public Windmill(AbstractMovable.MovableBaseHolder doorBase)
     {
         this(doorBase, 1);
-    }
-
-    @Override
-    public MovableType getType()
-    {
-        return MOVABLE_TYPE;
     }
 
     @Override

--- a/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/Windmill.java
+++ b/bigdoors-doors/doors-windmill/src/main/java/nl/pim16aap2/bigdoors/movable/windmill/Windmill.java
@@ -9,7 +9,7 @@ import nl.pim16aap2.bigdoors.movable.AbstractMovable;
 import nl.pim16aap2.bigdoors.movable.drawbridge.Drawbridge;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.movable.movablearchetypes.IPerpetualMover;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.moveblocks.MovementRequestData;
@@ -46,7 +46,7 @@ public class Windmill extends AbstractMovable implements IHorizontalAxisAligned,
     @Setter(onMethod_ = @Locked.Write)
     private int quarterCircles;
 
-    @DeserializationConstructor
+    @Deserialization
     public Windmill(AbstractMovable.MovableBaseHolder base, @PersistentVariable("quarterCircles") int quarterCircles)
     {
         super(base, MovableTypeWindmill.get());

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/movable/MovableSerializerTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/movable/MovableSerializerTest.java
@@ -3,7 +3,7 @@ package nl.pim16aap2.bigdoors.movable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import nl.pim16aap2.bigdoors.api.PPlayerData;
-import nl.pim16aap2.bigdoors.movable.serialization.DeserializationConstructor;
+import nl.pim16aap2.bigdoors.movable.serialization.Deserialization;
 import nl.pim16aap2.bigdoors.movable.serialization.PersistentVariable;
 import nl.pim16aap2.bigdoors.movabletypes.MovableType;
 import nl.pim16aap2.bigdoors.moveblocks.IAnimationComponent;
@@ -59,18 +59,19 @@ class MovableSerializerTest
     @Test
     void instantiate()
     {
-        final var instantiator = Assertions.assertDoesNotThrow(() -> new MovableSerializer<>(TestMovableType.class));
+        final var instantiator =
+            Assertions.assertDoesNotThrow(() -> new MovableSerializer<>(TestMovableType.class));
         final TestMovableType base = new TestMovableType(movableBase, "test", true, 42);
 
         TestMovableType test = Assertions.assertDoesNotThrow(
-            () -> instantiator.instantiate(movableBase,
+            () -> instantiator.instantiate(movableBase, 1,
                                            Map.of("testName", "test",
                                                   "isCoolType", true,
                                                   "blockTestCount", 42)));
         Assertions.assertEquals(base, test);
 
         test = Assertions.assertDoesNotThrow(
-            () -> instantiator.instantiate(movableBase,
+            () -> instantiator.instantiate(movableBase, 1,
                                            Map.of("testName", "alternativeName",
                                                   "isCoolType", true,
                                                   "blockTestCount", 42)));
@@ -85,8 +86,9 @@ class MovableSerializerTest
         final TestMovableType testMovableType = new TestMovableType(movableBase, "test", true, 42);
 
         final String serialized = Assertions.assertDoesNotThrow(() -> instantiator.serialize(testMovableType));
-        Assertions.assertEquals(testMovableType,
-                                Assertions.assertDoesNotThrow(() -> instantiator.deserialize(movableBase, serialized)));
+        Assertions.assertEquals(
+            testMovableType,
+            Assertions.assertDoesNotThrow(() -> instantiator.deserialize(movableBase, 1, serialized)));
     }
 
     @Test
@@ -98,7 +100,7 @@ class MovableSerializerTest
 
         final String serialized = Assertions.assertDoesNotThrow(() -> instantiator.serialize(testMovableSubType1));
         final var testMovableSubType2 = Assertions.assertDoesNotThrow(
-            () -> instantiator.deserialize(movableBase, serialized));
+            () -> instantiator.deserialize(movableBase, 1, serialized));
 
         Assertions.assertEquals(testMovableSubType1, testMovableSubType2);
     }
@@ -121,7 +123,7 @@ class MovableSerializerTest
         final TestMovableType testMovableType0 = new TestMovableType(movableBase, null, true, 42);
 
         final TestMovableType testMovableType1 =
-            instantiator.instantiate(movableBase,
+            instantiator.instantiate(movableBase, 1,
                                      Map.of("isCoolType", true,
                                             "blockTestCount", 42));
 
@@ -138,7 +140,7 @@ class MovableSerializerTest
         // Only objects can be missing.
         Assertions.assertThrows(
             Exception.class,
-            () -> instantiator.instantiate(movableBase,
+            () -> instantiator.instantiate(movableBase, 1,
                                            Map.of("testName", "testName",
                                                   "isCoolType", false)));
     }
@@ -184,7 +186,7 @@ class MovableSerializerTest
             this.lock = super.getLock();
         }
 
-        @DeserializationConstructor
+        @Deserialization
         public TestMovableType(
             AbstractMovable.MovableBaseHolder base,
             @Nullable String testName,
@@ -251,7 +253,7 @@ class MovableSerializerTest
         @PersistentVariable("subclassTestValue")
         private final int subclassTestValue;
 
-        @DeserializationConstructor
+        @Deserialization
         public TestMovableSubType(
             AbstractMovable.MovableBaseHolder base,
             String testName,
@@ -280,7 +282,7 @@ class MovableSerializerTest
         @PersistentVariable("ambiguousInteger1")
         private final int ambiguousInteger1;
 
-        @DeserializationConstructor
+        @Deserialization
         public TestMovableSubTypeAmbiguousParameterTypes(
             AbstractMovable.MovableBaseHolder base,
             String testName,
@@ -295,10 +297,11 @@ class MovableSerializerTest
         }
     }
 
+    @SuppressWarnings("unused")
     @EqualsAndHashCode(callSuper = true)
     private static class TestMovableSubTypeAmbiguousParameterNames extends TestMovableType
     {
-        @DeserializationConstructor
+        @Deserialization
         public TestMovableSubTypeAmbiguousParameterNames(
             AbstractMovable.MovableBaseHolder base,
             @PersistentVariable("ambiguous") UUID o0,
@@ -308,6 +311,7 @@ class MovableSerializerTest
         }
     }
 
+    @SuppressWarnings("unused")
     @EqualsAndHashCode(callSuper = true)
     private static class TestMovableSubTypeAmbiguousFieldTypes extends TestMovableType
     {
@@ -317,13 +321,14 @@ class MovableSerializerTest
         @PersistentVariable
         private int ambiguousInteger1;
 
-        @DeserializationConstructor
+        @Deserialization
         public TestMovableSubTypeAmbiguousFieldTypes(AbstractMovable.MovableBaseHolder base)
         {
             super(base);
         }
     }
 
+    @SuppressWarnings("unused")
     @EqualsAndHashCode(callSuper = true)
     private static class TestMovableSubTypeAmbiguousFieldNames extends TestMovableType
     {
@@ -333,7 +338,7 @@ class MovableSerializerTest
         @PersistentVariable("ambiguous")
         private String field1;
 
-        @DeserializationConstructor
+        @Deserialization
         public TestMovableSubTypeAmbiguousFieldNames(AbstractMovable.MovableBaseHolder base)
         {
             super(base);

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/movable/MovableSerializerTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/movable/MovableSerializerTest.java
@@ -160,6 +160,8 @@ class MovableSerializerTest
     @EqualsAndHashCode(callSuper = false)
     private static class TestMovableType extends AbstractMovable
     {
+        private static final MovableType MOVABLE_TYPE = Mockito.mock(MovableType.class);
+
         @EqualsAndHashCode.Exclude
         @SuppressWarnings({"unused", "FieldCanBeLocal"})
         private final ReentrantReadWriteLock lock;
@@ -176,11 +178,9 @@ class MovableSerializerTest
         @PersistentVariable("blockTestCount")
         private int blockTestCount;
 
-        private static final MovableType MOVABLE_TYPE = Mockito.mock(MovableType.class);
-
         public TestMovableType(AbstractMovable.MovableBaseHolder movableBase)
         {
-            super(movableBase);
+            super(movableBase, MOVABLE_TYPE);
             this.lock = super.getLock();
         }
 
@@ -195,12 +195,6 @@ class MovableSerializerTest
             this.testName = testName;
             this.isCoolType = isCoolType;
             this.blockTestCount = blockTestCount;
-        }
-
-        @Override
-        public MovableType getType()
-        {
-            return MOVABLE_TYPE;
         }
 
         @Override

--- a/utilities/util/src/main/java/nl/pim16aap2/reflection/ConstructorFinder.java
+++ b/utilities/util/src/main/java/nl/pim16aap2/reflection/ConstructorFinder.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -59,10 +60,21 @@ public class ConstructorFinder
                 ReflectionBackend.formatOptionalValue(parameters)));
         }
 
+        /**
+         * @return All constructors that match the provided data.
+         */
+        public List<Constructor<?>> getAll()
+        {
+            return ReflectionBackend.findCTor(
+                source, modifiers, parameters, setAccessible, Integer.MAX_VALUE, annotations);
+        }
+
         @Override
         public @Nullable Constructor<?> getNullable()
         {
-            return ReflectionBackend.findCTor(source, modifiers, parameters, setAccessible, annotations);
+            final List<Constructor<?>> ctors =
+                ReflectionBackend.findCTor(source, modifiers, parameters, setAccessible, 1, annotations);
+            return ctors.isEmpty() ? null : ctors.get(0);
         }
 
         @Override

--- a/utilities/util/src/main/java/nl/pim16aap2/reflection/ReflectionBackend.java
+++ b/utilities/util/src/main/java/nl/pim16aap2/reflection/ReflectionBackend.java
@@ -406,13 +406,16 @@ final class ReflectionBackend
      *     The parameters of the constructor. When this is null, the constructor's parameters are ignored.
      * @param setAccessible
      *     True to use {@link AccessibleObject#setAccessible(boolean)}.
-     * @return The constructor matching the specified description.
+     * @param maxCount
+     *     The maximum number of constructors to return.
+     * @return All constructors matching the specified description.
      */
     @SafeVarargs
-    public static @Nullable Constructor<?> findCTor(
-        Class<?> source, int modifiers, @Nullable ParameterGroup parameters, boolean setAccessible,
+    public static List<Constructor<?>> findCTor(
+        Class<?> source, int modifiers, @Nullable ParameterGroup parameters, boolean setAccessible, int maxCount,
         Class<? extends Annotation>... annotations)
     {
+        final List<Constructor<?>> ret = new ArrayList<>();
         for (final Constructor<?> ctor : source.getDeclaredConstructors())
         {
             if (modifiers != 0 && ctor.getModifiers() != modifiers)
@@ -421,9 +424,11 @@ final class ReflectionBackend
                 continue;
             if (!containsAnnotations(ctor, annotations))
                 continue;
-            return setAccessibleIfNeeded(ctor, setAccessible);
+            ret.add(setAccessibleIfNeeded(ctor, setAccessible));
+            if (ret.size() >= maxCount)
+                break;
         }
-        return null;
+        return ret;
     }
 
     /**


### PR DESCRIPTION
The `@Deserialization` annotation now accepts a version. When deserializing data, the plugin will try to pick the constructor for the correct version. If no constructor exists for the specific version, the default constructor is used.