### PR TITLE
Improve perpetual movement

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/commands/Info.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/commands/Info.java
@@ -78,7 +78,9 @@ public class Info extends StructureTargetCommand
                                            "constants.open_status.open" : "constants.open_status.closed"))
               .append('\n')
 
-              .append("Its open direction is: ", TextType.INFO).append("counter-clockwise\n", TextType.HIGHLIGHT)
+              .append("Its open direction is: ", TextType.INFO)
+              .append(localizer.getMessage(structure.getOpenDir().getLocalizationKey()), TextType.HIGHLIGHT)
+              .append('\n')
 
               .append("It is ", TextType.INFO)
               .append(localizer.getMessage(structure.isLocked() ?

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/Animator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/Animator.java
@@ -212,7 +212,7 @@ public final class Animator implements IAnimator
         final double animationTime = Math.min(animationType.getAnimationDurationLimit(), data.getAnimationTime());
         this.animationDuration = AnimationUtil.getAnimationTicks(animationTime, data.getServerTickTime());
 
-        this.perpetualMovement = !data.isPerpetualMovementPrevented() && isPerpetualMovement();
+        this.perpetualMovement = !data.isPreventPerpetualMovement() && isPerpetualMovement();
     }
 
     private boolean isPerpetualMovement()

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/Animator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/Animator.java
@@ -431,6 +431,23 @@ public final class Animator implements IAnimator
     }
 
     /**
+     * Calculates the number of ticks required in addition to the base duration of the animation to gracefully end an
+     * animation.
+     *
+     * @return The number of ticks required to gracefully stop the animation.
+     */
+    private int getStopCount()
+    {
+        // Perpetual movers will usually not require to stop gracefully; Their blocks are not meant to
+        // travel to a given position, so they can stop at any position and adding a stopCount can look glitchy.
+        if (structure instanceof IPerpetualMover)
+            return 0;
+
+        final int finishDurationTicks = Math.round((float) movementMethod.finishDuration() / serverTickTime);
+        return animationDuration + Math.max(0, finishDurationTicks);
+    }
+
+    /**
      * Runs the animation of the animated blocks.
      */
     private void animateEntities(Animation<IAnimatedBlock> animation)
@@ -450,9 +467,7 @@ public final class Animator implements IAnimator
 
         forEachHook("onPrepare", IAnimationHook::onPrepare);
 
-        final int finishDurationTicks = Math.round((float) movementMethod.finishDuration() / serverTickTime);
-        final int stopCount = animationDuration + Math.max(0, finishDurationTicks);
-
+        final int stopCount = getStopCount();
         final int initialDelay = Math.round((float) START_DELAY / serverTickTime);
 
         final TimerTask moverTask0 = new TimerTask()

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/Animator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/Animator.java
@@ -212,7 +212,7 @@ public final class Animator implements IAnimator
         final double animationTime = Math.min(animationType.getAnimationDurationLimit(), data.getAnimationTime());
         this.animationDuration = AnimationUtil.getAnimationTicks(animationTime, data.getServerTickTime());
 
