### PR TITLE
Assortment of minor fixes

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/annotations/PersistentVariable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/annotations/PersistentVariable.java
@@ -19,5 +19,5 @@ public @interface PersistentVariable
     /**
      * @return The name of the variable. The name does not need to match the name of the variable in the source file.
      */
-    String value() default "";
+    String value();
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/api/IBigDoorsPlatform.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/api/IBigDoorsPlatform.java
@@ -24,6 +24,7 @@ import nl.pim16aap2.bigdoors.core.moveblocks.StructureActivityManager;
 import nl.pim16aap2.bigdoors.core.structures.StructureAnimationRequest;
 import nl.pim16aap2.bigdoors.core.structures.StructureAnimationRequestBuilder;
 import nl.pim16aap2.bigdoors.core.structures.StructureRegistry;
+import nl.pim16aap2.bigdoors.core.util.VersionReader;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureFinder;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetriever;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetrieverFactory;
@@ -47,11 +48,18 @@ public interface IBigDoorsPlatform
     void shutDownPlugin();
 
     /**
-     * Gets the build id of BigDoors that is currently running.
+     * Getter for the name of current version.
+     * <p>
+     * It is not guaranteed that this will return the version in any specific format; only that it is a String.
      *
-     * @return The build id of BigDoors that is currently running.
+     * @return The name of the current version.
      */
-    String getVersion();
+    String getVersionName();
+
+    /**
+     * @return The version info. This provides access to items such as the commit hash, the build id, etc.
+     */
+    VersionReader.VersionInfo getVersionInfo();
 
     /**
      * Gets the instance of the {@link IBigDoorsToolUtil} for this platform.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/api/IBigDoorsPlatform.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/api/IBigDoorsPlatform.java
@@ -21,6 +21,8 @@ import nl.pim16aap2.bigdoors.core.managers.StructureSpecificationManager;
 import nl.pim16aap2.bigdoors.core.managers.StructureTypeManager;
 import nl.pim16aap2.bigdoors.core.managers.ToolUserManager;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureActivityManager;
+import nl.pim16aap2.bigdoors.core.structures.StructureAnimationRequest;
+import nl.pim16aap2.bigdoors.core.structures.StructureAnimationRequestBuilder;
 import nl.pim16aap2.bigdoors.core.structures.StructureRegistry;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureFinder;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetriever;
@@ -243,6 +245,11 @@ public interface IBigDoorsPlatform
      * @return The factory used to create new {@link StructureRetriever} and {@link StructureFinder} instances.
      */
     StructureRetrieverFactory getStructureRetrieverFactory();
+
+    /**
+     * @return A new builder used to create new {@link StructureAnimationRequest} instances.
+     */
+    StructureAnimationRequestBuilder.IBuilderStructure getStructureAnimationRequestBuilder();
 
     /**
      * Gets the instance of the {@link IProtectionCompatManager} for this platform.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/api/ILocation.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/api/ILocation.java
@@ -8,8 +8,6 @@ import org.jetbrains.annotations.Contract;
 
 /**
  * Represents a position in a world.
- * <p>
- * Note that, unlike the Spigot Location, this location is not mutable!
  *
  * @author Pim
  */

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/api/debugging/DebugReporter.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/api/debugging/DebugReporter.java
@@ -26,7 +26,7 @@ public abstract class DebugReporter
 
         sb.append("\n")
           .append("BigDoors version: ")
-          .append(() -> platformProvider.getPlatform().map(IBigDoorsPlatform::getVersion).orElse("NULL"))
+          .append(() -> platformProvider.getPlatform().map(IBigDoorsPlatform::getVersionName).orElse("NULL"))
           .append('\n')
           .append("Registered Platform: ")
           .append(() -> platformProvider.getPlatform().map(platform -> platform.getClass().getName()).orElse("NULL"))

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/api/restartable/IRestartable.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/api/restartable/IRestartable.java
@@ -17,5 +17,7 @@ public interface IRestartable
     /**
      * Handles a shutdown.
      */
