### PR TITLE
Fix enum deserialization

### DIFF
--- a/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/structures/StructureSerializerTest.java
+++ b/bigdoors-testing/bigdoors-integration-test/src/test/java/nl/pim16aap2/bigdoors/core/structures/StructureSerializerTest.java
@@ -95,14 +95,31 @@ class StructureSerializerTest
     {
         final var instantiator = Assertions.assertDoesNotThrow(
             () -> new StructureSerializer<>(TestStructureSubType.class, 1));
-        final TestStructureSubType testStructureSubType1 =
+        final TestStructureSubType realObj =
             new TestStructureSubType(structureBase, "testSubClass", 6, true, 42);
 
-        final String serialized = Assertions.assertDoesNotThrow(() -> instantiator.serialize(testStructureSubType1));
-        final var testStructureSubType2 = Assertions.assertDoesNotThrow(
+        final String serialized = Assertions.assertDoesNotThrow(() -> instantiator.serialize(realObj));
+        final var deserialized = Assertions.assertDoesNotThrow(
             () -> instantiator.deserialize(structureBase, 1, serialized));
 
-        Assertions.assertEquals(testStructureSubType1, testStructureSubType2);
+        Assertions.assertEquals(realObj, deserialized);
+    }
+
+    @Test
+    void testEnumSerialization()
+    {
+        final var instantiator = Assertions.assertDoesNotThrow(
+            () -> new StructureSerializer<>(TestStructureSubTypeEnum.class, 2));
+
+        final TestStructureSubTypeEnum realObj =
+            new TestStructureSubTypeEnum(structureBase, TestStructureSubTypeEnum.ArbitraryEnum.ENTRY_0,
+                                         TestStructureSubTypeEnum.ArbitraryEnum.ENTRY_2);
+
+        final String serialized = Assertions.assertDoesNotThrow(() -> instantiator.serialize(realObj));
+        final var deserialized = Assertions.assertDoesNotThrow(
+            () -> instantiator.deserialize(structureBase, 1, serialized));
+
+        Assertions.assertEquals(realObj, deserialized);
     }
 
     @Test
@@ -120,14 +137,14 @@ class StructureSerializerTest
     {
         final var instantiator = Assertions.assertDoesNotThrow(
             () -> new StructureSerializer<>(TestStructureType.class, 1));
-        final TestStructureType testStructureType0 = new TestStructureType(structureBase, null, true, 42);
+        final TestStructureType realObj = new TestStructureType(structureBase, null, true, 42);
 
-        final TestStructureType testStructureType1 =
+        final TestStructureType deserialized =
             instantiator.instantiate(structureBase, 1,
                                      Map.of("isCoolType", true,
                                             "blockTestCount", 42));
 
-        Assertions.assertEquals(testStructureType0, testStructureType1);
+        Assertions.assertEquals(realObj, deserialized);
     }
 
     @Test
@@ -429,6 +446,34 @@ class StructureSerializerTest
         public TestStructureSubTypeAmbiguousConstructorVersions(BaseHolder base, Object o)
         {
             super(base);
+        }
+    }
+
+
+    @EqualsAndHashCode(callSuper = true)
+    private static class TestStructureSubTypeEnum extends TestStructureType
+    {
+        @PersistentVariable("val0")
+        private final ArbitraryEnum val0;
+        @PersistentVariable("val1")
+        private final ArbitraryEnum val1;
+
+        @Deserialization(version = 1)
+        public TestStructureSubTypeEnum(
+            BaseHolder base,
+            @PersistentVariable("val0") ArbitraryEnum val0,
+            @PersistentVariable("val1") ArbitraryEnum val1)
+        {
+            super(base);
+            this.val0 = val0;
+            this.val1 = val1;
+        }
+
+        public enum ArbitraryEnum
+        {
+            ENTRY_0,
+            ENTRY_1,
+            ENTRY_2
         }
     }
 }

--- a/utilities/util/src/main/java/nl/pim16aap2/util/reflection/ReflectionBuilder.java
+++ b/utilities/util/src/main/java/nl/pim16aap2/util/reflection/ReflectionBuilder.java
@@ -118,22 +118,22 @@ public final class ReflectionBuilder
      * @return A new {@link EnumValuesFinder}.
      */
     @CheckReturnValue @Contract(pure = true)