-        this.perpetualMovement = isPerpetualMovement();
+        this.perpetualMovement = !data.isPerpetualMovementPrevented() && isPerpetualMovement();
     }
 
     private boolean isPerpetualMovement()

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/Animator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/Animator.java
@@ -217,9 +217,7 @@ public final class Animator implements IAnimator
 
     private boolean isPerpetualMovement()
     {
-        return this.animationType.allowsPerpetualAnimation() &&
-            structure instanceof IPerpetualMover perpetualMover &&
-            perpetualMover.isPerpetual();
+        return this.animationType.allowsPerpetualAnimation() && structure instanceof IPerpetualMover;
     }
 
     /**

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/StructureRequestData.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/StructureRequestData.java
@@ -43,13 +43,13 @@ public final class StructureRequestData
         IAudioPlayer audioPlayer,
         IExecutor executor,
         AnimationHookManager animationHookManager,
-        IConfig config,
         @Named("serverTickTime") int serverTickTime,
+        IConfig config,
         @Assisted StructureSnapshot structureSnapshot,
         @Assisted StructureActionCause cause,
         @Assisted double animationTime,
-        @Assisted boolean animationSkipped,
-        @Assisted boolean preventPerpetualMovement,
+        @Assisted("animationSkipped") boolean animationSkipped,
+        @Assisted("preventPerpetualMovement") boolean preventPerpetualMovement,
         @Assisted Cuboid newCuboid,
         @Assisted IPlayer responsible,
         @Assisted AnimationType animationType,
@@ -103,7 +103,8 @@ public final class StructureRequestData
          */
         StructureRequestData newToggleRequestData(
             StructureSnapshot structureSnapshot, StructureActionCause cause, double time,
-            boolean skipAnimation, boolean preventPerpetualMovement, Cuboid newCuboid, IPlayer responsible,
-            AnimationType animationType, StructureActionType actionType);
+            @Assisted("animationSkipped") boolean skipAnimation,
+            @Assisted("preventPerpetualMovement") boolean preventPerpetualMovement, Cuboid newCuboid,
+            IPlayer responsible, AnimationType animationType, StructureActionType actionType);
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/StructureRequestData.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/StructureRequestData.java
@@ -32,6 +32,7 @@ public final class StructureRequestData
     private final StructureActionCause cause;
     private final double animationTime;
     private final boolean animationSkipped;
+    private final boolean preventPerpetualMovement;
     private final Cuboid newCuboid;
     private final IPlayer responsible;
     private final AnimationType animationType;
@@ -48,6 +49,7 @@ public final class StructureRequestData
         @Assisted StructureActionCause cause,
         @Assisted double animationTime,
         @Assisted boolean animationSkipped,
+        @Assisted boolean preventPerpetualMovement,
         @Assisted Cuboid newCuboid,
         @Assisted IPlayer responsible,
         @Assisted AnimationType animationType,
@@ -63,6 +65,7 @@ public final class StructureRequestData
         this.cause = cause;
         this.animationTime = animationTime;
         this.animationSkipped = animationSkipped;
+        this.preventPerpetualMovement = preventPerpetualMovement;
         this.newCuboid = newCuboid;
         this.responsible = responsible;
         this.animationType = animationType;
@@ -85,6 +88,9 @@ public final class StructureRequestData
          *     The duration of the animation in seconds.
          * @param skipAnimation
          *     True to skip the animation and move the blocks to their new locations immediately.
+         * @param preventPerpetualMovement
+         *     True to prevent perpetual movement. When perpetual movement is requested but denied via this setting, the
+         *     animation will still be time-limited.
          * @param newCuboid
          *     The cuboid that described the coordinates of the structure after the animation has concluded.
          * @param responsible
@@ -97,7 +103,7 @@ public final class StructureRequestData
          */
         StructureRequestData newToggleRequestData(
             StructureSnapshot structureSnapshot, StructureActionCause cause, double time,
-            boolean skipAnimation, Cuboid newCuboid, IPlayer responsible, AnimationType animationType,
-            StructureActionType actionType);
+            boolean skipAnimation, boolean preventPerpetualMovement, Cuboid newCuboid, IPlayer responsible,
+            AnimationType animationType, StructureActionType actionType);
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureBase.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureBase.java
@@ -252,9 +252,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
         if (result == IRedstoneManager.RedstoneStatus.DISABLED)
             return;
 