-    void shutDown();
+    default void shutDown()
+    {
+    }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/commands/StopStructures.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/commands/StopStructures.java
@@ -22,7 +22,9 @@ public class StopStructures extends BaseCommand
 
     @AssistedInject //
     StopStructures(
-        @Assisted ICommandSender commandSender, ILocalizer localizer, ITextFactory textFactory,
+        @Assisted ICommandSender commandSender,
+        ILocalizer localizer,
+        ITextFactory textFactory,
         StructureActivityManager structureActivityManager)
     {
         super(commandSender, localizer, textFactory);
@@ -38,7 +40,9 @@ public class StopStructures extends BaseCommand
     @Override
     protected CompletableFuture<?> executeCommand(PermissionsStatus permissions)
     {
-        structureActivityManager.abortAnimators();
+        structureActivityManager.shutDown();
+        structureActivityManager.initialize();
+
         getCommandSender().sendSuccess(textFactory, localizer.getMessage("commands.stop_structures.success"));
         return CompletableFuture.completedFuture(null);
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/commands/Toggle.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/commands/Toggle.java
@@ -13,8 +13,8 @@ import nl.pim16aap2.bigdoors.core.events.StructureActionType;
 import nl.pim16aap2.bigdoors.core.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationType;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
+import nl.pim16aap2.bigdoors.core.structures.StructureAnimationRequestBuilder;
 import nl.pim16aap2.bigdoors.core.structures.StructureAttribute;
-import nl.pim16aap2.bigdoors.core.structures.StructureToggleRequestBuilder;
 import nl.pim16aap2.bigdoors.core.text.TextType;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetriever;
 import org.jetbrains.annotations.Nullable;
@@ -35,7 +35,7 @@ public class Toggle extends BaseCommand
     public static final StructureActionType DEFAULT_STRUCTURE_ACTION_TYPE = StructureActionType.TOGGLE;
     public static final AnimationType DEFAULT_ANIMATION_TYPE = AnimationType.MOVE_BLOCKS;
 
-    private final StructureToggleRequestBuilder structureToggleRequestBuilder;
+    private final StructureAnimationRequestBuilder structureToggleRequestBuilder;
     private final StructureRetriever[] structureRetrievers;
     private final IMessageable messageableServer;
     private final StructureActionType structureActionType;
@@ -48,7 +48,7 @@ public class Toggle extends BaseCommand
         ILocalizer localizer,
         ITextFactory textFactory,
         @Named("MessageableServer") IMessageable messageableServer,
-        StructureToggleRequestBuilder structureToggleRequestBuilder,
+        StructureAnimationRequestBuilder structureToggleRequestBuilder,
         @Assisted ICommandSender commandSender,
         @Assisted StructureActionType structureActionType,
         @Assisted AnimationType animationType,

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/commands/Version.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/commands/Version.java
@@ -39,7 +39,7 @@ public class Version extends BaseCommand
     @Override
     protected CompletableFuture<?> executeCommand(PermissionsStatus permissions)
     {
-        final String version = platformProvider.getPlatform().map(IBigDoorsPlatform::getVersion).orElse("ERROR");
+        final String version = platformProvider.getPlatform().map(IBigDoorsPlatform::getVersionName).orElse("ERROR");
         getCommandSender().sendInfo(textFactory, localizer.getMessage("commands.version.success", version));
         return CompletableFuture.completedFuture(null);
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/managers/LimitsManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/managers/LimitsManager.java
@@ -1,8 +1,8 @@
 package nl.pim16aap2.bigdoors.core.managers;
 
 import nl.pim16aap2.bigdoors.core.api.IConfig;
-import nl.pim16aap2.bigdoors.core.api.IPlayer;
 import nl.pim16aap2.bigdoors.core.api.IPermissionsManager;
+import nl.pim16aap2.bigdoors.core.api.IPlayer;
 import nl.pim16aap2.bigdoors.core.util.Limit;
 
 import javax.inject.Inject;
@@ -45,7 +45,9 @@ public class LimitsManager
         if (hasBypass)
             return globalLimit;
 
-        final OptionalInt playerLimit = permissionsManager.getMaxPermissionSuffix(player, limit.getUserPermission());
+        final OptionalInt playerLimit =
+            player.isOnline() ? permissionsManager.getMaxPermissionSuffix(player, limit.getUserPermission()) :
+            OptionalInt.of(player.getStructureSizeLimit());
 
         if (globalLimit.isPresent() && playerLimit.isPresent())
             return OptionalInt.of(Math.min(globalLimit.getAsInt(), playerLimit.getAsInt()));
@@ -56,8 +58,7 @@ public class LimitsManager
     }
 
     /**
-     * Checks if a given value exceeds the limit for this player. For more info, see
-     * {@link #getLimit(IPlayer, Limit)}.
+     * Checks if a given value exceeds the limit for this player. For more info, see {@link #getLimit(IPlayer, Limit)}.
      *
      * @param player
      *     The player for whom to check the limit.

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/managers/StructureTypeManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/managers/StructureTypeManager.java
@@ -6,8 +6,6 @@ import lombok.experimental.NonFinal;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.core.api.debugging.DebuggableRegistry;
 import nl.pim16aap2.bigdoors.core.api.debugging.IDebuggable;
-import nl.pim16aap2.bigdoors.core.api.restartable.Restartable;
-import nl.pim16aap2.bigdoors.core.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.core.localization.LocalizationManager;
 import nl.pim16aap2.bigdoors.core.structures.StructureType;
 import nl.pim16aap2.util.SafeStringBuilder;
@@ -34,7 +32,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 @SuppressWarnings("unused")
 @Singleton
 @Flogger
-public final class StructureTypeManager extends Restartable implements IDebuggable
+public final class StructureTypeManager implements IDebuggable
 {
     private static final boolean DEFAULT_IS_ENABLED = true;
 
@@ -44,10 +42,8 @@ public final class StructureTypeManager extends Restartable implements IDebuggab
     private final LocalizationManager localizationManager;
 
     @Inject
-    public StructureTypeManager(
-        RestartableHolder holder, DebuggableRegistry debuggableRegistry, LocalizationManager localizationManager)
+    public StructureTypeManager(DebuggableRegistry debuggableRegistry, LocalizationManager localizationManager)
     {
-        super(holder);
         this.localizationManager = localizationManager;
         debuggableRegistry.registerDebuggable(this);
     }
@@ -271,23 +267,6 @@ public final class StructureTypeManager extends Restartable implements IDebuggab
     {
         registerTypeWithLocalizer(structureTypes);
         structureTypes.forEach(structureType -> registerStructureType0(structureType, DEFAULT_IS_ENABLED));
-    }
-
-    @Override
-    public void shutDown()
-    {
-        structureTypeStatus.clear();
-        sortedStructureTypes.clear();
-        structureTypeFromName.clear();
-        structureTypeFromFullName.clear();
-    }
-
-    @Override
-    public void initialize()
-    {
-        if (this.structureTypeStatus.keySet().isEmpty())
-            return;
-
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/AnimationRequestData.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/AnimationRequestData.java
@@ -20,7 +20,7 @@ import javax.inject.Named;
  * Simple class that holds the data of a toggle request that is passed to the BlockMover.
  */
 @Getter
-public final class StructureRequestData
+public final class AnimationRequestData
 {
     private final StructureActivityManager structureActivityManager;
     private final IAudioPlayer audioPlayer;
@@ -38,7 +38,7 @@ public final class StructureRequestData
     private final AnimationType animationType;
     private final StructureActionType actionType;
 
-    @AssistedInject StructureRequestData(
+    @AssistedInject AnimationRequestData(
         StructureActivityManager structureActivityManager,
         IAudioPlayer audioPlayer,
         IExecutor executor,
@@ -73,7 +73,7 @@ public final class StructureRequestData
     }
 
     /**
-     * Factory for new {@link StructureRequestData} instances.
+     * Factory for new {@link AnimationRequestData} instances.
      */
     @AssistedFactory
     public interface IFactory
@@ -99,9 +99,9 @@ public final class StructureRequestData
          *     The type of animation to apply.
          * @param actionType
          *     The type of movement to apply.
-         * @return The new {@link StructureRequestData}.
+         * @return The new {@link AnimationRequestData}.
          */
-        StructureRequestData newToggleRequestData(
+        AnimationRequestData newToggleRequestData(
             StructureSnapshot structureSnapshot, StructureActionCause cause, double time,
             @Assisted("animationSkipped") boolean skipAnimation,
             @Assisted("preventPerpetualMovement") boolean preventPerpetualMovement, Cuboid newCuboid,

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/Animator.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/moveblocks/Animator.java
@@ -183,7 +183,7 @@ public final class Animator implements IAnimator
      *     The manager of the animated blocks. This is responsible for handling the lifecycle of the animated blocks.
      */
     public Animator(
-        AbstractStructure structure, StructureRequestData data, IAnimationComponent animationComponent,
+        AbstractStructure structure, AnimationRequestData data, IAnimationComponent animationComponent,
         IAnimationBlockManager animationBlockManager)
     {
         executor = data.getExecutor();

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/AbstractStructure.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/AbstractStructure.java
@@ -580,6 +580,7 @@ public abstract class AbstractStructure implements IStructure
         assertWriteLockable();
         invalidateBasicData();
         base.setPowerBlock(pos);
+        verifyRedstoneState();
     }
 
     @Override
@@ -596,6 +597,7 @@ public abstract class AbstractStructure implements IStructure
         assertWriteLockable();
         invalidateAnimationData();
         base.setOpen(open);
+        verifyRedstoneState();
     }
 
     @Override
@@ -612,6 +614,7 @@ public abstract class AbstractStructure implements IStructure
         assertWriteLockable();
         invalidateBasicData();
         base.setLocked(locked);
+        verifyRedstoneState();
     }
 
     @Override

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/AbstractStructure.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/AbstractStructure.java
@@ -9,9 +9,9 @@ import nl.pim16aap2.bigdoors.core.api.IConfig;
 import nl.pim16aap2.bigdoors.core.api.IPlayer;
 import nl.pim16aap2.bigdoors.core.api.IWorld;
 import nl.pim16aap2.bigdoors.core.managers.DatabaseManager;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
 import nl.pim16aap2.bigdoors.core.util.LazyValue;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
@@ -312,11 +312,11 @@ public abstract class AbstractStructure implements IStructure
      *     The data for the toggle request.
      * @return A new {@link Animator} for this type of structure.
      */
-    protected abstract IAnimationComponent constructAnimationComponent(StructureRequestData data);
+    protected abstract IAnimationComponent constructAnimationComponent(AnimationRequestData data);
 
     /**
      * Attempts to toggle a structure. Think twice before using this method. Instead, please look at
-     * {@link StructureToggleRequestBuilder}.
+     * {@link StructureAnimationRequestBuilder}.
      *
      * @param request
      *     The toggle request to process.
@@ -325,7 +325,7 @@ public abstract class AbstractStructure implements IStructure
      *     or the prime owner when this data is not available.
      * @return The result of the attempt.
      */
-    final StructureToggleResult toggle(StructureToggleRequest request, IPlayer responsible)
+    final StructureToggleResult toggle(StructureAnimationRequest request, IPlayer responsible)
     {
         return base.getStructureOpeningHelper().toggle(this, request, responsible);
     }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureAnimationRequest.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureAnimationRequest.java
@@ -14,9 +14,9 @@ import nl.pim16aap2.bigdoors.core.api.factories.IPlayerFactory;
 import nl.pim16aap2.bigdoors.core.events.StructureActionCause;
 import nl.pim16aap2.bigdoors.core.events.StructureActionType;
 import nl.pim16aap2.bigdoors.core.localization.ILocalizer;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationType;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureActivityManager;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.util.Util;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetriever;
 import org.jetbrains.annotations.Nullable;
@@ -24,10 +24,18 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Represents the principal way to submit a request to animate a structure.
+ * <p>
+ * To submit a new request, first create a new instance using
+ * {@link IBigDoorsPlatform#getStructureAnimationRequestBuilder()}.
+ * <p>
+ * Once the new request has been constructed, it can be submitted using {@link #execute()}.
+ */
 @Getter
 @ToString
 @Flogger
-public class StructureToggleRequest
+public class StructureAnimationRequest
 {
     @Getter
     private final StructureRetriever structureRetriever;
@@ -54,7 +62,7 @@ public class StructureToggleRequest
     private final IExecutor executor;
 
     @AssistedInject
-    public StructureToggleRequest(
+    public StructureAnimationRequest(
         @Assisted StructureRetriever structureRetriever,
         @Assisted StructureActionCause cause,
         @Assisted IMessageable messageReceiver,
@@ -134,10 +142,17 @@ public class StructureToggleRequest
         return playerFactory.create(structure.getPrimeOwner().playerData());
     }
 
+    /**
+     * The factory class for {@link StructureAnimationRequest} instances.
+     */
     @AssistedFactory
     public interface IFactory
     {
         /**
+         * Creates a new {@link StructureAnimationRequest}.
+         * <p>
+         * Once created, use {@link StructureAnimationRequest#execute()} to submit the request.
+         *
          * @param structureRetriever
          *     A retriever for the structure for which this toggle request will be created.
          *     <p>
@@ -161,13 +176,17 @@ public class StructureToggleRequest
          *     The type of animation to apply.
          * @param actionType
          *     The type of movement to apply.
-         * @return The new {@link StructureRequestData}.
+         * @return The new {@link AnimationRequestData}.
          */
-        StructureToggleRequest create(
-            StructureRetriever structureRetriever, StructureActionCause cause,
-            IMessageable messageReceiver, @Nullable IPlayer responsible, @Nullable Double time,
+        StructureAnimationRequest create(
+            StructureRetriever structureRetriever,
+            StructureActionCause cause,
+            IMessageable messageReceiver,
+            @Nullable IPlayer responsible,
+            @Nullable Double time,
             @Assisted("skipAnimation") boolean skipAnimation,
-            @Assisted("preventPerpetualMovement") boolean preventPerpetualMovement, StructureActionType actionType,
+            @Assisted("preventPerpetualMovement") boolean preventPerpetualMovement,
+            StructureActionType actionType,
             AnimationType animationType);
     }
 }

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureAnimationRequestBuilder.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureAnimationRequestBuilder.java
@@ -23,20 +23,22 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Builder for {@link StructureToggleRequest} instances implemented as a guided builder.
+ * Builder for {@link StructureAnimationRequest} instances implemented as a guided builder.
+ * <p>
+ * You can obtain an instance of this class using {@link IBigDoorsPlatform#getStructureAnimationRequestBuilder()}.
  *
  * @author Pim
  */
-public class StructureToggleRequestBuilder
+public class StructureAnimationRequestBuilder
 {
-    private final StructureToggleRequest.IFactory structureToggleRequestFactory;
+    private final StructureAnimationRequest.IFactory structureToggleRequestFactory;
     private final IMessageable messageableServer;
     private final IPlayerFactory playerFactory;
     private final IConfig config;
 
     @Inject
-    public StructureToggleRequestBuilder(
-        StructureToggleRequest.IFactory structureToggleRequestFactory,
+    public StructureAnimationRequestBuilder(
+        StructureAnimationRequest.IFactory structureToggleRequestFactory,
         @Named("MessageableServer") IMessageable messageableServer,
         IPlayerFactory playerFactory, IConfig config)
     {
@@ -47,7 +49,7 @@ public class StructureToggleRequestBuilder
     }
 
     /**
-     * Creates a new guided builder for a {@link StructureToggleRequest}.
+     * Creates a new guided builder for a {@link StructureAnimationRequest}.
      *
      * @return The first step of the guided builder.
      */
@@ -60,7 +62,7 @@ public class StructureToggleRequestBuilder
     public static final class Builder
         implements IBuilderStructure, IBuilderStructureActionCause, IBuilderStructureActionType, IBuilder
     {
-        private final StructureToggleRequest.IFactory structureToggleRequestFactory;
+        private final StructureAnimationRequest.IFactory structureToggleRequestFactory;
         private final IMessageable messageableServer;
         private final IPlayerFactory playerFactory;
         private final IConfig config;
@@ -177,7 +179,7 @@ public class StructureToggleRequestBuilder
         }
 
         @Override
-        public StructureToggleRequest build()
+        public StructureAnimationRequest build()
         {
             updateMessageReceiver();
             verify();
@@ -326,9 +328,9 @@ public class StructureToggleRequestBuilder
         /**
          * Constructs the new structure toggle request.
          *
-         * @return The new {@link StructureToggleRequest}.
+         * @return The new {@link StructureAnimationRequest}.
          */
-        StructureToggleRequest build();
+        StructureAnimationRequest build();
     }
 
     public interface IBuilderStructureActionType

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureBase.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureBase.java
@@ -60,7 +60,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
     private final IWorld world;
 
     @EqualsAndHashCode.Exclude @ToString.Exclude
-    private final StructureToggleRequestBuilder structureToggleRequestBuilder;
+    private final StructureAnimationRequestBuilder structureToggleRequestBuilder;
 
     @GuardedBy("lock")
     @Getter(onMethod_ = @Locked.Read)
@@ -157,7 +157,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
         DatabaseManager databaseManager,
         StructureRegistry structureRegistry,
         StructureOpeningHelper structureOpeningHelper,
-        StructureToggleRequestBuilder structureToggleRequestBuilder,
+        StructureAnimationRequestBuilder structureToggleRequestBuilder,
         IPlayerFactory playerFactory,
         IExecutor executor,
         IRedstoneManager redstoneManager,

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureOpeningHelper.java
@@ -278,7 +278,7 @@ public final class StructureOpeningHelper
                          data.getResponsible(), messageReceiver, null);
 
         final OptionalLong registrationResult =
-            structureActivityManager.registerAnimation(snapshot.getUid(), animationType.requiresWriteAccess());
+            structureActivityManager.registerAnimation(targetStructure, animationType.requiresWriteAccess());
         if (registrationResult.isEmpty())
             return StructureToggleResult.BUSY;
 

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureOpeningHelper.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/StructureOpeningHelper.java
@@ -25,12 +25,12 @@ import nl.pim16aap2.bigdoors.core.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.core.managers.LimitsManager;
 import nl.pim16aap2.bigdoors.core.managers.StructureTypeManager;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationBlockManagerFactory;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationType;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationBlockManager;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureActivityManager;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IDiscreteMovement;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
 import nl.pim16aap2.bigdoors.core.util.Limit;
@@ -70,7 +70,7 @@ public final class StructureOpeningHelper
     private final LimitsManager limitsManager;
     private final IBigDoorsEventCaller bigDoorsEventCaller;
     private final AnimationBlockManagerFactory animationBlockManagerFactory;
-    private final StructureRequestData.IFactory movementRequestDataFactory;
+    private final AnimationRequestData.IFactory movementRequestDataFactory;
 
     @Inject //
     StructureOpeningHelper(
@@ -90,7 +90,7 @@ public final class StructureOpeningHelper
         LimitsManager limitsManager,
         IBigDoorsEventCaller bigDoorsEventCaller,
         AnimationBlockManagerFactory animationBlockManagerFactory,
-        StructureRequestData.IFactory movementRequestDataFactory)
+        AnimationRequestData.IFactory movementRequestDataFactory)
     {
         this.localizer = localizer;
         this.textFactory = textFactory;
@@ -183,7 +183,7 @@ public final class StructureOpeningHelper
      * {@link IBigDoorsEventFactory#createTogglePrepareEvent(StructureSnapshot, StructureActionCause,
      * StructureActionType, IPlayer, double, boolean, Cuboid)}.
      */
-    private IStructureEventTogglePrepare callTogglePrepareEvent(StructureRequestData data)
+    private IStructureEventTogglePrepare callTogglePrepareEvent(AnimationRequestData data)
     {
         return callTogglePrepareEvent(
             data.getStructureSnapshot(),
@@ -217,7 +217,7 @@ public final class StructureOpeningHelper
      * {@link IBigDoorsEventFactory#createToggleStartEvent(AbstractStructure, StructureSnapshot, StructureActionCause,
      * StructureActionType, IPlayer, double, boolean, Cuboid)}.
      */
-    private IStructureEventToggleStart callToggleStartEvent(AbstractStructure structure, StructureRequestData data)
+    private IStructureEventToggleStart callToggleStartEvent(AbstractStructure structure, AnimationRequestData data)
     {
         return callToggleStartEvent(
             structure,
@@ -239,7 +239,7 @@ public final class StructureOpeningHelper
      * Registers a new block mover. Must be called from the main thread.
      */
     private boolean registerBlockMover(
-        AbstractStructure structure, StructureRequestData data, IAnimationComponent component,
+        AbstractStructure structure, AnimationRequestData data, IAnimationComponent component,
         @Nullable IPlayer player,
         AnimationType animationType, long stamp)
     {
@@ -263,7 +263,7 @@ public final class StructureOpeningHelper
     }
 
     private StructureToggleResult toggle(
-        StructureSnapshot snapshot, AbstractStructure targetStructure, StructureRequestData data,
+        StructureSnapshot snapshot, AbstractStructure targetStructure, AnimationRequestData data,
         IAnimationComponent component, IMessageable messageReceiver, @Nullable IPlayer player,
         AnimationType animationType)
     {
@@ -314,10 +314,10 @@ public final class StructureOpeningHelper
         return StructureToggleResult.SUCCESS;
     }
 
-    StructureToggleResult toggle(AbstractStructure structure, StructureToggleRequest request, IPlayer responsible)
+    StructureToggleResult toggle(AbstractStructure structure, StructureAnimationRequest request, IPlayer responsible)
     {
         final StructureSnapshot snapshot;
-        final StructureRequestData data;
+        final AnimationRequestData data;
         final IAnimationComponent component;
 
         structure.getLock().readLock().lock();

--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/structurearchetypes/IHorizontalAxisAligned.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/structures/structurearchetypes/IHorizontalAxisAligned.java
@@ -9,7 +9,10 @@ import nl.pim16aap2.bigdoors.core.structures.StructureType;
 public interface IHorizontalAxisAligned
 {
     /**
-     * Checks if the {@link AbstractStructure} is aligned with the z-axis (North/South).
+     * Describes if the {@link AbstractStructure} is animated along the North/South (-/+ Z) axis <b>(= TRUE)</b> or
+     * along the East/West (+/- X) axis <b>(= FALSE)</b>.
+     *
+     * @return True if this structure is animated along the North/South axis.
      */
-    boolean isNorthSouthAligned();
+    boolean isNorthSouthAnimated();
 }

--- a/bigdoors-core/src/main/resources/version
+++ b/bigdoors-core/src/main/resources/version
@@ -1,2 +1,3 @@
 ${git.branch}: ${git.commit.id} dirty:${git.dirty} (${git.commit.time})
-${actions.run.id} ${actions.run.number}
+${actions.run.number}
+${actions.run.id}

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/core/commands/StopMovablesTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/core/commands/StopMovablesTest.java
@@ -46,6 +46,6 @@ class StopStructuresTest
     void test()
     {
         Assertions.assertDoesNotThrow(() -> factory.newStopStructures(commandSender).run().get(1, TimeUnit.SECONDS));
-        Mockito.verify(structureActivityManager).abortAnimators();
+        Mockito.verify(structureActivityManager).shutDown();
     }
 }

--- a/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/core/commands/ToggleTest.java
+++ b/bigdoors-core/src/test/java/nl/pim16aap2/bigdoors/core/commands/ToggleTest.java
@@ -11,8 +11,8 @@ import nl.pim16aap2.bigdoors.core.events.StructureActionType;
 import nl.pim16aap2.bigdoors.core.localization.ILocalizer;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationType;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
-import nl.pim16aap2.bigdoors.core.structures.StructureToggleRequest;
-import nl.pim16aap2.bigdoors.core.structures.StructureToggleRequestBuilder;
+import nl.pim16aap2.bigdoors.core.structures.StructureAnimationRequest;
+import nl.pim16aap2.bigdoors.core.structures.StructureAnimationRequestBuilder;
 import nl.pim16aap2.bigdoors.core.structures.StructureType;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetriever;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetrieverFactory;
@@ -46,18 +46,18 @@ class ToggleTest
     private StructureType structureType;
 
     @Mock(answer = Answers.CALLS_REAL_METHODS)
-    private StructureToggleRequest.IFactory structureToggleRequestFactory;
+    private StructureAnimationRequest.IFactory structureToggleRequestFactory;
 
     @Mock(answer = Answers.CALLS_REAL_METHODS)
     private Toggle.IFactory factory;
 
-    private StructureToggleRequestBuilder structureToggleRequestBuilder;
+    private StructureAnimationRequestBuilder structureToggleRequestBuilder;
 
     @Mock
     private IMessageable messageableServer;
 
     @Mock
-    private StructureToggleRequest structureToggleRequest;
+    private StructureAnimationRequest structureToggleRequest;
 
     @BeforeEach
     void init()
@@ -81,7 +81,7 @@ class ToggleTest
                                                           Mockito.anyBoolean(), Mockito.any(), Mockito.any()))
                .thenReturn(structureToggleRequest);
 
-        structureToggleRequestBuilder = new StructureToggleRequestBuilder(
+        structureToggleRequestBuilder = new StructureAnimationRequestBuilder(
             structureToggleRequestFactory, messageableServer, Mockito.mock(IPlayerFactory.class),
             Mockito.mock(IConfig.class));
 

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/BigDoorsSpigotComponent.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/BigDoorsSpigotComponent.java
@@ -37,6 +37,7 @@ import nl.pim16aap2.bigdoors.core.managers.StructureTypeManager;
 import nl.pim16aap2.bigdoors.core.managers.ToolUserManager;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureActivityManager;
 import nl.pim16aap2.bigdoors.core.storage.sqlite.SQLiteStorageModule;
+import nl.pim16aap2.bigdoors.core.structures.StructureAnimationRequestBuilder;
 import nl.pim16aap2.bigdoors.core.structures.StructureRegistry;
 import nl.pim16aap2.bigdoors.core.util.VersionReader;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetrieverFactory;
@@ -143,6 +144,8 @@ interface BigDoorsSpigotComponent
     ProtectionCompatManagerSpigot getProtectionCompatManager();
 
     GuiFactory getGUIFactory();
+
+    StructureAnimationRequestBuilder structureAnimationRequestBuilder();
 
     ConfigSpigot getConfig();
 

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/BigDoorsSpigotPlatform.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/BigDoorsSpigotPlatform.java
@@ -207,7 +207,7 @@ public final class BigDoorsSpigotPlatform implements IBigDoorsPlatform
     private final CommandManager commandListener;
 
     @Getter
-    private final VersionReader versionReader;
+    private final VersionReader.VersionInfo versionInfo;
 
     BigDoorsSpigotPlatform(BigDoorsSpigotComponent bigDoorsSpigotComponent, BigDoorsPlugin plugin)
         throws InitializationException
@@ -277,7 +277,7 @@ public final class BigDoorsSpigotPlatform implements IBigDoorsPlatform
         doorTypeLoader = safeGetter(BigDoorsSpigotComponent::getDoorTypeLoader);
         restartableHolder = safeGetter(BigDoorsSpigotComponent::getRestartableHolder);
         commandListener = safeGetter(BigDoorsSpigotComponent::getCommandListener);
-        versionReader = safeGetter(BigDoorsSpigotComponent::getVersionReader);
+        versionInfo = safeGetter(BigDoorsSpigotComponent::getVersionReader).getVersionInfo();
 
         initPlatform();
     }
@@ -333,7 +333,7 @@ public final class BigDoorsSpigotPlatform implements IBigDoorsPlatform
     }
 
     @Override
-    public String getVersion()
+    public String getVersionName()
     {
         return plugin.getDescription().getVersion();
     }

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/BigDoorsSpigotPlatform.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/BigDoorsSpigotPlatform.java
@@ -38,6 +38,7 @@ import nl.pim16aap2.bigdoors.core.managers.StructureTypeManager;
 import nl.pim16aap2.bigdoors.core.managers.ToolUserManager;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureActivityManager;
 import nl.pim16aap2.bigdoors.core.storage.IStorage;
+import nl.pim16aap2.bigdoors.core.structures.StructureAnimationRequestBuilder;
 import nl.pim16aap2.bigdoors.core.structures.StructureRegistry;
 import nl.pim16aap2.bigdoors.core.util.VersionReader;
 import nl.pim16aap2.bigdoors.core.util.structureretriever.StructureRetrieverFactory;
@@ -82,6 +83,8 @@ public final class BigDoorsSpigotPlatform implements IBigDoorsPlatform
 
     @Getter
     private final GuiFactory guiFactory;
+
+    private final StructureAnimationRequestBuilder structureAnimationRequestBuilder;
 
     @Getter
     private final IPlayerFactory playerFactory;
@@ -252,6 +255,7 @@ public final class BigDoorsSpigotPlatform implements IBigDoorsPlatform
         animatedBlockFactory = safeGetter(BigDoorsSpigotComponent::getAnimatedBlockFactory);
         bigDoorsEventFactory = safeGetter(BigDoorsSpigotComponent::getIBigDoorsEventFactory);
         guiFactory = safeGetter(BigDoorsSpigotComponent::getGUIFactory);
+        structureAnimationRequestBuilder = safeGetter(BigDoorsSpigotComponent::structureAnimationRequestBuilder);
 
         redstoneListener = safeGetter(BigDoorsSpigotComponent::getRedstoneListener);
         loginResourcePackListener = safeGetter(BigDoorsSpigotComponent::getLoginResourcePackListener);
@@ -308,6 +312,12 @@ public final class BigDoorsSpigotPlatform implements IBigDoorsPlatform
             throw new InitializationException(
                 "Failed to instantiate the BigDoors platform for Spigot: Missing dependency!");
         return ret;
+    }
+
+    @Override
+    public StructureAnimationRequestBuilder.IBuilderStructure getStructureAnimationRequestBuilder()
+    {
+        return structureAnimationRequestBuilder.builder();
     }
 
     @Override

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/comands/DirectionParser.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/comands/DirectionParser.java
@@ -79,8 +79,9 @@ public class DirectionParser implements ArgumentParser<ICommandSender, MovementD
         final Stream<String> suggestionsStream =
             Objects.requireNonNullElseGet(tryRetrieveGuidedSuggestions(commandContext),
                                           () -> invertedSuggestions.values().stream());
-        final String lowerCaseInput = input.toLowerCase(Locale.ROOT);
-        return suggestionsStream.filter(val -> val.startsWith(lowerCaseInput)).toList();
+        return suggestionsStream
+            .filter(val -> val.toLowerCase(Locale.ROOT).startsWith(input.toLowerCase(Locale.ROOT)))
+            .toList();
     }
 
     private @Nullable Stream<String> tryRetrieveGuidedSuggestions(

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/AbstractListener.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/AbstractListener.java
@@ -8,16 +8,17 @@ import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 
 /**
  * Represents a base Listener class.
  *
  * @author Pim
  */
-public abstract class AbstractListener implements Listener, IRestartable
+abstract class AbstractListener implements Listener, IRestartable
 {
-    private final @Nullable Supplier<Boolean> enabler;
+    private final @Nullable BooleanSupplier enabler;
+
     protected final JavaPlugin plugin;
 
     protected boolean isRegistered = false;
@@ -29,7 +30,7 @@ public abstract class AbstractListener implements Listener, IRestartable
      *     A supplier that is used to query whether this listener should be enabled. When this is not provided, it is
      *     assumed that this listener should always be enabled.
      */
-    public AbstractListener(@Nullable RestartableHolder holder, JavaPlugin plugin, @Nullable Supplier<Boolean> enabler)
+    protected AbstractListener(@Nullable RestartableHolder holder, JavaPlugin plugin, @Nullable BooleanSupplier enabler)
     {
         if (holder != null)
             holder.registerRestartable(this);
@@ -38,7 +39,7 @@ public abstract class AbstractListener implements Listener, IRestartable
     }
 
     /**
-     * See {@link #AbstractListener(RestartableHolder, JavaPlugin, Supplier)}
+     * See {@link #AbstractListener(RestartableHolder, JavaPlugin, BooleanSupplier)}
      */
     protected AbstractListener(@Nullable RestartableHolder holder, JavaPlugin plugin)
     {
@@ -76,7 +77,7 @@ public abstract class AbstractListener implements Listener, IRestartable
     @Override
     public void initialize()
     {
-        if (enabler == null || enabler.get())
+        if (enabler == null || enabler.getAsBoolean())
             register();
     }
 

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/ChunkListener.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/ChunkListener.java
@@ -46,17 +46,19 @@ public class ChunkListener extends AbstractListener
     private final StructureActivityManager structureActivityManager;
     private final IExecutor executor;
 
-    @Inject
-    public ChunkListener(
-        JavaPlugin javaPlugin, DatabaseManager databaseManager, PowerBlockManager powerBlockManager,
-        RestartableHolder restartableHolder, StructureActivityManager structureActivityManager, IExecutor executor)
+    @Inject ChunkListener(
+        JavaPlugin javaPlugin,
+        DatabaseManager databaseManager,
+        PowerBlockManager powerBlockManager,
+        RestartableHolder restartableHolder,
+        StructureActivityManager structureActivityManager,
+        IExecutor executor)
     {
         super(restartableHolder, javaPlugin);
         this.databaseManager = databaseManager;
         this.powerBlockManager = powerBlockManager;
         this.structureActivityManager = structureActivityManager;
         this.executor = executor;
-        register();
     }
 
     private void onChunkLoad(World world, Chunk chunk)

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/EventListeners.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/EventListeners.java
@@ -5,9 +5,9 @@ import nl.pim16aap2.bigdoors.core.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.core.managers.DatabaseManager;
 import nl.pim16aap2.bigdoors.core.managers.DelayedCommandInputManager;
 import nl.pim16aap2.bigdoors.core.managers.ToolUserManager;
+import nl.pim16aap2.bigdoors.core.tooluser.ToolUser;
 import nl.pim16aap2.bigdoors.spigot.core.implementations.BigDoorsToolUtilSpigot;
 import nl.pim16aap2.bigdoors.spigot.util.SpigotAdapter;
-import nl.pim16aap2.bigdoors.core.tooluser.ToolUser;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
@@ -34,7 +34,6 @@ import javax.inject.Singleton;
  *
  * @author Pim
  */
-// TODO: Split this class up. It's got too much stuff.
 @Singleton
 @Flogger
 public class EventListeners extends AbstractListener
@@ -44,10 +43,12 @@ public class EventListeners extends AbstractListener
     private final ToolUserManager toolUserManager;
     private final DelayedCommandInputManager delayedCommandInputManager;
 
-    @Inject
-    public EventListeners(
-        JavaPlugin javaPlugin, BigDoorsToolUtilSpigot bigDoorsToolUtil, DatabaseManager databaseManager,
-        ToolUserManager toolUserManager, DelayedCommandInputManager delayedCommandInputManager,
+    @Inject EventListeners(
+        JavaPlugin javaPlugin,
+        BigDoorsToolUtilSpigot bigDoorsToolUtil,
+        DatabaseManager databaseManager,
+        ToolUserManager toolUserManager,
+        DelayedCommandInputManager delayedCommandInputManager,
         RestartableHolder restartableHolder)
     {
         super(restartableHolder, javaPlugin);
@@ -55,7 +56,6 @@ public class EventListeners extends AbstractListener
         this.databaseManager = databaseManager;
         this.toolUserManager = toolUserManager;
         this.delayedCommandInputManager = delayedCommandInputManager;
-        register();
     }
 
     /**

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/LoginMessageListener.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/LoginMessageListener.java
@@ -1,8 +1,8 @@
 package nl.pim16aap2.bigdoors.spigot.core.listeners;
 
 import nl.pim16aap2.bigdoors.core.api.restartable.RestartableHolder;
-import nl.pim16aap2.bigdoors.spigot.core.BigDoorsPlugin;
 import nl.pim16aap2.bigdoors.core.util.Constants;
+import nl.pim16aap2.bigdoors.spigot.core.BigDoorsPlugin;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -29,7 +29,8 @@ public final class LoginMessageListener extends AbstractListener
     {
         super(restartableHolder, javaPlugin);
         this.plugin = javaPlugin;
-        register();
+        if (restartableHolder == null)
+            register();
     }
 
     /**

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/LoginResourcePackListener.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/LoginResourcePackListener.java
@@ -23,8 +23,7 @@ public class LoginResourcePackListener extends AbstractListener
     private final ConfigSpigot config;
     private String resourcePackURL;
 
-    @Inject
-    public LoginResourcePackListener(RestartableHolder holder, ConfigSpigot config, JavaPlugin plugin)
+    @Inject LoginResourcePackListener(RestartableHolder holder, ConfigSpigot config, JavaPlugin plugin)
     {
         super(holder, plugin, () -> shouldBeEnabled(config));
         this.config = config;

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/RedstoneListener.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/RedstoneListener.java
@@ -34,8 +34,7 @@ public class RedstoneListener extends AbstractListener
     private final Set<Material> powerBlockTypes = new HashSet<>();
     private final PowerBlockManager powerBlockManager;
 
-    @Inject
-    public RedstoneListener(
+    @Inject RedstoneListener(
         RestartableHolder holder, JavaPlugin plugin, ConfigSpigot config, PowerBlockManager powerBlockManager)
     {
         super(holder, plugin, config::isRedstoneEnabled);

--- a/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/WorldListener.java
+++ b/bigdoors-spigot/spigot-core/src/main/java/nl/pim16aap2/bigdoors/spigot/core/listeners/WorldListener.java
@@ -22,12 +22,17 @@ public final class WorldListener extends AbstractListener
 {
     private final PowerBlockManager powerBlockManager;
 
-    @Inject
-    public WorldListener(
+    @Inject WorldListener(
         JavaPlugin javaPlugin, PowerBlockManager powerBlockManager, RestartableHolder restartableHolder)
     {
         super(restartableHolder, javaPlugin);
         this.powerBlockManager = powerBlockManager;
+    }
+
+    @Override
+    public void initialize()
+    {
+        super.initialize();
         for (final World world : Bukkit.getWorlds())
             powerBlockManager.loadWorld(world.getName());
     }

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/storage/SQLiteJDBCDriverConnectionTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/storage/SQLiteJDBCDriverConnectionTest.java
@@ -125,8 +125,8 @@ public class SQLiteJDBCDriverConnectionTest
         MockitoAnnotations.openMocks(this);
 
         worldFactory = new TestWorldFactory();
-        structureRegistry = StructureRegistry.unCached(
-            restartableHolder, debuggableRegistry, Mockito.mock(StructureDeletionManager.class));
+        structureRegistry =
+            StructureRegistry.unCached(debuggableRegistry, Mockito.mock(StructureDeletionManager.class));
 
         structureTypeManager = new StructureTypeManager(restartableHolder, debuggableRegistry, localizationManager);
 

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/storage/SQLiteJDBCDriverConnectionTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/storage/SQLiteJDBCDriverConnectionTest.java
@@ -617,7 +617,6 @@ public class SQLiteJDBCDriverConnectionTest
         max = new Vector3Di(144, 131, 182);
         rotationPoint = new Vector3Di(144, 75, 153);
         powerBlock = new Vector3Di(144, 75, 153);
-        boolean modeUp = true;
 
         structure2 = new Drawbridge(
             structureBaseBuilder
@@ -628,8 +627,7 @@ public class SQLiteJDBCDriverConnectionTest
                 .isLocked(false).openDir(MovementDirection.NONE)
                 .primeOwner(
                     new StructureOwner(12L, PermissionLevel.CREATOR, PLAYER_DATA_1))
-                .build(),
-            modeUp);
+                .build());
 
         min = new Vector3Di(144, 70, 168);
         max = new Vector3Di(144, 151, 112);

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/storage/SQLiteJDBCDriverConnectionTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/storage/SQLiteJDBCDriverConnectionTest.java
@@ -128,7 +128,7 @@ public class SQLiteJDBCDriverConnectionTest
         structureRegistry =
             StructureRegistry.unCached(debuggableRegistry, Mockito.mock(StructureDeletionManager.class));
 
-        structureTypeManager = new StructureTypeManager(restartableHolder, debuggableRegistry, localizationManager);
+        structureTypeManager = new StructureTypeManager(debuggableRegistry, localizationManager);
 
         final var builderResult = newStructureBaseBuilder();
         builderResult.assistedFactoryMocker().setMock(StructureRegistry.class, structureRegistry);

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/structures/StructureSerializerTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/structures/StructureSerializerTest.java
@@ -146,10 +146,8 @@ class StructureSerializerTest
     }
 
     @Test
-    void testAmbiguousClass()
+    void testAmbiguousNames()
     {
-        Assertions.assertThrows(Exception.class,
-                                () -> new StructureSerializer<>(TestStructureSubTypeAmbiguousFieldTypes.class, 1));
         Assertions.assertThrows(Exception.class,
                                 () -> new StructureSerializer<>(TestStructureSubTypeAmbiguousFieldNames.class, 1));
     }
@@ -199,11 +197,11 @@ class StructureSerializerTest
         private final ReentrantReadWriteLock lock;
 
         @Getter
-        @PersistentVariable
+        @PersistentVariable("testName")
         protected @Nullable String testName;
 
         @Getter
-        @PersistentVariable
+        @PersistentVariable("isCoolType")
         protected boolean isCoolType;
 
         @Getter
@@ -280,16 +278,16 @@ class StructureSerializerTest
         private final ReentrantReadWriteLock lock;
 
         @Getter
-        @PersistentVariable("subclassTestValue")
+        @PersistentVariable(value = "subclassTestValue")
         private final int subclassTestValue;
 
         @Deserialization
         public TestStructureSubType(
             BaseHolder base,
             String testName,
-            @PersistentVariable("subclassTestValue") int subclassTestValue,
+            @PersistentVariable(value = "subclassTestValue") int subclassTestValue,
             boolean isCoolType,
-            @PersistentVariable("blockTestCount") int blockTestCount)
+            @PersistentVariable(value = "blockTestCount") int blockTestCount)
         {
             super(base, testName, isCoolType, blockTestCount);
             this.lock = super.getLock();
@@ -309,7 +307,7 @@ class StructureSerializerTest
     @EqualsAndHashCode(callSuper = true)
     private static class TestStructureSubTypeAmbiguousParameterTypes extends TestStructureType
     {
-        @PersistentVariable("ambiguousInteger1")
+        @PersistentVariable(value = "ambiguousInteger1")
         private final int ambiguousInteger1;
 
         @Deserialization
@@ -334,25 +332,8 @@ class StructureSerializerTest
         @Deserialization
         public TestStructureSubTypeAmbiguousParameterNames(
             BaseHolder base,
-            @PersistentVariable("ambiguous") UUID o0,
-            @PersistentVariable("ambiguous") String o1)
-        {
-            super(base);
-        }
-    }
-
-    @SuppressWarnings("unused")
-    @EqualsAndHashCode(callSuper = true)
-    private static class TestStructureSubTypeAmbiguousFieldTypes extends TestStructureType
-    {
-        @PersistentVariable
-        private int ambiguousInteger0;
-
-        @PersistentVariable
-        private int ambiguousInteger1;
-
-        @Deserialization
-        public TestStructureSubTypeAmbiguousFieldTypes(BaseHolder base)
+            @PersistentVariable(value = "ambiguous") UUID o0,
+            @PersistentVariable(value = "ambiguous") String o1)
         {
             super(base);
         }

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/structures/StructureSerializerTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/structures/StructureSerializerTest.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
 import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.core.api.PlayerData;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
 import nl.pim16aap2.bigdoors.core.util.Rectangle;
@@ -266,7 +266,7 @@ class StructureSerializerTest
         }
 
         @Override
-        protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
+        protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
         {
             return null;
         }

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/structures/bigdoor/CreatorBigDoorTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/structures/bigdoor/CreatorBigDoorTest.java
@@ -1,7 +1,7 @@
 package nl.pim16aap2.bigdoors.structures.bigdoor;
 
-import nl.pim16aap2.bigdoors.tooluser.creator.CreatorTestsUtil;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
+import nl.pim16aap2.bigdoors.tooluser.creator.CreatorTestsUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +21,7 @@ class CreatorBigDoorTest extends CreatorTestsUtil
 
         final BigDoor actualStructure = new BigDoor(constructStructureBase());
         Assertions.assertNotNull(StructureTypeBigDoor.get());
-        final CreatorBigDoor creator = new CreatorBigDoor(context, player);
+        final CreatorBigDoor creator = new CreatorBigDoor(context, player, null);
         testCreation(creator, actualStructure,
                      structureName,
                      min.toLocation(locationFactory, world),

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/structures/portcullis/CreatorPortcullisTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/structures/portcullis/CreatorPortcullisTest.java
@@ -32,7 +32,7 @@ class CreatorPortcullisTest extends CreatorTestsUtil
         setBuyStructure(true);
 
         final Portcullis actualStructure = new Portcullis(constructStructureBase(), blocksToMove);
-        final CreatorPortcullis creator = new CreatorPortcullis(context, player);
+        final CreatorPortcullis creator = new CreatorPortcullis(context, player, null);
         testCreation(creator, actualStructure,
                      structureName,
                      min.toLocation(locationFactory, world),
@@ -47,7 +47,7 @@ class CreatorPortcullisTest extends CreatorTestsUtil
     @Test
     void testBlocksToMove()
     {
-        final CreatorPortcullis creator = new CreatorPortcullis(context, player);
+        final CreatorPortcullis creator = new CreatorPortcullis(context, player, null);
         final int blocksToMoveLimit = blocksToMove - 1;
         Mockito.when(config.maxBlocksToMove()).thenReturn(OptionalInt.of(blocksToMoveLimit));
 

--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/tooluser/creator/CreatorTestsUtil.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/tooluser/creator/CreatorTestsUtil.java
@@ -13,7 +13,6 @@ import nl.pim16aap2.bigdoors.core.api.debugging.DebuggableRegistry;
 import nl.pim16aap2.bigdoors.core.api.factories.ILocationFactory;
 import nl.pim16aap2.bigdoors.core.api.factories.IPlayerFactory;
 import nl.pim16aap2.bigdoors.core.api.factories.ITextFactory;
-import nl.pim16aap2.bigdoors.core.api.restartable.RestartableHolder;
 import nl.pim16aap2.bigdoors.core.commands.CommandFactory;
 import nl.pim16aap2.bigdoors.core.commands.DelayedCommand;
 import nl.pim16aap2.bigdoors.core.commands.DelayedCommandInputRequest;
@@ -153,7 +152,7 @@ public class CreatorTestsUtil
         builderResult.assistedFactoryMocker()
                      .setMock(ILocalizer.class, localizer)
                      .setMock(StructureRegistry.class,
-                              StructureRegistry.unCached(Mockito.mock(RestartableHolder.class), debuggableRegistry,
+                              StructureRegistry.unCached(debuggableRegistry,
                                                          Mockito.mock(StructureDeletionManager.class)));
         structureBaseBuilder = builderResult.structureBaseBuilder();
 

--- a/structures/structure-bigdoor/src/main/java/nl/pim16aap2/bigdoors/structures/bigdoor/BigDoor.java
+++ b/structures/structure-bigdoor/src/main/java/nl/pim16aap2/bigdoors/structures/bigdoor/BigDoor.java
@@ -42,14 +42,14 @@ public class BigDoor extends AbstractStructure
      *
      * @return The number of quarter circles this structure will rotate.
      */
-    @PersistentVariable("quarterCircles")
+    @PersistentVariable(value = "quarterCircles")
     @GuardedBy("lock")
     @Getter(onMethod_ = @Locked.Read)
     @Setter(onMethod_ = @Locked.Write)
     private int quarterCircles;
 
     @Deserialization
-    public BigDoor(BaseHolder base, @PersistentVariable("quarterCircles") int quarterCircles)
+    public BigDoor(BaseHolder base, @PersistentVariable(value = "quarterCircles") int quarterCircles)
     {
         super(base, StructureTypeBigDoor.get());
         this.lock = getLock();

--- a/structures/structure-bigdoor/src/main/java/nl/pim16aap2/bigdoors/structures/bigdoor/BigDoor.java
+++ b/structures/structure-bigdoor/src/main/java/nl/pim16aap2/bigdoors/structures/bigdoor/BigDoor.java
@@ -8,8 +8,8 @@ import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
 import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
 import nl.pim16aap2.bigdoors.core.util.MathUtil;
@@ -150,7 +150,7 @@ public class BigDoor extends AbstractStructure
 
     @Override
     @Locked.Read
-    protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
+    protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return new BigDoorAnimationComponent(data, getCurrentToggleDir(), quarterCircles);
     }

--- a/structures/structure-bigdoor/src/main/java/nl/pim16aap2/bigdoors/structures/bigdoor/BigDoorAnimationComponent.java
+++ b/structures/structure-bigdoor/src/main/java/nl/pim16aap2/bigdoors/structures/bigdoor/BigDoorAnimationComponent.java
@@ -2,10 +2,10 @@ package nl.pim16aap2.bigdoors.structures.bigdoor;
 
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.core.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationUtil;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimator;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.StructureSnapshot;
 import nl.pim16aap2.bigdoors.core.util.MathUtil;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
@@ -22,7 +22,7 @@ public class BigDoorAnimationComponent implements IAnimationComponent
     private final double angle;
     private final double step;
 
-    public BigDoorAnimationComponent(StructureRequestData data, MovementDirection movementDirection, int quarterCircles)
+    public BigDoorAnimationComponent(AnimationRequestData data, MovementDirection movementDirection, int quarterCircles)
     {
         this.snapshot = data.getStructureSnapshot();
         this.movementDirection = movementDirection;

--- a/structures/structure-bigdoor/src/main/java/nl/pim16aap2/bigdoors/structures/bigdoor/CreatorBigDoor.java
+++ b/structures/structure-bigdoor/src/main/java/nl/pim16aap2/bigdoors/structures/bigdoor/CreatorBigDoor.java
@@ -19,11 +19,6 @@ public class CreatorBigDoor extends Creator
         super(context, player, name);
     }
 
-    public CreatorBigDoor(Creator.Context context, IPlayer player)
-    {
-        this(context, player, null);
-    }
-
     @Override
     protected List<Step> generateSteps()
         throws InstantiationException

--- a/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/Clock.java
+++ b/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/Clock.java
@@ -6,8 +6,8 @@ import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
 import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IPerpetualMover;
@@ -98,7 +98,7 @@ public class Clock extends AbstractStructure implements IHorizontalAxisAligned, 
 
     @Override
     @Locked.Read
-    protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
+    protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return new ClockAnimationComponent(data, getCurrentToggleDir(), isNorthSouthAnimated());
     }

--- a/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/Clock.java
+++ b/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/Clock.java
@@ -33,24 +33,13 @@ public class Clock extends AbstractStructure implements IHorizontalAxisAligned, 
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
-    /**
-     * Describes if the {@link Clock} is situated along the North/South axis <b>(= TRUE)</b> or along the East/West
-     * axis
-     * <b>(= FALSE)</b>.
-     * <p>
-     * To be situated along a specific axis means that the blocks move along that axis. For example, if the structure
-     * moves along the North/South <i>(= Z)</i> axis, all animated blocks will have a different Z-coordinate depending
-     * on the time of day and an X-coordinate depending on the X-coordinate they originally started at.
-     *
-     * @return True if this clock is situated along the north/south axis.
-     */
     @Getter
-    @PersistentVariable("northSouthAligned")
-    protected final boolean northSouthAligned;
+    @PersistentVariable("northSouthAnimated")
+    protected final boolean northSouthAnimated;
 
     /**
      * Describes on which side the hour arm is. If the clock is situated along the North/South axis see
-     * {@link #northSouthAligned}, then the hour arm can either be on the {@link PBlockFace#WEST} or the
+     * {@link #northSouthAnimated}, then the hour arm can either be on the {@link PBlockFace#WEST} or the
      * {@link PBlockFace#EAST} side.
      * <p>
      * This is stored as a direction rather than an integer value (for example the X/Z axis value) so that it could also
@@ -65,12 +54,12 @@ public class Clock extends AbstractStructure implements IHorizontalAxisAligned, 
     @Deserialization
     public Clock(
         BaseHolder base,
-        @PersistentVariable("northSouthAligned") boolean northSouthAligned,
+        @PersistentVariable("northSouthAnimated") boolean northSouthAnimated,
         @PersistentVariable("hourArmSide") PBlockFace hourArmSide)
     {
         super(base, StructureTypeClock.get());
         this.lock = getLock();
-        this.northSouthAligned = northSouthAligned;
+        this.northSouthAnimated = northSouthAnimated;
         this.hourArmSide = hourArmSide;
     }
 
@@ -98,7 +87,7 @@ public class Clock extends AbstractStructure implements IHorizontalAxisAligned, 
         final int boxRadius = MathUtil.ceil(Math.sqrt(2 * Math.pow(circleRadius, 2)));
         final int delta = boxRadius - circleRadius;
 
-        return (isNorthSouthAligned() ? cuboid.grow(0, delta, delta) : cuboid.grow(delta, delta, 0)).asFlatRectangle();
+        return (isNorthSouthAnimated() ? cuboid.grow(0, delta, delta) : cuboid.grow(delta, delta, 0)).asFlatRectangle();
     }
 
     @Override
@@ -111,7 +100,7 @@ public class Clock extends AbstractStructure implements IHorizontalAxisAligned, 
     @Locked.Read
     protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
     {
-        return new ClockAnimationComponent(data, getCurrentToggleDir(), isNorthSouthAligned());
+        return new ClockAnimationComponent(data, getCurrentToggleDir(), isNorthSouthAnimated());
     }
 
     @Override

--- a/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/Clock.java
+++ b/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/Clock.java
@@ -34,7 +34,7 @@ public class Clock extends AbstractStructure implements IHorizontalAxisAligned, 
     private final ReentrantReadWriteLock lock;
 
     @Getter
-    @PersistentVariable("northSouthAnimated")
+    @PersistentVariable(value = "northSouthAnimated")
     protected final boolean northSouthAnimated;
 
     /**
@@ -47,15 +47,15 @@ public class Clock extends AbstractStructure implements IHorizontalAxisAligned, 
      *
      * @return The side of the hour arm relative to the minute arm.
      */
-    @PersistentVariable("hourArmSide")
+    @PersistentVariable(value = "hourArmSide")
     @Getter
     protected final PBlockFace hourArmSide;
 
     @Deserialization
     public Clock(
         BaseHolder base,
-        @PersistentVariable("northSouthAnimated") boolean northSouthAnimated,
-        @PersistentVariable("hourArmSide") PBlockFace hourArmSide)
+        @PersistentVariable(value = "northSouthAnimated") boolean northSouthAnimated,
+        @PersistentVariable(value = "hourArmSide") PBlockFace hourArmSide)
     {
         super(base, StructureTypeClock.get());
         this.lock = getLock();

--- a/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/ClockAnimationComponent.java
+++ b/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/ClockAnimationComponent.java
@@ -1,9 +1,9 @@
 package nl.pim16aap2.bigdoors.structures.clock;
 
 import nl.pim16aap2.bigdoors.core.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimator;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.StructureSnapshot;
 import nl.pim16aap2.bigdoors.core.util.MathUtil;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
@@ -51,7 +51,7 @@ public final class ClockAnimationComponent extends WindmillAnimationComponent
     private final StructureSnapshot snapshot;
 
     public ClockAnimationComponent(
-        StructureRequestData data, MovementDirection movementDirection, boolean isNorthSouthAligned)
+        AnimationRequestData data, MovementDirection movementDirection, boolean isNorthSouthAligned)
     {
         super(data, movementDirection, isNorthSouthAligned);
         this.snapshot = data.getStructureSnapshot();

--- a/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/CreatorClock.java
+++ b/structures/structure-clock/src/main/java/nl/pim16aap2/bigdoors/structures/clock/CreatorClock.java
@@ -46,12 +46,6 @@ public class CreatorClock extends Creator
         super(context, player, name);
     }
 
-    @SuppressWarnings("unused")
-    public CreatorClock(Creator.Context context, IPlayer player)
-    {
-        this(context, player, null);
-    }
-
     @Override
     protected List<Step> generateSteps()
         throws InstantiationException

--- a/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/CreatorDrawbridge.java
+++ b/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/CreatorDrawbridge.java
@@ -19,11 +19,6 @@ public class CreatorDrawbridge extends Creator
         super(context, player, name);
     }
 
-    public CreatorDrawbridge(Creator.Context context, IPlayer player)
-    {
-        this(context, player, null);
-    }
-
     @Override
     protected List<Step> generateSteps()
         throws InstantiationException

--- a/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/CreatorDrawbridge.java
+++ b/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/CreatorDrawbridge.java
@@ -48,7 +48,7 @@ public class CreatorDrawbridge extends Creator
     @Override
     protected AbstractStructure constructStructure()
     {
-        return new Drawbridge(constructStructureData(), true);
+        return new Drawbridge(constructStructureData());
     }
 
     @Override

--- a/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/Drawbridge.java
+++ b/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/Drawbridge.java
@@ -40,14 +40,14 @@ public class Drawbridge extends AbstractStructure implements IHorizontalAxisAlig
      *
      * @return The number of quarter circles this structure will rotate.
      */
-    @PersistentVariable("quarterCircles")
+    @PersistentVariable(value = "quarterCircles")
     @GuardedBy("lock")
     @Getter(onMethod_ = @Locked.Read)
     @Setter(onMethod_ = @Locked.Write)
     private int quarterCircles;
 
     @Deserialization
-    public Drawbridge(BaseHolder base, @PersistentVariable("quarterCircles") int quarterCircles)
+    public Drawbridge(BaseHolder base, @PersistentVariable(value = "quarterCircles") int quarterCircles)
     {
         super(base, StructureTypeDrawbridge.get());
         this.lock = getLock();

--- a/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/Drawbridge.java
+++ b/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/Drawbridge.java
@@ -1,12 +1,9 @@
 package nl.pim16aap2.bigdoors.structures.drawbridge;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
-import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
@@ -17,7 +14,6 @@ import nl.pim16aap2.bigdoors.core.util.MovementDirection;
 import nl.pim16aap2.bigdoors.core.util.Rectangle;
 import nl.pim16aap2.bigdoors.core.util.vector.Vector3Di;
 
-import javax.annotation.concurrent.GuardedBy;
 import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Stream;
@@ -35,24 +31,11 @@ public class Drawbridge extends AbstractStructure implements IHorizontalAxisAlig
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
-    /**
-     * Describes if this drawbridge's vertical position points (when taking the rotation point Y value as center) up
-     * <b>(= TRUE)</b> or down <b>(= FALSE)</b>
-     *
-     * @return True if this {@link Drawbridge}'s vertical stance points up.
-     */
-    @PersistentVariable("modeUp")
-    @GuardedBy("lock")
-    @Getter(onMethod_ = @Locked.Read)
-    @Setter(onMethod_ = @Locked.Write)
-    protected boolean modeUp;
-
     @Deserialization
-    public Drawbridge(BaseHolder base, @PersistentVariable("modeUp") boolean modeUp)
+    public Drawbridge(BaseHolder base)
     {
         super(base, StructureTypeDrawbridge.get());
         this.lock = getLock();
-        this.modeUp = modeUp;
     }
 
     @Override

--- a/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/Drawbridge.java
+++ b/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/Drawbridge.java
@@ -96,21 +96,21 @@ public class Drawbridge extends AbstractStructure implements IHorizontalAxisAlig
     @Locked.Read
     protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
     {
-        return new DrawbridgeAnimationComponent(data, getCurrentToggleDir(), isNorthSouthAligned(), quarterCircles);
+        return new DrawbridgeAnimationComponent(data, getCurrentToggleDir(), isNorthSouthAnimated(), quarterCircles);
     }
 
     @Override
-    public boolean isNorthSouthAligned()
+    public boolean isNorthSouthAnimated()
     {
         final MovementDirection openDir = getOpenDir();
-        return openDir == MovementDirection.EAST || openDir == MovementDirection.WEST;
+        return openDir == MovementDirection.NORTH || openDir == MovementDirection.SOUTH;
     }
 
     @Override
     @Locked.Read
     protected double calculateAnimationCycleDistance()
     {
-        final double maxRadius = getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint());
+        final double maxRadius = getMaxRadius(isNorthSouthAnimated(), getCuboid(), getRotationPoint());
         return quarterCircles * maxRadius * MathUtil.HALF_PI;
     }
 
@@ -118,7 +118,7 @@ public class Drawbridge extends AbstractStructure implements IHorizontalAxisAlig
     @Locked.Read
     protected Rectangle calculateAnimationRange()
     {
-        final double maxRadius = getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint());
+        final double maxRadius = getMaxRadius(isNorthSouthAnimated(), getCuboid(), getRotationPoint());
         return calculateAnimationRange(maxRadius, getCuboid());
     }
 

--- a/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/Drawbridge.java
+++ b/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/Drawbridge.java
@@ -7,8 +7,8 @@ import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
 import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
@@ -94,7 +94,7 @@ public class Drawbridge extends AbstractStructure implements IHorizontalAxisAlig
 
     @Override
     @Locked.Read
-    protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
+    protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return new DrawbridgeAnimationComponent(data, getCurrentToggleDir(), isNorthSouthAnimated(), quarterCircles);
     }

--- a/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/DrawbridgeAnimationComponent.java
+++ b/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/DrawbridgeAnimationComponent.java
@@ -1,11 +1,11 @@
 package nl.pim16aap2.bigdoors.structures.drawbridge;
 
 import nl.pim16aap2.bigdoors.core.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationUtil;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimator;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.StructureSnapshot;
 import nl.pim16aap2.bigdoors.core.util.MathUtil;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
@@ -31,7 +31,7 @@ public class DrawbridgeAnimationComponent implements IAnimationComponent
     private final int rotateCount;
 
     public DrawbridgeAnimationComponent(
-        StructureRequestData data, MovementDirection movementDirection, boolean isNorthSouthAligned, int quarterCircles)
+        AnimationRequestData data, MovementDirection movementDirection, boolean isNorthSouthAligned, int quarterCircles)
     {
         this.snapshot = data.getStructureSnapshot();
         this.northSouth = isNorthSouthAligned;

--- a/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/DrawbridgeAnimationComponent.java
+++ b/structures/structure-drawbridge/src/main/java/nl/pim16aap2/bigdoors/structures/drawbridge/DrawbridgeAnimationComponent.java
@@ -103,7 +103,7 @@ public class DrawbridgeAnimationComponent implements IAnimationComponent
         // Get the current radius of a block between used axis (either x and y, or z and y).
         // When the rotation point is positioned along the NS axis, the Z values does not change.
         final double deltaA = rotationPoint.yD() - yAxis;
-        final double deltaB = northSouthAligned ? (rotationPoint.xD() - xAxis) : (rotationPoint.zD() - zAxis);
+        final double deltaB = northSouthAligned ? (rotationPoint.zD() - zAxis) : (rotationPoint.xD() - xAxis);
         return (float) Math.sqrt(Math.pow(deltaA, 2) + Math.pow(deltaB, 2));
     }
 
@@ -119,8 +119,8 @@ public class DrawbridgeAnimationComponent implements IAnimationComponent
         // Get the angle between the used axes (either x and y, or z and y).
         // When the rotation point is positioned along the NS axis, the Z values does not change.
         final double deltaA = northSouth ?
-                              snapshot.getRotationPoint().x() - xAxis :
-                              snapshot.getRotationPoint().z() - zAxis;
+                              snapshot.getRotationPoint().z() - zAxis :
+                              snapshot.getRotationPoint().x() - xAxis;
         final double deltaB = snapshot.getRotationPoint().y() - yAxis;
         return (float) Util.clampAngleRad(Math.atan2(deltaA, deltaB));
     }

--- a/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/CreatorFlag.java
+++ b/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/CreatorFlag.java
@@ -25,11 +25,6 @@ public class CreatorFlag extends Creator
         super(context, player, name);
     }
 
-    public CreatorFlag(Creator.Context context, IPlayer player)
-    {
-        this(context, player, null);
-    }
-
     @Override
     protected List<Step> generateSteps()
         throws InstantiationException

--- a/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/CreatorFlag.java
+++ b/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/CreatorFlag.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class CreatorFlag extends Creator
 {
     private static final StructureType STRUCTURE_TYPE = StructureTypeFlag.get();
-    protected boolean northSouthAligned;
+    protected boolean northSouthAnimated;
 
     public CreatorFlag(Creator.Context context, IPlayer player, @Nullable String name)
     {
@@ -57,7 +57,7 @@ public class CreatorFlag extends Creator
         // Flags must have a dimension of 1 along either the x or z axis, as it's a `2d` shape.
         if ((cuboidDims.x() == 1) ^ (cuboidDims.z() == 1))
         {
-            northSouthAligned = cuboidDims.x() == 1;
+            northSouthAnimated = cuboidDims.x() == 1;
             return super.setSecondPos(loc);
         }
 
@@ -84,12 +84,12 @@ public class CreatorFlag extends Creator
     {
         Util.requireNonNull(cuboid, "cuboid");
         Util.requireNonNull(rotationPoint, "rotationPoint");
-        if (northSouthAligned)
+        if (northSouthAnimated)
             openDir = rotationPoint.z() == cuboid.getMin().z() ? MovementDirection.SOUTH : MovementDirection.NORTH;
         else
             openDir = rotationPoint.x() == cuboid.getMin().x() ? MovementDirection.EAST : MovementDirection.WEST;
 
-        return new Flag(constructStructureData(), northSouthAligned);
+        return new Flag(constructStructureData(), northSouthAnimated);
     }
 
     @Override

--- a/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/Flag.java
+++ b/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/Flag.java
@@ -43,11 +43,11 @@ public class Flag extends AbstractStructure implements IHorizontalAxisAligned, I
      * @return True if this structure is animated along the North/South axis.
      */
     @Getter
-    @PersistentVariable("northSouthAnimated")
+    @PersistentVariable(value = "northSouthAnimated")
     protected final boolean northSouthAnimated;
 
     @Deserialization
-    public Flag(BaseHolder base, @PersistentVariable("northSouthAnimated") boolean northSouthAnimated)
+    public Flag(BaseHolder base, @PersistentVariable(value = "northSouthAnimated") boolean northSouthAnimated)
     {
         super(base, StructureTypeFlag.get());
         this.lock = getLock();

--- a/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/Flag.java
+++ b/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/Flag.java
@@ -6,8 +6,8 @@ import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
 import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IPerpetualMover;
@@ -89,7 +89,7 @@ public class Flag extends AbstractStructure implements IHorizontalAxisAligned, I
 
     @Override
     @Locked.Read
-    protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
+    protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return new FlagAnimationComponent(data, isNorthSouthAnimated());
     }

--- a/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/Flag.java
+++ b/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/Flag.java
@@ -43,16 +43,15 @@ public class Flag extends AbstractStructure implements IHorizontalAxisAligned, I
      * @return True if this structure is animated along the North/South axis.
      */
     @Getter
-    @PersistentVariable("northSouthAligned")
-    protected final boolean northSouthAligned;
+    @PersistentVariable("northSouthAnimated")
+    protected final boolean northSouthAnimated;
 
     @Deserialization
-    public Flag(
-        BaseHolder base, @PersistentVariable("northSouthAligned") boolean northSouthAligned)
+    public Flag(BaseHolder base, @PersistentVariable("northSouthAnimated") boolean northSouthAnimated)
     {
         super(base, StructureTypeFlag.get());
         this.lock = getLock();
-        this.northSouthAligned = northSouthAligned;
+        this.northSouthAnimated = northSouthAnimated;
     }
 
     @Override
@@ -92,7 +91,7 @@ public class Flag extends AbstractStructure implements IHorizontalAxisAligned, I
     @Locked.Read
     protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
     {
-        return new FlagAnimationComponent(data, isNorthSouthAligned());
+        return new FlagAnimationComponent(data, isNorthSouthAnimated());
     }
 
     @Override

--- a/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/FlagAnimationComponent.java
+++ b/structures/structure-flag/src/main/java/nl/pim16aap2/bigdoors/structures/flag/FlagAnimationComponent.java
@@ -3,10 +3,10 @@ package nl.pim16aap2.bigdoors.structures.flag;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.core.api.IConfig;
 import nl.pim16aap2.bigdoors.core.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimator;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.StructureSnapshot;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
 import nl.pim16aap2.bigdoors.core.util.vector.IVector3D;
@@ -33,7 +33,7 @@ public final class FlagAnimationComponent implements IAnimationComponent
     private final int minY;
     private final Cuboid oldCuboid;
 
-    public FlagAnimationComponent(StructureRequestData data, boolean isNorthSouthAligned)
+    public FlagAnimationComponent(AnimationRequestData data, boolean isNorthSouthAligned)
     {
         this.snapshot = data.getStructureSnapshot();
         this.oldCuboid = snapshot.getCuboid();

--- a/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/CreatorGarageDoor.java
+++ b/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/CreatorGarageDoor.java
@@ -40,11 +40,6 @@ public class CreatorGarageDoor extends Creator
         super(context, player, name);
     }
 
-    public CreatorGarageDoor(Creator.Context context, IPlayer player)
-    {
-        this(context, player, null);
-    }
-
     @Override
     protected List<Step> generateSteps()
         throws InstantiationException

--- a/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/CreatorGarageDoor.java
+++ b/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/CreatorGarageDoor.java
@@ -22,18 +22,18 @@ public class CreatorGarageDoor extends Creator
     private static final StructureType STRUCTURE_TYPE = StructureTypeGarageDoor.get();
 
     /**
-     * The valid open directions when the structure is positioned along the north/south axis.
+     * The valid open directions when the structure is animated along the north/south axis.
      */
     private static final Set<MovementDirection> NORTH_SOUTH_AXIS_OPEN_DIRS =
-        EnumSet.of(MovementDirection.EAST, MovementDirection.WEST);
-
-    /**
-     * The valid open directions when the structure is positioned along the east/west axis.
-     */
-    private static final Set<MovementDirection> EAST_WEST_AXIS_OPEN_DIRS =
         EnumSet.of(MovementDirection.NORTH, MovementDirection.SOUTH);
 
-    private boolean northSouthAligned;
+    /**
+     * The valid open directions when the structure is animated along the east/west axis.
+     */
+    private static final Set<MovementDirection> EAST_WEST_AXIS_OPEN_DIRS =
+        EnumSet.of(MovementDirection.EAST, MovementDirection.WEST);
+
+    private boolean northSouthAnimated;
 
     public CreatorGarageDoor(Creator.Context context, IPlayer player, @Nullable String name)
     {
@@ -67,7 +67,7 @@ public class CreatorGarageDoor extends Creator
         // Check if there's exactly 1 dimension that is 1 block deep.
         if ((cuboidDims.x() == 1) ^ (cuboidDims.y() == 1) ^ (cuboidDims.z() == 1))
         {
-            northSouthAligned = cuboidDims.x() == 1;
+            northSouthAnimated = cuboidDims.z() == 1;
             isOpen = cuboidDims.y() == 1;
             return super.setSecondPos(loc);
         }
@@ -82,7 +82,7 @@ public class CreatorGarageDoor extends Creator
         if (isOpen)
             return getStructureType().getValidOpenDirections();
         // When the garage structure is not open (i.e. vertical), it can only be opened along one axis.
-        return northSouthAligned ? NORTH_SOUTH_AXIS_OPEN_DIRS : EAST_WEST_AXIS_OPEN_DIRS;
+        return northSouthAnimated ? NORTH_SOUTH_AXIS_OPEN_DIRS : EAST_WEST_AXIS_OPEN_DIRS;
     }
 
     @Override
@@ -96,11 +96,8 @@ public class CreatorGarageDoor extends Creator
     {
         if (super.completeSetOpenDirStep(direction))
         {
-            // This may seem counter-intuitive, but if it's positioned along the north/south axis,
-            // then it can only open in east/west direction, because there isn't any space in the other
-            // directions.
             if (openDir == MovementDirection.NORTH || openDir == MovementDirection.SOUTH)
-                northSouthAligned = false;
+                northSouthAnimated = true;
             return true;
         }
         return false;
@@ -124,7 +121,7 @@ public class CreatorGarageDoor extends Creator
         // The rotation point should be located at the bottom of the garage structure.
         // An additional 1 is subtracted because garage structures in the 'up' position
         // are 1 block above the highest point.
-        final int moveDistance = northSouthAligned ? cuboid.getDimensions().x() : cuboid.getDimensions().z();
+        final int moveDistance = northSouthAnimated ? cuboid.getDimensions().z() : cuboid.getDimensions().x();
         final int rotationPointY = cuboid.getMin().y() - moveDistance - 1;
         final Vector3Di rotationPointTmp = cuboid.getCenterBlock();
 
@@ -147,7 +144,7 @@ public class CreatorGarageDoor extends Creator
     protected AbstractStructure constructStructure()
     {
         setRotationPoint();
-        return new GarageDoor(constructStructureData(), northSouthAligned);
+        return new GarageDoor(constructStructureData(), northSouthAnimated);
     }
 
     @Override

--- a/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/GarageDoor.java
+++ b/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/GarageDoor.java
@@ -37,11 +37,11 @@ public class GarageDoor extends AbstractStructure implements IHorizontalAxisAlig
     private final ReentrantReadWriteLock lock;
 
     @Getter
-    @PersistentVariable("northSouthAnimated")
+    @PersistentVariable(value = "northSouthAnimated")
     protected final boolean northSouthAnimated;
 
     @Deserialization
-    public GarageDoor(BaseHolder base, @PersistentVariable("northSouthAnimated") boolean northSouthAnimated)
+    public GarageDoor(BaseHolder base, @PersistentVariable(value = "northSouthAnimated") boolean northSouthAnimated)
     {
         super(base, StructureTypeGarageDoor.get());
         this.lock = getLock();

--- a/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/GarageDoor.java
+++ b/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/GarageDoor.java
@@ -36,28 +36,16 @@ public class GarageDoor extends AbstractStructure implements IHorizontalAxisAlig
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
-    /**
-     * Describes if the {@link GarageDoor} is situated along the North/South axis <b>(= TRUE)</b> or along the East/West
-     * axis
-     * <b>(= FALSE)</b>.
-     * <p>
-     * To be situated along a specific axis means that the blocks move along that axis. For example, if the structure
-     * moves along the North/South <i>(= Z)</i> axis, all animated blocks will have a different Z-coordinate depending
-     * on the time of day and an X-coordinate depending on the X-coordinate they originally started at.
-     *
-     * @return True if this structure is animated along the North/South axis.
-     */
     @Getter
-    @PersistentVariable("northSouthAligned")
-    protected final boolean northSouthAligned;
+    @PersistentVariable("northSouthAnimated")
+    protected final boolean northSouthAnimated;
 
     @Deserialization
-    public GarageDoor(
-        BaseHolder base, @PersistentVariable("northSouthAligned") boolean northSouthAligned)
+    public GarageDoor(BaseHolder base, @PersistentVariable("northSouthAnimated") boolean northSouthAnimated)
     {
         super(base, StructureTypeGarageDoor.get());
         this.lock = getLock();
-        this.northSouthAligned = northSouthAligned;
+        this.northSouthAnimated = northSouthAnimated;
     }
 
     @Override
@@ -69,7 +57,7 @@ public class GarageDoor extends AbstractStructure implements IHorizontalAxisAlig
 
         final double movement;
         if (isOpen())
-            movement = isNorthSouthAligned() ? dims.z() : dims.x();
+            movement = isNorthSouthAnimated() ? dims.z() : dims.x();
         else
             movement = dims.y();
         // Not exactly correct, but much faster and pretty close.
@@ -112,7 +100,7 @@ public class GarageDoor extends AbstractStructure implements IHorizontalAxisAlig
     @Override
     public MovementDirection cycleOpenDirection()
     {
-        if (isNorthSouthAligned())
+        if (isNorthSouthAnimated())
             return getOpenDir().equals(MovementDirection.EAST) ? MovementDirection.WEST : MovementDirection.EAST;
         return getOpenDir().equals(MovementDirection.NORTH) ? MovementDirection.SOUTH : MovementDirection.NORTH;
     }

--- a/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/GarageDoor.java
+++ b/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/GarageDoor.java
@@ -8,8 +8,8 @@ import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
 import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
@@ -182,7 +182,7 @@ public class GarageDoor extends AbstractStructure implements IHorizontalAxisAlig
 
     @Override
     @Locked.Read
-    protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
+    protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return new GarageDoorAnimationComponent(data, getCurrentToggleDir());
     }

--- a/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/GarageDoorAnimationComponent.java
+++ b/structures/structure-garagedoor/src/main/java/nl/pim16aap2/bigdoors/structures/garagedoor/GarageDoorAnimationComponent.java
@@ -1,11 +1,11 @@
 package nl.pim16aap2.bigdoors.structures.garagedoor;
 
 import nl.pim16aap2.bigdoors.core.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationUtil;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimator;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.StructureSnapshot;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
@@ -32,7 +32,7 @@ public final class GarageDoorAnimationComponent implements IAnimationComponent
     private final boolean isOpen;
     private final Cuboid oldCuboid;
 
-    public GarageDoorAnimationComponent(StructureRequestData data, MovementDirection movementDirection)
+    public GarageDoorAnimationComponent(AnimationRequestData data, MovementDirection movementDirection)
     {
         this.snapshot = data.getStructureSnapshot();
         this.oldCuboid = snapshot.getCuboid();

--- a/structures/structure-portcullis/src/main/java/nl/pim16aap2/bigdoors/structures/portcullis/CreatorPortcullis.java
+++ b/structures/structure-portcullis/src/main/java/nl/pim16aap2/bigdoors/structures/portcullis/CreatorPortcullis.java
@@ -26,11 +26,6 @@ public class CreatorPortcullis extends Creator
         super(context, player, name);
     }
 
-    public CreatorPortcullis(Creator.Context context, IPlayer player)
-    {
-        this(context, player, null);
-    }
-
     @Override
     protected List<Step> generateSteps()
         throws InstantiationException

--- a/structures/structure-portcullis/src/main/java/nl/pim16aap2/bigdoors/structures/portcullis/Portcullis.java
+++ b/structures/structure-portcullis/src/main/java/nl/pim16aap2/bigdoors/structures/portcullis/Portcullis.java
@@ -6,8 +6,8 @@ import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
 import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.StructureType;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IDiscreteMovement;
@@ -109,7 +109,7 @@ public class Portcullis extends AbstractStructure implements IDiscreteMovement
 
     @Override
     @Locked.Read
-    protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
+    protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return new VerticalAnimationComponent(data, getDirectedBlocksToMove());
     }

--- a/structures/structure-portcullis/src/main/java/nl/pim16aap2/bigdoors/structures/portcullis/Portcullis.java
+++ b/structures/structure-portcullis/src/main/java/nl/pim16aap2/bigdoors/structures/portcullis/Portcullis.java
@@ -33,7 +33,7 @@ public class Portcullis extends AbstractStructure implements IDiscreteMovement
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
-    @PersistentVariable("blocksToMove")
+    @PersistentVariable(value = "blocksToMove")
     @GuardedBy("lock")
     @Getter(onMethod_ = @Locked.Read)
     protected int blocksToMove;
@@ -41,7 +41,7 @@ public class Portcullis extends AbstractStructure implements IDiscreteMovement
     protected Portcullis(
         BaseHolder base,
         StructureType type,
-        @PersistentVariable("blocksToMove") int blocksToMove)
+        @PersistentVariable(value = "blocksToMove") int blocksToMove)
     {
         super(base, type);
         this.lock = getLock();
@@ -49,7 +49,7 @@ public class Portcullis extends AbstractStructure implements IDiscreteMovement
     }
 
     @Deserialization
-    public Portcullis(BaseHolder base, @PersistentVariable("blocksToMove") int blocksToMove)
+    public Portcullis(BaseHolder base, @PersistentVariable(value = "blocksToMove") int blocksToMove)
     {
         this(base, StructureTypePortcullis.get(), blocksToMove);
     }

--- a/structures/structure-portcullis/src/main/java/nl/pim16aap2/bigdoors/structures/portcullis/VerticalAnimationComponent.java
+++ b/structures/structure-portcullis/src/main/java/nl/pim16aap2/bigdoors/structures/portcullis/VerticalAnimationComponent.java
@@ -1,11 +1,11 @@
 package nl.pim16aap2.bigdoors.structures.portcullis;
 
 import nl.pim16aap2.bigdoors.core.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationUtil;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimator;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.core.util.vector.Vector3Dd;
 
@@ -19,7 +19,7 @@ public final class VerticalAnimationComponent implements IAnimationComponent
     private final int blocksToMove;
     private final double step;
 
-    public VerticalAnimationComponent(StructureRequestData data, int blocksToMove)
+    public VerticalAnimationComponent(AnimationRequestData data, int blocksToMove)
     {
         this.blocksToMove = blocksToMove;
 

--- a/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/CreatorRevolvingDoor.java
+++ b/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/CreatorRevolvingDoor.java
@@ -20,11 +20,6 @@ public class CreatorRevolvingDoor extends CreatorBigDoor
         super(context, player, name);
     }
 
-    public CreatorRevolvingDoor(Creator.Context context, IPlayer player)
-    {
-        this(context, player, null);
-    }
-
     @Override
     protected List<Step> generateSteps()
         throws InstantiationException

--- a/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/CreatorRevolvingDoor.java
+++ b/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/CreatorRevolvingDoor.java
@@ -17,10 +17,7 @@ public class CreatorRevolvingDoor extends CreatorBigDoor
 
     public CreatorRevolvingDoor(Creator.Context context, IPlayer player, @Nullable String name)
     {
-        super(context, player);
-        if (name != null)
-            completeNamingStep(name);
-        prepareCurrentStep();
+        super(context, player, name);
     }
 
     public CreatorRevolvingDoor(Creator.Context context, IPlayer player)

--- a/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/RevolvingDoor.java
+++ b/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/RevolvingDoor.java
@@ -5,8 +5,8 @@ import lombok.ToString;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IPerpetualMover;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
@@ -67,7 +67,7 @@ public class RevolvingDoor extends AbstractStructure implements IPerpetualMover
 
     @Override
     @Locked.Read
-    protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
+    protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return new RevolvingDoorAnimationComponent(data, getCurrentToggleDir());
     }

--- a/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/RevolvingDoorAnimationComponent.java
+++ b/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/RevolvingDoorAnimationComponent.java
@@ -1,7 +1,7 @@
 package nl.pim16aap2.bigdoors.structures.revolvingdoor;
 
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
 import nl.pim16aap2.bigdoors.core.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.core.util.vector.Vector3Dd;
@@ -14,7 +14,7 @@ import nl.pim16aap2.bigdoors.structures.bigdoor.BigDoorAnimationComponent;
  */
 public class RevolvingDoorAnimationComponent extends BigDoorAnimationComponent
 {
-    public RevolvingDoorAnimationComponent(StructureRequestData data, MovementDirection movementDirection)
+    public RevolvingDoorAnimationComponent(AnimationRequestData data, MovementDirection movementDirection)
     {
         super(data, movementDirection, 4);
     }

--- a/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/RevolvingDoorAnimationComponent.java
+++ b/structures/structure-revolvingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/revolvingdoor/RevolvingDoorAnimationComponent.java
@@ -1,113 +1,27 @@
 package nl.pim16aap2.bigdoors.structures.revolvingdoor;
 
-import nl.pim16aap2.bigdoors.core.api.animatedblock.IAnimatedBlock;
-import nl.pim16aap2.bigdoors.core.moveblocks.AnimationUtil;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
-import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
-import nl.pim16aap2.bigdoors.core.structures.StructureSnapshot;
-import nl.pim16aap2.bigdoors.core.util.MathUtil;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
 import nl.pim16aap2.bigdoors.core.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.core.util.vector.Vector3Dd;
-
-import java.util.function.BiFunction;
+import nl.pim16aap2.bigdoors.structures.bigdoor.BigDoorAnimationComponent;
 
 /**
  * Represents a {@link Animator} for {@link RevolvingDoor}s.
  *
  * @author Pim
  */
-public class RevolvingDoorAnimationComponent implements IAnimationComponent
+public class RevolvingDoorAnimationComponent extends BigDoorAnimationComponent
 {
-    private final BiFunction<IAnimatedBlock, Double, Vector3Dd> getGoalPos;
-    private final StructureSnapshot snapshot;
-    private final double step;
-    private final double endStepSum;
-    private final MovementDirection openDirection;
-
-    public RevolvingDoorAnimationComponent(
-        StructureRequestData data, MovementDirection movementDirection, int quarterCircles)
+    public RevolvingDoorAnimationComponent(StructureRequestData data, MovementDirection movementDirection)
     {
-        this.snapshot = data.getStructureSnapshot();
-        this.openDirection = movementDirection;
-
-        switch (movementDirection)
-        {
-            case CLOCKWISE -> getGoalPos = this::getGoalPosClockwise;
-            case COUNTERCLOCKWISE -> getGoalPos = this::getGoalPosCounterClockwise;
-            default -> throw new IllegalStateException(
-                String.format("Failed to open structure '%d'. Reason: Invalid movement direction '%s'",
-                              snapshot.getUid(), movementDirection.name()));
-        }
-
-        final double animationDuration =
-            AnimationUtil.getAnimationTicks(data.getAnimationTime(), data.getServerTickTime());
-        step = (MathUtil.HALF_PI * quarterCircles) / animationDuration * -1.0;
-        endStepSum = animationDuration * step;
-    }
-
-    private Vector3Dd getGoalPosClockwise(double radius, double startAngle, double startY, double stepSum)
-    {
-        final double posX = 0.5 + snapshot.getRotationPoint().xD() - radius * Math.sin(startAngle + stepSum);
-        final double posZ = 0.5 + snapshot.getRotationPoint().zD() - radius * Math.cos(startAngle + stepSum);
-        return new Vector3Dd(posX, startY, posZ);
-    }
-
-    private Vector3Dd getGoalPosClockwise(IAnimatedBlock animatedBlock, double stepSum)
-    {
-        return getGoalPosClockwise(animatedBlock.getRadius(), animatedBlock.getStartAngle(),
-                                   animatedBlock.getStartY(),
-                                   stepSum);
-    }
-
-    private Vector3Dd getGoalPosCounterClockwise(double radius, double startAngle, double startY, double stepSum)
-    {
-        final double posX = 0.5 + snapshot.getRotationPoint().xD() - radius * Math.sin(startAngle - stepSum);
-        final double posZ = 0.5 + snapshot.getRotationPoint().zD() - radius * Math.cos(startAngle - stepSum);
-        return new Vector3Dd(posX, startY, posZ);
-    }
-
-    private Vector3Dd getGoalPosCounterClockwise(IAnimatedBlock animatedBlock, double stepSum)
-    {
-        return getGoalPosCounterClockwise(animatedBlock.getRadius(), animatedBlock.getStartAngle(),
-                                          animatedBlock.getStartY(), stepSum);
+        super(data, movementDirection, 4);
     }
 
     @Override
     public Vector3Dd getFinalPosition(IVector3D startLocation, float radius)
     {
-        final double startAngle = getStartAngle(MathUtil.floor(startLocation.xD()),
-                                                MathUtil.floor(startLocation.yD()),
-                                                MathUtil.floor(startLocation.zD()));
-
-        if (openDirection == MovementDirection.CLOCKWISE)
-            return getGoalPosClockwise(radius, startAngle, startLocation.yD(), endStepSum);
-        return getGoalPosCounterClockwise(radius, startAngle, startLocation.yD(), endStepSum);
-    }
-
-    @Override
-    public void executeAnimationStep(IAnimator animator, int ticks, int ticksRemaining)
-    {
-        final double stepSum = step * ticks;
-
-        for (final IAnimatedBlock animatedBlock : animator.getAnimatedBlocks())
-            animator.applyMovement(animatedBlock, getGoalPos.apply(animatedBlock, stepSum), ticksRemaining);
-    }
-
-    @Override
-    public float getRadius(int xAxis, int yAxis, int zAxis)
-    {
-        final double deltaA = snapshot.getRotationPoint().xD() - xAxis;
-        final double deltaB = snapshot.getRotationPoint().zD() - zAxis;
-        return (float) Math.sqrt(Math.pow(deltaA, 2) + Math.pow(deltaB, 2));
-    }
-
-    @Override
-    public float getStartAngle(int xAxis, int yAxis, int zAxis)
-    {
-        return (float) Math.atan2(snapshot.getRotationPoint().xD() - xAxis,
-                                  snapshot.getRotationPoint().zD() - zAxis);
+        return Vector3Dd.of(startLocation);
     }
 }

--- a/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/slidingdoor/CreatorSlidingDoor.java
+++ b/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/slidingdoor/CreatorSlidingDoor.java
@@ -26,11 +26,6 @@ public class CreatorSlidingDoor extends Creator
         super(context, player, name);
     }
 
-    public CreatorSlidingDoor(Creator.Context context, IPlayer player)
-    {
-        this(context, player, null);
-    }
-
     @Override
     protected List<Step> generateSteps()
         throws InstantiationException

--- a/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/slidingdoor/SlidingDoor.java
+++ b/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/slidingdoor/SlidingDoor.java
@@ -34,13 +34,13 @@ public class SlidingDoor extends AbstractStructure implements IDiscreteMovement
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
-    @PersistentVariable("blocksToMove")
+    @PersistentVariable(value = "blocksToMove")
     @GuardedBy("lock")
     @Getter(onMethod_ = @Locked.Read)
     protected int blocksToMove;
 
     @Deserialization
-    public SlidingDoor(BaseHolder base, @PersistentVariable("blocksToMove") int blocksToMove)
+    public SlidingDoor(BaseHolder base, @PersistentVariable(value = "blocksToMove") int blocksToMove)
     {
         super(base, StructureTypeSlidingDoor.get());
         this.lock = getLock();

--- a/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/slidingdoor/SlidingDoor.java
+++ b/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/slidingdoor/SlidingDoor.java
@@ -6,8 +6,8 @@ import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
 import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IDiscreteMovement;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
@@ -105,7 +105,7 @@ public class SlidingDoor extends AbstractStructure implements IDiscreteMovement
 
     @Override
     @Locked.Read
-    protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
+    protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return new SlidingDoorAnimationComponent(data, getCurrentToggleDir(), getBlocksToMove());
     }

--- a/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/slidingdoor/SlidingDoorAnimationComponent.java
+++ b/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/bigdoors/structures/slidingdoor/SlidingDoorAnimationComponent.java
@@ -1,11 +1,11 @@
 package nl.pim16aap2.bigdoors.structures.slidingdoor;
 
 import nl.pim16aap2.bigdoors.core.api.animatedblock.IAnimatedBlock;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.AnimationUtil;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimator;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
 import nl.pim16aap2.bigdoors.core.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.core.util.vector.Vector3Dd;
@@ -29,7 +29,7 @@ public class SlidingDoorAnimationComponent implements IAnimationComponent
     protected final int blocksToMove;
 
     public SlidingDoorAnimationComponent(
-        StructureRequestData data, MovementDirection movementDirection, int blocksToMove)
+        AnimationRequestData data, MovementDirection movementDirection, int blocksToMove)
     {
         this.blocksToMove = blocksToMove;
 

--- a/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/CreatorWindMill.java
+++ b/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/CreatorWindMill.java
@@ -19,11 +19,6 @@ public class CreatorWindMill extends Creator
         super(context, player, name);
     }
 
-    public CreatorWindMill(Creator.Context context, IPlayer player)
-    {
-        this(context, player, null);
-    }
-
     @Override
     protected List<Step> generateSteps()
         throws InstantiationException

--- a/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/Windmill.java
+++ b/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/Windmill.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IPerpetualMover;
@@ -88,7 +88,7 @@ public class Windmill extends AbstractStructure implements IHorizontalAxisAligne
 
     @Override
     @Locked.Read
-    protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
+    protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return new WindmillAnimationComponent(data, getCurrentToggleDir(), isNorthSouthAnimated());
     }

--- a/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/Windmill.java
+++ b/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/Windmill.java
@@ -56,24 +56,24 @@ public class Windmill extends AbstractStructure implements IHorizontalAxisAligne
     }
 
     @Override
