### PR TITLE
Update reflection finder for Enums

### DIFF
--- a/utilities/util/src/main/java/nl/pim16aap2/util/reflection/ReflectionBuilder.java
+++ b/utilities/util/src/main/java/nl/pim16aap2/util/reflection/ReflectionBuilder.java
@@ -118,22 +118,22 @@ public final class ReflectionBuilder
      * @return A new {@link EnumValuesFinder}.
      */
     @CheckReturnValue @Contract(pure = true)
-    public static EnumValuesFinder findEnumValues()
+    public static EnumValuesFinder.EnumFieldFinderFactory findEnumValues()
     {
-        return new EnumValuesFinder();
+        return EnumValuesFinder.EnumFieldFinderFactory.INSTANCE;
     }
 
     /**
-     * Creates a new {@link EnumValuesFinder.EnumValuesFinderInSource} and configures the enum they should exist in.
+     * Creates a new {@link EnumValuesFinder} and configures the enum class they should exist in.
      *
      * @param source
      *     The class in which the finder will look for the enum values.
-     * @return A new {@link EnumValuesFinder.EnumValuesFinderInSource}.
+     * @return A new {@link EnumValuesFinder}.
      */
     @CheckReturnValue @Contract(pure = true)
-    public static EnumValuesFinder.EnumValuesFinderInSource findEnumValues(Class<?> source)
+    public static EnumValuesFinder findEnumValues(Class<?> source)
     {
-        return new EnumValuesFinder().inClass(source);
+        return findEnumValues().inClass(source);
     }
 
     /**

--- a/utilities/util/src/test/java/nl/pim16aap2/util/reflection/EnumValuesFinderInSourceTest.java
+++ b/utilities/util/src/test/java/nl/pim16aap2/util/reflection/EnumValuesFinderInSourceTest.java
@@ -1,0 +1,62 @@
+package nl.pim16aap2.util.reflection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class EnumValuesFinderInSourceTest
+{
+    @Test
+    void testNamedRetrieval()
+    {
+        Assertions.assertEquals(TestEnum.FIELD_0,
+                                new EnumValuesFinder(TestEnum.class).withName("FIELD_0").getNullable());
+        Assertions.assertEquals(TestEnum.FIELD_1, new EnumValuesFinder(TestEnum.class).withName("FIELD_1").get());
+    }
+
+    @Test
+    void testIndexedRetrieval()
+    {
+        Assertions.assertEquals(TestEnum.FIELD_2,
+                                new EnumValuesFinder(TestEnum.class).atIndex(2).getNullable());
+        Assertions.assertEquals(TestEnum.FIELD_3, new EnumValuesFinder(TestEnum.class).atIndex(3).get());
+    }
+
+    @Test
+    void testArrayRetrieval()
+    {
+        Assertions.assertArrayEquals(TestEnum.values(), new EnumValuesFinder(TestEnum.class).get());
+        Assertions.assertArrayEquals(TestEnum.values(), new EnumValuesFinder(TestEnum.class).getNullable());
+    }
+
+    @Test
+    void testInvalidClass()
+    {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new EnumValuesFinder(this.getClass()));
+    }
+
+    @Test
+    void testInvalidName()
+    {
+        //noinspection ResultOfMethodCallIgnored
+        Assertions.assertThrows(NullPointerException.class,
+                                () -> new EnumValuesFinder(TestEnum.class).withName("FIELD_999").get());
+        Assertions.assertNull(new EnumValuesFinder(TestEnum.class).withName("FIELD_999").getNullable());
+    }
+
+    @Test
+    void testInvalidIndex()
+    {
+        //noinspection ResultOfMethodCallIgnored
+        Assertions.assertThrows(NullPointerException.class,
+                                () -> new EnumValuesFinder(TestEnum.class).atIndex(999).get());
+        Assertions.assertNull(new EnumValuesFinder(TestEnum.class).atIndex(999).getNullable());
+    }
+
+    private enum TestEnum
+    {
+        FIELD_0,
+        FIELD_1,
+        FIELD_2,
+        FIELD_3
+    }
+}


### PR DESCRIPTION
- We now use the Enum#valueOf(Class, String) method to retrieve a named enum field rather than getting an array of all field and looping through them to find it.
- Added some tests for the EnumValuesFinder class(es).
- Flattened the construction of EnumValuesFinder a bit. It gets rid of an unnecessary object construction.