-        if (result == IRedstoneManager.RedstoneStatus.UNPOWERED &&
-            structure instanceof IPerpetualMover perpetualMover &&
-            perpetualMover.isPerpetual())
+        if (result == IRedstoneManager.RedstoneStatus.UNPOWERED && structure instanceof IPerpetualMover)
         {
             structureActivityManager.stopAnimatorsWithWriteAccess(structure.getUid());
             return;

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureBase.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureBase.java
@@ -273,15 +273,36 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
         if (!config.isRedstoneEnabled())
             return;
 
-        if (isPowered && !structure.isOpenable() || !isPowered && !structure.isCloseable())
+        final StructureActionType actionType;
+        if (structure instanceof IPerpetualMover)
+        {
+            if (!isPowered)
+            {
+                structureActivityManager.stopAnimatorsWithWriteAccess(structure.getUid());
+                return;
+            }
+            actionType = StructureActionType.TOGGLE;
+        }
+        else if (isPowered && structure.isOpenable())
+        {
+            actionType = StructureActionType.OPEN;
+        }
+        else if (!isPowered && structure.isCloseable())
+        {
+            actionType = StructureActionType.CLOSE;
+        }
+        else
+        {
+            log.atFinest().log("Aborted toggle attempt with %s redstone for structure: %s",
+                               (isPowered ? "powered" : "unpowered"), structure);
             return;
+        }
 
-        final StructureActionType type = isPowered ? StructureActionType.OPEN : StructureActionType.CLOSE;
         structureToggleRequestBuilder
             .builder()
             .structure(structure)
             .structureActionCause(StructureActionCause.REDSTONE)
-            .structureActionType(type)
+            .structureActionType(actionType)
             .messageReceiverServer()
             .responsible(playerFactory.create(getPrimeOwner().playerData()))
             .build()

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureOpeningHelper.java
@@ -345,7 +345,8 @@ public final class StructureOpeningHelper
             snapshot = structure.getSnapshot();
 
             data = movementRequestDataFactory.newToggleRequestData(
-                snapshot, request.getCause(), animationTime, request.isSkipAnimation(), newCuboid.get(), responsible,
+                snapshot, request.getCause(), animationTime, request.isSkipAnimation(),
+                request.isPreventPerpetualMovement(), newCuboid.get(), responsible,
                 request.getAnimationType(), request.getActionType());
             component = structure.constructAnimationComponent(data);
         }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureToggleRequest.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureToggleRequest.java
@@ -6,6 +6,7 @@ import dagger.assisted.AssistedInject;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.bigdoors.core.api.IBigDoorsPlatform;
 import nl.pim16aap2.bigdoors.core.api.IExecutor;
 import nl.pim16aap2.bigdoors.core.api.IMessageable;
 import nl.pim16aap2.bigdoors.core.api.IPlayer;
@@ -15,6 +16,7 @@ import nl.pim16aap2.bigdoors.core.events.StructureActionType;
 import nl.pim16aap2.bigdoors.core.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationType;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureActivityManager;
+import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.util.Util;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetriever;
 import org.jetbrains.annotations.Nullable;
@@ -40,6 +42,8 @@ public class StructureToggleRequest
     @Getter
     private final boolean skipAnimation;
     @Getter
+    private final boolean preventPerpetualMovement;
+    @Getter
     private final StructureActionType actionType;
     @Getter
     private final AnimationType animationType;
