### PR TITLE
Resolve Localizer issues on Windows

### DIFF
--- a/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/localization/LocalizationManager.java
+++ b/bigdoors-core/src/main/java/nl/pim16aap2/bigdoors/core/localization/LocalizationManager.java
@@ -16,7 +16,6 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -102,8 +101,7 @@ public final class LocalizationManager extends Restartable implements ILocalizat
         try
         {
             final LocalizationPatcher localizationPatcher = new LocalizationPatcher(baseDir, baseName);
-            final Set<String> rootKeys = (patchGenerator == null ? baseGenerator : patchGenerator).getOutputRootKeys();
-            localizationPatcher.updatePatchKeys(rootKeys);
+            localizationPatcher.updatePatchKeys(baseGenerator.getRootKeys());
 
             final List<LocaleFile> patchFiles = localizationPatcher.getPatchFiles();
             final Map<LocaleFile, Map<String, String>> patches =


### PR DESCRIPTION
- Because Windows has issues with file management, the localizer initialization system was updated to use a more awkward method of keeping track of root keys that will result in higher memory usage.