-    public static EnumValuesFinder findEnumValues()
+    public static EnumValuesFinder.EnumFieldFinderFactory findEnumValues()
     {
-        return new EnumValuesFinder();
+        return EnumValuesFinder.EnumFieldFinderFactory.INSTANCE;
     }
 
     /**
-     * Creates a new {@link EnumValuesFinder.EnumValuesFinderInSource} and configures the enum they should exist in.
+     * Creates a new {@link EnumValuesFinder} and configures the enum class they should exist in.
      *
      * @param source
      *     The class in which the finder will look for the enum values.
-     * @return A new {@link EnumValuesFinder.EnumValuesFinderInSource}.
+     * @return A new {@link EnumValuesFinder}.
      */
     @CheckReturnValue @Contract(pure = true)
-    public static EnumValuesFinder.EnumValuesFinderInSource findEnumValues(Class<?> source)
+    public static EnumValuesFinder findEnumValues(Class<?> source)
     {
-        return new EnumValuesFinder().inClass(source);
+        return findEnumValues().inClass(source);
     }
 
     /**

--- a/utilities/util/src/test/java/nl/pim16aap2/util/reflection/EnumValuesFinderInSourceTest.java
+++ b/utilities/util/src/test/java/nl/pim16aap2/util/reflection/EnumValuesFinderInSourceTest.java
@@ -1,0 +1,62 @@
+package nl.pim16aap2.util.reflection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class EnumValuesFinderInSourceTest
+{
+    @Test
+    void testNamedRetrieval()
+    {
+        Assertions.assertEquals(TestEnum.FIELD_0,
+                                new EnumValuesFinder(TestEnum.class).withName("FIELD_0").getNullable());
+        Assertions.assertEquals(TestEnum.FIELD_1, new EnumValuesFinder(TestEnum.class).withName("FIELD_1").get());
+    }
+
+    @Test
+    void testIndexedRetrieval()
+    {
+        Assertions.assertEquals(TestEnum.FIELD_2,
+                                new EnumValuesFinder(TestEnum.class).atIndex(2).getNullable());
+        Assertions.assertEquals(TestEnum.FIELD_3, new EnumValuesFinder(TestEnum.class).atIndex(3).get());
+    }
+
+    @Test
+    void testArrayRetrieval()
+    {
+        Assertions.assertArrayEquals(TestEnum.values(), new EnumValuesFinder(TestEnum.class).get());
+        Assertions.assertArrayEquals(TestEnum.values(), new EnumValuesFinder(TestEnum.class).getNullable());
+    }
+
+    @Test
+    void testInvalidClass()
+    {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new EnumValuesFinder(this.getClass()));
+    }
+
+    @Test
+    void testInvalidName()
+    {
+        //noinspection ResultOfMethodCallIgnored
+        Assertions.assertThrows(NullPointerException.class,
+                                () -> new EnumValuesFinder(TestEnum.class).withName("FIELD_999").get());
+        Assertions.assertNull(new EnumValuesFinder(TestEnum.class).withName("FIELD_999").getNullable());
+    }
+
+    @Test
+    void testInvalidIndex()
+    {
+        //noinspection ResultOfMethodCallIgnored
+        Assertions.assertThrows(NullPointerException.class,
+                                () -> new EnumValuesFinder(TestEnum.class).atIndex(999).get());
+        Assertions.assertNull(new EnumValuesFinder(TestEnum.class).atIndex(999).getNullable());
+    }
+
+    private enum TestEnum
+    {
+        FIELD_0,
+        FIELD_1,
+        FIELD_2,
+        FIELD_3
+    }
+}


### PR DESCRIPTION
All enum values were deserialized as Strings (from Enum#getName()). As such, structure types that used enum values in their deserialization constructors would cause errors. 
We now add a post-processing step when deserializing objects that allows us to retrieve the correct enum value using the constructor parameter type and the deserialized name of the enum constant. 