@@ -51,11 +55,18 @@ public class StructureToggleRequest
 
     @AssistedInject
     public StructureToggleRequest(
-        @Assisted StructureRetriever structureRetriever, @Assisted StructureActionCause cause,
-        @Assisted IMessageable messageReceiver, @Assisted @Nullable IPlayer responsible,
-        @Assisted @Nullable Double time, @Assisted boolean skipAnimation, @Assisted StructureActionType actionType,
+        @Assisted StructureRetriever structureRetriever,
+        @Assisted StructureActionCause cause,
+        @Assisted IMessageable messageReceiver,
+        @Assisted @Nullable IPlayer responsible,
+        @Assisted @Nullable Double time,
+        @Assisted boolean skipAnimation,
+        @Assisted boolean preventPerpetualMovement,
+        @Assisted StructureActionType actionType,
         @Assisted AnimationType animationType,
-        ILocalizer localizer, StructureActivityManager structureActivityManager, IPlayerFactory playerFactory,
+        ILocalizer localizer,
+        StructureActivityManager structureActivityManager,
+        IPlayerFactory playerFactory,
         IExecutor executor)
     {
         this.structureRetriever = structureRetriever;
@@ -64,6 +75,7 @@ public class StructureToggleRequest
         this.responsible = responsible;
         this.time = time;
         this.skipAnimation = skipAnimation;
+        this.preventPerpetualMovement = preventPerpetualMovement;
         this.actionType = actionType;
         this.animationType = animationType;
         this.localizer = localizer;
@@ -80,9 +92,9 @@ public class StructureToggleRequest
     public CompletableFuture<StructureToggleResult> execute()
     {
         log.atFine().log("Executing toggle request: %s", this);
-        return structureRetriever.getStructure().thenApply(this::execute)
-                                 .exceptionally(
-                                     throwable -> Util.exceptionally(throwable, StructureToggleResult.ERROR));
+        return structureRetriever
+            .getStructure().thenApply(this::execute)
+            .exceptionally(throwable -> Util.exceptionally(throwable, StructureToggleResult.ERROR));
     }
 
     private StructureToggleResult execute(Optional<AbstractStructure> structureOpt)
@@ -125,10 +137,35 @@ public class StructureToggleRequest
     @AssistedFactory
     public interface IFactory
     {
+        /**
+         * @param structureRetriever
+         *     A retriever for the structure for which this toggle request will be created.
+         *     <p>
+         *     Note that the retriever may only specify a single structure. See
+         *     {@link StructureRetriever#getStructure()}.
+         * @param cause
+         *     The cause of the movement.
+         * @param messageReceiver
+         *     The receiver for all messages related to the toggle. When no player is available, this should usually be
+         *     the server (See {@link IBigDoorsPlatform#getServer()}) or {@link IMessageable.BlackHoleMessageable}.
+         * @param time
+         *     The duration of the animation in seconds. May be null to use the default time.
+         * @param skipAnimation
+         *     True to skip the animation and move the blocks to their new locations immediately.
+         * @param preventPerpetualMovement
+         *     True to prevent perpetual movement. When perpetual movement is requested but denied via this setting, the
+         *     animation will still be time-limited.
+         * @param responsible
+         *     The player responsible for the movement.
+         * @param animationType
+         *     The type of animation to apply.
+         * @param actionType
+         *     The type of movement to apply.
+         * @return The new {@link StructureRequestData}.
+         */
         StructureToggleRequest create(
-            StructureRetriever structureRetriever, StructureActionCause structureActionCause,
-            IMessageable messageReceiver,
-            @Nullable IPlayer responsible, @Nullable Double time, boolean skipAnimation,
-            StructureActionType structureActionType, AnimationType animationType);
+            StructureRetriever structureRetriever, StructureActionCause cause,
+            IMessageable messageReceiver, @Nullable IPlayer responsible, @Nullable Double time, boolean skipAnimation,
+            boolean preventPerpetualMovement, StructureActionType actionType, AnimationType animationType);
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureToggleRequest.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureToggleRequest.java
@@ -60,8 +60,8 @@ public class StructureToggleRequest
         @Assisted IMessageable messageReceiver,
         @Assisted @Nullable IPlayer responsible,
         @Assisted @Nullable Double time,
-        @Assisted boolean skipAnimation,
-        @Assisted boolean preventPerpetualMovement,
+        @Assisted("skipAnimation") boolean skipAnimation,
+        @Assisted("preventPerpetualMovement") boolean preventPerpetualMovement,
         @Assisted StructureActionType actionType,
         @Assisted AnimationType animationType,
         ILocalizer localizer,
@@ -165,7 +165,9 @@ public class StructureToggleRequest
          */
         StructureToggleRequest create(
             StructureRetriever structureRetriever, StructureActionCause cause,
-            IMessageable messageReceiver, @Nullable IPlayer responsible, @Nullable Double time, boolean skipAnimation,
-            boolean preventPerpetualMovement, StructureActionType actionType, AnimationType animationType);
+            IMessageable messageReceiver, @Nullable IPlayer responsible, @Nullable Double time,
+            @Assisted("skipAnimation") boolean skipAnimation,
+            @Assisted("preventPerpetualMovement") boolean preventPerpetualMovement, StructureActionType actionType,
+            AnimationType animationType);
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureToggleRequestBuilder.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureToggleRequestBuilder.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.bigdoors.core.structures;
 
 import lombok.RequiredArgsConstructor;
 import nl.pim16aap2.bigdoors.core.annotations.Initializer;