-    public boolean isNorthSouthAligned()
+    public boolean isNorthSouthAnimated()
     {
         final MovementDirection openDir = getOpenDir();
-        return openDir == MovementDirection.EAST || openDir == MovementDirection.WEST;
+        return openDir == MovementDirection.NORTH || openDir == MovementDirection.SOUTH;
     }
 
     @Override
     @Locked.Read
     protected double calculateAnimationCycleDistance()
     {
-        return Drawbridge.getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint()) * Math.TAU;
+        return Drawbridge.getMaxRadius(isNorthSouthAnimated(), getCuboid(), getRotationPoint()) * Math.TAU;
     }
 
     @Override
     @Locked.Read
     protected Rectangle calculateAnimationRange()
     {
-        final double maxRadius = Drawbridge.getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint());
+        final double maxRadius = Drawbridge.getMaxRadius(isNorthSouthAnimated(), getCuboid(), getRotationPoint());
         return Drawbridge.calculateAnimationRange(maxRadius, getCuboid());
     }
 
@@ -90,6 +90,6 @@ public class Windmill extends AbstractStructure implements IHorizontalAxisAligne
     @Locked.Read
     protected IAnimationComponent constructAnimationComponent(StructureRequestData data)
     {
-        return new WindmillAnimationComponent(data, getCurrentToggleDir(), isNorthSouthAligned());
+        return new WindmillAnimationComponent(data, getCurrentToggleDir(), isNorthSouthAnimated());
     }
 }

