### PR TITLE
Implement placeholder substitution in Text objects

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/text/MessageFormatProcessor.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/text/MessageFormatProcessor.java
@@ -1,0 +1,144 @@
+package nl.pim16aap2.animatedarchitecture.core.text;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import java.text.AttributedCharacterIterator;
+import java.text.CharacterIterator;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Tool that can be used to process Strings containing variables.
+ * <p>
+ * This class is backed by {@link MessageFormat} for all variable substitution.
+ * <p>
+ * What makes this class different from the MessageFormat class is that it keeps a list of {@link MessageFormatSection}s
+ * that can be used to determine the character ranges of the parts of the output message.
+ * <p>
+ * For example, given an input String "Hello there, {0}!" with an argument "John Smith", we end up with the following
+ * output:
+ * <ul>
+ *     <li>The formatted String: "Hello there, John Smith!"</li>
+ *     <li>The three sections:
+ *         <ol>
+ *             <li>Start:  0, End: 13, ArgumentIdx: -1. Selection: "Hello there, "</li>
+ *             <li>Start: 13, End: 23, ArgumentIdx:  0, Selection: "John Smith"</li>
+ *             <li>Start: 23, End: 24, ArgumentIdx: -1, Selection: "!"</li>
+ *         </ol>
+ *     </li>
+ * </ul>
+ */
+final class MessageFormatProcessor
+{
+    private static final Locale DEFAULT_LOCALE = Locale.ROOT;
+
+    private final StringBuilder sb;
+    private final List<MessageFormatSection> sections = new ArrayList<>();
+
+    public MessageFormatProcessor(String input, Locale locale, Object... arguments)
+    {
+        final var iter = new MessageFormat(input, locale).formatToCharacterIterator(arguments);
+        sb = new StringBuilder(iter.getEndIndex());
+        processMessageFormatIterator(iter);
+    }
+
+    public MessageFormatProcessor(String input, Object... arguments)
+    {
+        this(input, DEFAULT_LOCALE, arguments);
+    }
+
+    public MessageFormatProcessor(String input, TextArgument... arguments)
+    {
+        this(input, Arrays.stream(arguments).map(TextArgument::text).toArray());
+    }
+
+    /**
+     * Retrieves the formatted String created using {@link MessageFormat#format(String, Object...)}.
+     *
+     * @return The formatted String.
+     */
+    public String getFormattedString()
+    {
+        return this.sb.toString();
+    }
+
+    /**
+     * Retrieves the list of sections in the formatted String. The start and end index of each section refers to the
+     * positions of characters in the formatted String; not the input String!
+     *
+     * @return The list of sections in the formatted String.
+     */
+    public List<MessageFormatSection> getSections()
+    {
+        return Collections.unmodifiableList(this.sections);
+    }
+
+    private static int getFieldId(AttributedCharacterIterator iter)
+    {
+        for (final var attr : iter.getAttributes().entrySet())
+            if (attr.getKey() instanceof MessageFormat.Field)
+                return (Integer) attr.getValue();
+        return -1;
+    }
+
+    private void processMessageFormatIterator(AttributedCharacterIterator iter)
+    {
+        @Nullable Integer argumentIdx = null;
+
+        for (char c = iter.first(); c != CharacterIterator.DONE; c = iter.next())
+        {
+            sb.append(c);
+            final int currentArgumentIdx = getFieldId(iter);
+            if (argumentIdx == null || argumentIdx != currentArgumentIdx)
+            {
+                sections.add(new MessageFormatSection(iter.getRunStart(), iter.getRunLimit(), currentArgumentIdx));
+                argumentIdx = currentArgumentIdx;
+            }
+        }
+    }
+
+    /**
+     * Represents a section in a fully-formatted {@link MessageFormat}.
+     */
+    @Getter
+    @Accessors(fluent = true)
+    @ToString
+    @EqualsAndHashCode
+    public static final class MessageFormatSection
+    {
+        /**
+         * The start of the section in the fully formatted result String.
+         */
+        private final int start;
+
+        /**
+         * The end of the section in the fully formatted result String.
+         */
+        private final int end;
+
+        /**
+         * The index of the argument this section was created from in the input arguments.
+         * <p>
+         * This is -1 for all sections that were not created from an input argument.
+         */
+        private final int argumentIdx;
+
+        @VisibleForTesting MessageFormatSection(int start, int end, int argumentIdx)
+        {
+            if (end < start)
+                throw new IllegalArgumentException("Range end " + end + " cannot be lower than range start: " + start);
+            this.start = start;
+            this.end = end;
+            this.argumentIdx = argumentIdx;
+        }
+    }
+}

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/text/TextArgument.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/text/TextArgument.java
@@ -1,0 +1,23 @@
+package nl.pim16aap2.animatedarchitecture.core.text;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents an argument in a piece of text.
+ * <p>
+ * For example given a String "Hello there, {0}", the TextArgument can be used to provide the substitution for "{0}".
+ *
+ * @param text
+ *     The text of the argument.
+ * @param component
+ *     The optional text component to use for the text. This can be used to override the decorations of the surrounding
+ *     text for the argument.
+ */
+public record TextArgument(String text, @Nullable TextComponent component)
+{
+    @SuppressWarnings("unused")
+    public TextArgument(String text)
+    {
+        this(text, null);
+    }
+}

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/text/MessageFormatProcessorTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/text/MessageFormatProcessorTest.java
@@ -1,0 +1,48 @@
+package nl.pim16aap2.animatedarchitecture.core.text;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class MessageFormatProcessorTest
+{
+    @Test
+    void testFormatting()
+    {
+        Assertions.assertEquals("Test", new MessageFormatProcessor("Test").getFormattedString());
+        Assertions.assertEquals("Test", new MessageFormatProcessor("Test", "Ignored").getFormattedString());
+        Assertions.assertEquals("Test 3.14",
+                                new MessageFormatProcessor("Test {0,number,#.##}", Math.PI).getFormattedString());
+    }
+
+    @Test
+    void testSections()
+    {
+        final var proc = new MessageFormatProcessor("Hello there, {0}!", "John Smith");
+
+        Assertions.assertEquals(
+            List.of(new MessageFormatProcessor.MessageFormatSection(0, 13, -1),
+                    new MessageFormatProcessor.MessageFormatSection(13, 23, 0),
+                    new MessageFormatProcessor.MessageFormatSection(23, 24, -1)),
+            proc.getSections());
+
+        Assertions.assertEquals("Hello there, John Smith!", proc.getFormattedString());
+    }
+
+    @Test
+    void testMixedParameterOrdering()
+    {
+        final var proc = new MessageFormatProcessor("{2} {1} {0}", "C", "B", "A");
+
+        Assertions.assertEquals("A B C", proc.getFormattedString());
+
+        Assertions.assertEquals(
+            List.of(new MessageFormatProcessor.MessageFormatSection(0, 1, 2),
+                    new MessageFormatProcessor.MessageFormatSection(1, 2, -1),
+                    new MessageFormatProcessor.MessageFormatSection(2, 3, 1),
+                    new MessageFormatProcessor.MessageFormatSection(3, 4, -1),
+                    new MessageFormatProcessor.MessageFormatSection(4, 5, 0)),
+            proc.getSections());
+    }
+}

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/text/TextTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/text/TextTest.java
@@ -1,7 +1,6 @@
 package nl.pim16aap2.animatedarchitecture.core.text;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -145,6 +144,30 @@ class TextTest
     }
 
     @Test