+import nl.pim16aap2.bigdoors.core.api.IBigDoorsPlatform;
 import nl.pim16aap2.bigdoors.core.api.IConfig;
 import nl.pim16aap2.bigdoors.core.api.IMessageable;
 import nl.pim16aap2.bigdoors.core.api.IPlayer;
@@ -73,6 +74,7 @@ public class StructureToggleRequestBuilder
         private @Nullable Double time = null;
         private @Nullable AnimationType animationType = null;
         private boolean skipAnimation = false;
+        private boolean preventPerpetualMovement = false;
 
         @Override
         public IBuilder time(@Nullable Double time)
@@ -85,6 +87,13 @@ public class StructureToggleRequestBuilder
         public IBuilder skipAnimation(boolean skip)
         {
             skipAnimation = skip;
+            return this;
+        }
+
+        @Override
+        public IBuilder preventPerpetualMovement(boolean preventPerpetualMovement)
+        {
+            this.preventPerpetualMovement = preventPerpetualMovement;
             return this;
         }
 
@@ -176,7 +185,7 @@ public class StructureToggleRequestBuilder
             return structureToggleRequestFactory.create(
                 structureRetriever, structureActionCause,
                 Util.requireNonNull(messageReceiver, "MessageReceiver"),
-                responsible, time, skipAnimation, structureActionType,
+                responsible, time, skipAnimation, preventPerpetualMovement, structureActionType,
                 Objects.requireNonNullElse(animationType, AnimationType.MOVE_BLOCKS));
         }
 
@@ -239,6 +248,27 @@ public class StructureToggleRequestBuilder
         }
 
         /**
+         * Sets if perpetual movement should be blocked. When perpetual movement is requested but denied via this
+         * setting, the animation will still be time-limited.
+         *
+         * @param preventPerpetualMovement
+         *     True to prevent any perpetual movement.
+         * @return The next step of the guided builder process.
+         */
+        IBuilder preventPerpetualMovement(boolean preventPerpetualMovement);
+
+        /**
+         * Prevents perpetual movement. When perpetual movement is requested but denied via this setting, the animation
+         * will still be time-limited.
+         *
+         * @return The next step of the guided builder process.
+         */
+        default IBuilder preventPerpetualMovement()
+        {
+            return preventPerpetualMovement(true);
+        }
+
+        /**
          * Sets the player responsible for the toggle. When the toggle was not caused by a player this value is
          * optional.
          * <p>
@@ -269,7 +299,7 @@ public class StructureToggleRequestBuilder
          * related to the toggle request.
          * <p>
          * When the toggle request is caused by a player, this defaults to that player. In all other situations, it
-         * defaults to the server.
+         * defaults to the server (See {@link IBigDoorsPlatform#getServer()}).
          *
          * @param messageReceiver
          *     The message receiver for all messages related to the toggle request.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/structurearchetypes/IPerpetualMover.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/structurearchetypes/IPerpetualMover.java
@@ -7,15 +7,4 @@ import nl.pim16aap2.bigdoors.core.structures.IStructure;
  */
 public interface IPerpetualMover extends IStructure
 {
-    /**
-     * Checks if this specific perpetual mover should move perpetually.
-     * <p>
-     * Not all perpetual movers make use of this ability.
-     *
-     * @return True if this perpetual mover should move perpetually.
-     */
-    default boolean isPerpetual()
-    {
-        return true;
-    }
 }

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/core/commands/InfoTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/core/commands/InfoTest.java
@@ -8,6 +8,7 @@ import nl.pim16aap2.bigdoors.core.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.StructureType;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
+import nl.pim16aap2.bigdoors.core.util.MovementDirection;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetriever;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetrieverFactory;
 import nl.pim16aap2.bigdoors.core.util.vector.Vector3Di;
@@ -48,6 +49,7 @@ class InfoTest
         Mockito.when(structure.isOwner(Mockito.any(IPlayer.class))).thenReturn(true);
         Mockito.when(structure.getCuboid()).thenReturn(new Cuboid(new Vector3Di(1, 2, 3), new Vector3Di(4, 5, 6)));
         Mockito.when(structure.getNameAndUid()).thenReturn("Structure (0)");