--- a/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/Windmill.java
+++ b/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/Windmill.java
@@ -1,24 +1,19 @@
 package nl.pim16aap2.bigdoors.structures.windmill;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Locked;
 import nl.pim16aap2.bigdoors.core.annotations.Deserialization;
-import nl.pim16aap2.bigdoors.core.annotations.PersistentVariable;
 import nl.pim16aap2.bigdoors.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.structures.AbstractStructure;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IHorizontalAxisAligned;
 import nl.pim16aap2.bigdoors.core.structures.structurearchetypes.IPerpetualMover;
 import nl.pim16aap2.bigdoors.core.util.Cuboid;
-import nl.pim16aap2.bigdoors.core.util.MathUtil;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
 import nl.pim16aap2.bigdoors.core.util.Rectangle;
 import nl.pim16aap2.bigdoors.structures.drawbridge.Drawbridge;
 
-import javax.annotation.concurrent.GuardedBy;
 import java.util.Optional;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -35,28 +30,11 @@ public class Windmill extends AbstractStructure implements IHorizontalAxisAligne
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
-    /**
-     * The number of quarter circles (so 90 degree rotations) this structure will make before stopping.
-     *
-     * @return The number of quarter circles this structure will rotate.
-     */
-    @PersistentVariable("quarterCircles")
-    @GuardedBy("lock")
-    @Getter(onMethod_ = @Locked.Read)
-    @Setter(onMethod_ = @Locked.Write)
-    private int quarterCircles;
-
     @Deserialization