+    void testArguments()
+    {
+        final Text text = new Text(textComponentFactory);
+        text.append("Click {1}, {2}, or {0} to do {3}!", TextType.INFO,
+                    new TextArgument("HERE0", text.getClickableTextComponent(TextType.INFO, "url0", null)),
+                    new TextArgument("HERE1", text.getClickableTextComponent(TextType.ERROR, "url1", null)),
+                    new TextArgument("HERE2", text.getClickableTextComponent(TextType.ERROR, "url2", "hi")),
+                    new TextArgument("something", text.getTextComponent(null)));
+
+        final String result =
+            "<info>Click </info>" +
+                "<a href=\"url1\"><err>HERE1</err></a>" +
+                "<info>, </info>" +
+                "<a href=\"url2\" title=\"hi\"><err>HERE2</err></a>" +
+                "<info>, or </info>" +
+                "<a href=\"url0\"><info>HERE0</info></a>" +
+                "<info> to do </info>" +
+                "something" +
+                "<info>!</info>";
+
+        Assertions.assertEquals(result, text.render(new Renderer()));
+    }
+
+    @Test
     void testHashCode()
     {
         final Text textA = new Text(textComponentFactory);
@@ -166,6 +189,7 @@ class TextTest
         Assertions.assertNotEquals(textE.hashCode(), textF.hashCode());
     }
 
+    @ToString
     private static final class TextComponentFactory implements ITextComponentFactory
     {
         private final ColorScheme<Style> colorScheme;
@@ -221,12 +245,8 @@ class TextTest
         }
     }
 
-    @AllArgsConstructor
-    @EqualsAndHashCode
-    private static final class StyleDecorator implements ITextTestDecorator
+    private record StyleDecorator(Style style) implements ITextTestDecorator
     {
-        private final Style style;
-
         @Override
         public String apply(String input)
         {
@@ -234,13 +254,8 @@ class TextTest
         }
     }
 
-    @AllArgsConstructor
-    @EqualsAndHashCode
-    private static final class CommandDecorator implements ITextTestDecorator
+    private record CommandDecorator(String command, @Nullable String info) implements ITextTestDecorator
     {
-        private final String command;
-        private final @Nullable String info;
-
         @Override
         public String apply(String input)
         {


### PR DESCRIPTION
-he Text system was updated to allow setting TextArguments in Texts. This allows inserting Styled Sections for the provided arguments. For example to add a clickable command as parameter: 
Input String: `"click {0} to do something"`. 
Appending to a Text: `text.append("click {0} to do something", TextType.INFO, text.getClickableTextComponent(TextType.HIGHLIGHT, "/myCommand", "Click me!"));`

  The system uses the MessageFormat under the hood, so it still has the same substitution capabilities as before.