+        Mockito.when(structure.getOpenDir()).thenReturn(MovementDirection.NORTH);
 
         final StructureType structureType = Mockito.mock(StructureType.class);
         Mockito.when(structureType.getLocalizationKey()).thenReturn("StructureType");

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/core/commands/ToggleTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/core/commands/ToggleTest.java
@@ -78,7 +78,7 @@ class ToggleTest
 
         Mockito.when(structureToggleRequestFactory.create(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
                                                           Mockito.nullable(Double.class), Mockito.anyBoolean(),
-                                                          Mockito.any(), Mockito.any()))
+                                                          Mockito.anyBoolean(), Mockito.any(), Mockito.any()))
                .thenReturn(structureToggleRequest);
 
         structureToggleRequestBuilder = new StructureToggleRequestBuilder(
@@ -87,19 +87,23 @@ class ToggleTest
 
         Mockito.when(factory.newToggle(Mockito.any(ICommandSender.class), Mockito.any(StructureActionType.class),
                                        Mockito.any(AnimationType.class), Mockito.nullable(Double.class),
-                                       Mockito.any(StructureRetriever[].class)))
+                                       Mockito.anyBoolean(), Mockito.any(StructureRetriever[].class)))
                .thenAnswer(
                    invoc ->
                    {
                        final StructureRetriever[] retrievers =
-                           UnitTestUtil.arrayFromCapturedVarArgs(StructureRetriever.class, invoc, 4);
-
-                       return new Toggle(invoc.getArgument(0, ICommandSender.class), localizer,
-                                         ITextFactory.getSimpleTextFactory(),
-                                         invoc.getArgument(1, StructureActionType.class),
-                                         invoc.getArgument(2, AnimationType.class),
-                                         invoc.getArgument(3, Double.class), structureToggleRequestBuilder,
-                                         messageableServer, retrievers);
+                           UnitTestUtil.arrayFromCapturedVarArgs(StructureRetriever.class, invoc, 5);
+                       return new Toggle(
+                           localizer,
+                           ITextFactory.getSimpleTextFactory(),
+                           messageableServer,
+                           structureToggleRequestBuilder,
+                           invoc.getArgument(0, ICommandSender.class),
+                           invoc.getArgument(1, StructureActionType.class),
+                           invoc.getArgument(2, AnimationType.class),
+                           invoc.getArgument(3, Double.class),
+                           invoc.getArgument(4, Boolean.class),
+                           retrievers);
                    });
     }
 
@@ -114,7 +118,7 @@ class ToggleTest
         toggle.executeCommand(new PermissionsStatus(true, true)).get(1, TimeUnit.SECONDS);
         Mockito.verify(structureToggleRequestFactory)
                .create(structureRetriever, StructureActionCause.PLAYER, commandSender, commandSender, null, false,
-                       StructureActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
+                       true, StructureActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
 
         Mockito.when(structure.getOwner(commandSender))
                .thenReturn(Optional.of(CommandTestingUtil.structureOwnerCreator));
@@ -122,7 +126,7 @@ class ToggleTest
         Mockito.verify(structureToggleRequestFactory, Mockito.times(2))
                .create(structureRetriever, StructureActionCause.PLAYER,
                        commandSender, commandSender,
-                       null, false, StructureActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
+                       null, false, true, StructureActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
     }
 
     @Test
@@ -147,7 +151,7 @@ class ToggleTest
 
         final Toggle toggle =
             factory.newToggle(commandSender, Toggle.DEFAULT_STRUCTURE_ACTION_TYPE,
-                              Toggle.DEFAULT_ANIMATION_TYPE, null, retrievers);
+                              Toggle.DEFAULT_ANIMATION_TYPE, null, false, retrievers);
 
         toggle.executeCommand(new PermissionsStatus(true, true)).get(1, TimeUnit.SECONDS);
 