-    public Windmill(BaseHolder base, @PersistentVariable("quarterCircles") int quarterCircles)
+    public Windmill(BaseHolder base)
     {
         super(base, StructureTypeWindmill.get());
         this.lock = getLock();
-        this.quarterCircles = quarterCircles;
-    }
-
-    public Windmill(BaseHolder doorBase)
-    {
-        this(doorBase, 1);
     }
 
     @Override
@@ -88,8 +66,7 @@ public class Windmill extends AbstractStructure implements IHorizontalAxisAligne
     @Locked.Read
     protected double calculateAnimationCycleDistance()
     {
-        final double maxRadius = Drawbridge.getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint());
-        return maxRadius * MathUtil.HALF_PI;
+        return Drawbridge.getMaxRadius(isNorthSouthAligned(), getCuboid(), getRotationPoint()) * Math.TAU;
     }
 
     @Override

--- a/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/WindmillAnimationComponent.java
+++ b/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/WindmillAnimationComponent.java
@@ -1,7 +1,7 @@
 package nl.pim16aap2.bigdoors.structures.windmill;
 
+import nl.pim16aap2.bigdoors.core.moveblocks.AnimationRequestData;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
-import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
 import nl.pim16aap2.bigdoors.core.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.core.util.vector.Vector3Dd;
@@ -15,7 +15,7 @@ import nl.pim16aap2.bigdoors.structures.drawbridge.DrawbridgeAnimationComponent;
 public class WindmillAnimationComponent extends DrawbridgeAnimationComponent
 {
     public WindmillAnimationComponent(
-        StructureRequestData data, MovementDirection movementDirection, boolean isNorthSouthAligned)
+        AnimationRequestData data, MovementDirection movementDirection, boolean isNorthSouthAligned)
     {
         super(data, movementDirection, isNorthSouthAligned, 4);
     }

--- a/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/WindmillAnimationComponent.java
+++ b/structures/structure-windmill/src/main/java/nl/pim16aap2/bigdoors/structures/windmill/WindmillAnimationComponent.java
@@ -1,11 +1,8 @@
 package nl.pim16aap2.bigdoors.structures.windmill;
 
-import nl.pim16aap2.bigdoors.core.api.animatedblock.IAnimatedBlock;
 import nl.pim16aap2.bigdoors.core.moveblocks.Animator;
-import nl.pim16aap2.bigdoors.core.moveblocks.IAnimator;
 import nl.pim16aap2.bigdoors.core.moveblocks.StructureRequestData;
 import nl.pim16aap2.bigdoors.core.util.MovementDirection;
-import nl.pim16aap2.bigdoors.core.util.Util;
 import nl.pim16aap2.bigdoors.core.util.vector.IVector3D;
 import nl.pim16aap2.bigdoors.core.util.vector.Vector3Dd;
 import nl.pim16aap2.bigdoors.structures.drawbridge.DrawbridgeAnimationComponent;