@@ -171,16 +175,16 @@ class ToggleTest
             () -> factory.newToggle(commandSender, structureRetriever).run().get(1, TimeUnit.SECONDS));
         Mockito.verify(structureToggleRequestFactory, Mockito.times(1))
                .create(structureRetriever, StructureActionCause.PLAYER, commandSender, commandSender,
-                       null, false, StructureActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
+                       null, false, true, StructureActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
 
 
         Assertions.assertDoesNotThrow(
             () -> factory.newToggle(commandSender, StructureActionType.TOGGLE,
-                                    AnimationType.MOVE_BLOCKS, 3.141592653589793D, structureRetriever).run()
+                                    AnimationType.MOVE_BLOCKS, 3.141592653589793D, true, structureRetriever).run()
                          .get(1, TimeUnit.SECONDS));
         Mockito.verify(structureToggleRequestFactory, Mockito.times(1))
                .create(structureRetriever, StructureActionCause.PLAYER, commandSender, commandSender,
-                       3.141592653589793D, false, StructureActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
+                       3.141592653589793D, false, true, StructureActionType.TOGGLE, AnimationType.MOVE_BLOCKS);
 
 
         Assertions.assertDoesNotThrow(
@@ -189,16 +193,16 @@ class ToggleTest
                          .run().get(1, TimeUnit.SECONDS));
         Mockito.verify(structureToggleRequestFactory, Mockito.times(1))
                .create(structureRetriever, StructureActionCause.PLAYER, commandSender, commandSender,
-                       null, false, StructureActionType.CLOSE, AnimationType.MOVE_BLOCKS);
+                       null, false, true, StructureActionType.CLOSE, AnimationType.MOVE_BLOCKS);
 
 
         Assertions.assertDoesNotThrow(
             () -> factory.newToggle(commandSender, StructureActionType.OPEN,
-                                    AnimationType.MOVE_BLOCKS, 42D, structureRetriever).run()
+                                    AnimationType.MOVE_BLOCKS, 42D, true, structureRetriever).run()
                          .get(1, TimeUnit.SECONDS));
         Mockito.verify(structureToggleRequestFactory, Mockito.times(1))
                .create(structureRetriever, StructureActionCause.PLAYER, commandSender,
-                       commandSender, 42D, false, StructureActionType.OPEN, AnimationType.MOVE_BLOCKS);
+                       commandSender, 42D, false, true, StructureActionType.OPEN, AnimationType.MOVE_BLOCKS);
     }
 
     @Test
@@ -212,14 +216,14 @@ class ToggleTest
                          .get(1, TimeUnit.SECONDS));
         Mockito.verify(structureToggleRequestFactory, Mockito.times(1))
                .create(structureRetriever, StructureActionCause.SERVER, messageableServer, null,
-                       null, false, StructureActionType.TOGGLE, AnimationType.PREVIEW);
+                       null, false, true, StructureActionType.TOGGLE, AnimationType.PREVIEW);
     }
 
     private void verifyNoOpenerCalls()
     {
         Mockito.verify(structureToggleRequestFactory, Mockito.never())
                .create(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-                       Mockito.anyDouble(), Mockito.anyBoolean(), Mockito.any(), Mockito.any());
+                       Mockito.anyDouble(), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any(), Mockito.any());
     }
 
     @Test

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/gui/AttributeButtonFactory.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/gui/AttributeButtonFactory.java
@@ -88,6 +88,7 @@ class AttributeButtonFactory
                     Toggle.DEFAULT_STRUCTURE_ACTION_TYPE,
                     Toggle.DEFAULT_ANIMATION_TYPE,
                     config.getAnimationTimeMultiplier(structure.getType()),
+                    true,
                     structureRetrieverFactory.of(structure)).run();
                 return true;
             },

--- a/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/Clock.java
+++ b/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/Clock.java
@@ -10,6 +10,7 @@ import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IHorizontalAxisAligned;
+import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IPerpetualMover;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
 import nl.pim16aap2.bigdoors.core.util.MathUtil;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
@@ -26,7 +27,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class Clock extends AbstractStructure implements IHorizontalAxisAligned
+public class Clock extends AbstractStructure implements IHorizontalAxisAligned, IPerpetualMover
 {
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})

--- a/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/DrawbridgeAnimationComponent.java
+++ b/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/DrawbridgeAnimationComponent.java
@@ -21,15 +21,15 @@ import nl.pim16aap2.bigdoors.core.util.vector.Vector3Dd;
  */
 public class DrawbridgeAnimationComponent implements IAnimationComponent
 {
-    private final Vector3Dd rotationCenter;
+    protected final Vector3Dd rotationCenter;
     protected final boolean northSouth;
     protected final TriFunction<Vector3Dd, Vector3Dd, Double, Vector3Dd> rotator;
     protected final StructureSnapshot snapshot;
     protected final int animationDuration;
 
     protected final double angle;
-    private final int halfEndCount;
-    private final double step;
+    protected final double step;
+    protected final int halfEndCount;
 
     public DrawbridgeAnimationComponent(
         StructureRequestData data, MovementDirection movementDirection, boolean isNorthSouthAligned)

--- a/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/CreatorRevolvingDoor.java
+++ b/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/CreatorRevolvingDoor.java
@@ -37,7 +37,6 @@ public class CreatorRevolvingDoor extends CreatorBigDoor
                              factorySetSecondPos.messageKey("creator.revolving_door.step_2").construct(),
                              factorySetRotationPointPos.messageKey("creator.revolving_door.step_3").construct(),
                              factorySetPowerBlockPos.construct(),
-                             factorySetOpenStatus.construct(),
                              factorySetOpenDir.construct(),
                              factoryConfirmPrice.construct(),
                              factoryCompleteProcess.messageKey("creator.revolving_door.success").construct());

--- a/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/RevolvingDoor.java
+++ b/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/RevolvingDoor.java
@@ -11,6 +11,7 @@ import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
+import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IPerpetualMover;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
 import nl.pim16aap2.bigdoors.core.util.MathUtil;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
@@ -29,7 +30,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @Flogger
-public class RevolvingDoor extends AbstractStructure
+public class RevolvingDoor extends AbstractStructure implements IPerpetualMover
 {
     @EqualsAndHashCode.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})

--- a/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/CreatorWindMill.java
+++ b/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/CreatorWindMill.java
@@ -33,7 +33,6 @@ public class CreatorWindMill extends Creator
                              factorySetSecondPos.messageKey("creator.windmill.step_2").construct(),
                              factorySetRotationPointPos.messageKey("creator.windmill.step_3").construct(),
                              factorySetPowerBlockPos.construct(),
-                             factorySetOpenStatus.construct(),
                              factorySetOpenDir.construct(),
                              factoryConfirmPrice.construct(),
                              factoryCompleteProcess.messageKey("creator.windmill.success").construct());

--- a/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/WindmillAnimationComponent.java
+++ b/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/WindmillAnimationComponent.java
@@ -4,12 +4,11 @@ import nl.pim16aap2.bigdoors.core.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
-import nl.pim16aap2.bigdoors.structures.drawbridge.DrawbridgeAnimationComponent;
-import nl.pim16aap2.bigdoors.core.util.MathUtil;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
 import nl.pim16aap2.bigdoors.core.util.Util;
 import nl.pim16aap2.bigdoors.core.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.core.util.vector.Vector3Dd;
+import nl.pim16aap2.bigdoors.structures.drawbridge.DrawbridgeAnimationComponent;
 
 /**
  * Represents a {@link Animator} for {@link Windmill}s.
@@ -18,14 +17,10 @@ import nl.pim16aap2.bigdoors.core.util.vector.Vector3Dd;
  */
 public class WindmillAnimationComponent extends DrawbridgeAnimationComponent
 {
-    private final double step;
-
     public WindmillAnimationComponent(
         StructureRequestData data, MovementDirection movementDirection, boolean isNorthSouthAligned)
     {
         super(data, movementDirection, isNorthSouthAligned);
-
-        step = MathUtil.HALF_PI / animationDuration;
     }
 
     @Override


### PR DESCRIPTION
Fixed a bunch of issues with perpetual movement:
- Toggling structures that are supposed to move perpetually via command/GUI no longer causes a perpetual animation. Instead, it will animate for the default duration. These types are meant to be switched using their power blocks.
- Perpetual movers are now stopped properly when their power block loses power.
- The revolving door and clock structure types are now correctly handled as perpetual movers.
- Fixed windmill animation direction.