@@ -20,45 +17,12 @@ public class WindmillAnimationComponent extends DrawbridgeAnimationComponent
     public WindmillAnimationComponent(
         StructureRequestData data, MovementDirection movementDirection, boolean isNorthSouthAligned)
     {
-        super(data, movementDirection, isNorthSouthAligned);
+        super(data, movementDirection, isNorthSouthAligned, 4);
     }
 
     @Override
     public Vector3Dd getFinalPosition(IVector3D startLocation, float radius)
     {
         return Vector3Dd.of(startLocation);
-    }
-
-    @Override
-    public void executeAnimationStep(IAnimator animator, int ticks, int ticksRemaining)
-    {
-        final double stepSum = step * ticks;
-        for (final IAnimatedBlock animatedBlock : animator.getAnimatedBlocks())
-            animator.applyMovement(animatedBlock, getGoalPos(stepSum, animatedBlock), ticksRemaining);
-    }
-
-    @Override
-    public float getRadius(int xAxis, int yAxis, int zAxis)
-    {
-        // Get the current radius of a block between used axis (either x and y, or z and y).
-        // When the rotation point is positioned along the NS axis, the X values does not change for this type.
-        final double deltaA = snapshot.getRotationPoint().yD() - yAxis;
-        final double deltaB =
-            northSouth ? (snapshot.getRotationPoint().z() - zAxis) :
-            (snapshot.getRotationPoint().x() - xAxis);
-        return (float) Math.sqrt(Math.pow(deltaA, 2) + Math.pow(deltaB, 2));
-    }
-
-    @Override
-    public float getStartAngle(int xAxis, int yAxis, int zAxis)
-    {
-        // Get the angle between the used axes (either x and y, or z and y).
-        // When the rotation point is positioned along the NS axis, the X values does not change for this type.
-        final double deltaA =
-            northSouth ? snapshot.getRotationPoint().z() - zAxis :
-            snapshot.getRotationPoint().x() - xAxis;
-        final double deltaB = snapshot.getRotationPoint().yD() - yAxis;
-
-        return (float) Util.clampAngleRad(Math.atan2(deltaA, deltaB));
     }
 }


### PR DESCRIPTION
- Fixed command parameter suggestions for directions not matching correctly, resulting in the suggestions disappearing if you started typing them out.
- Moved the `quarterCircles` PersistentVariable out of the Windmill/RevolvingDoor classes into the Drawbridge/BigDoor classes. This means that any existing structures of the Drawbridge/BigDoor type will need to be recreated.
- The Windmill/RevovingDoor structures now rotate a full circle instead of 1/4 circle when toggled via commands. When toggled via redstone, they remain active until their powerblock loses power.
- Restarting the plugin or stopping active animations will now verify the redstone state of all structures whose animations with read/write access were aborted. This ensures that they remain in the correct state wrt the redstone system.
- Extensions are no longer reloaded when the plugin is restarted. New structures can be loaded, but existing ones cannot be unloaded/reloaded anymore. This caused some issues before and this is the easiest and safest way to avoid them.
- Fixed incorrect handling of offline players when retrieving size limits.
- General cleanup and documentation.