### PR TITLE
Use variable substitution for Text

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/DelayedCommandInputRequest.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/DelayedCommandInputRequest.java
@@ -8,13 +8,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
+import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.managers.DelayedCommandInputManager;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
-import nl.pim16aap2.animatedarchitecture.core.util.delayedinput.DelayedInputRequest;
-import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.util.Util;
-import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
+import nl.pim16aap2.animatedarchitecture.core.util.delayedinput.DelayedInputRequest;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
@@ -173,14 +173,14 @@ public final class DelayedCommandInputRequest<T> extends DelayedInputRequest<T>
     {
         delayedCommandInputManager.deregister(commandSender, this);
         if (getStatus() == Status.TIMED_OUT)
-            commandSender.sendMessage(textFactory, TextType.ERROR,
-                                      localizer.getMessage("commands.base.error.timed_out",
-                                                           commandDefinition.getName().toLowerCase(Locale.ENGLISH)));
+            commandSender.sendMessage(textFactory.newText().append(
+                localizer.getMessage("commands.base.error.timed_out"), TextType.ERROR,
+                arg -> arg.highlight(commandDefinition.getName().toLowerCase(Locale.ROOT))));
 
         if (getStatus() == Status.CANCELLED)
-            commandSender.sendMessage(textFactory, TextType.ERROR,
-                                      localizer.getMessage("commands.base.error.cancelled",
-                                                           commandDefinition.getName().toLowerCase(Locale.ENGLISH)));
+            commandSender.sendMessage(textFactory.newText().append(
+                localizer.getMessage("commands.base.error.cancelled"), TextType.ERROR,
+                arg -> arg.highlight(commandDefinition.getName().toLowerCase(Locale.ROOT))));
     }
 
     /**

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Delete.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Delete.java
@@ -4,13 +4,14 @@ import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 import lombok.ToString;
-import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
-import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
-import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
-import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetrieverFactory;
-import nl.pim16aap2.animatedarchitecture.core.managers.DatabaseManager;
 import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
+import nl.pim16aap2.animatedarchitecture.core.managers.DatabaseManager;
+import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
+import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
+import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetrieverFactory;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -49,8 +50,10 @@ public class Delete extends StructureTargetCommand
     protected void handleDatabaseActionSuccess()
     {
         final var desc = getRetrievedStructureDescription();
-        getCommandSender().sendSuccess(textFactory,
-                                       localizer.getMessage("commands.delete.success", desc.typeName(), desc.id()));
+        getCommandSender().sendMessage(textFactory.newText().append(
+            localizer.getMessage("commands.delete.success"), TextType.SUCCESS,
+            arg -> arg.highlight(desc.localizedTypeName()),
+            arg -> arg.highlight(desc.id())));
     }
 
     @Override

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Lock.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Lock.java
@@ -11,6 +11,7 @@ import nl.pim16aap2.animatedarchitecture.core.events.IAnimatedArchitectureEventC
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
 import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetrieverFactory;
 
@@ -47,7 +48,10 @@ public class Lock extends StructureTargetCommand
     {
         final String msg = lockedStatus ? "commands.lock.success.locked" : "commands.lock.success.unlocked";
         final var desc = getRetrievedStructureDescription();
-        getCommandSender().sendSuccess(textFactory, localizer.getMessage(msg, desc.typeName(), desc.id()));
+        getCommandSender().sendMessage(textFactory.newText().append(
+            localizer.getMessage(msg), TextType.SUCCESS,
+            arg -> arg.highlight(desc.localizedTypeName()),
+            arg -> arg.highlight(desc.id())));
     }
 
     @Override

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/SetBlocksToMove.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/SetBlocksToMove.java
@@ -4,14 +4,14 @@ import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 import lombok.ToString;
-import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
-import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
-import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetrieverFactory;
 import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
+import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
 import nl.pim16aap2.animatedarchitecture.core.structures.structurearchetypes.IDiscreteMovement;
 import nl.pim16aap2.animatedarchitecture.core.text.TextType;
+import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
+import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetrieverFactory;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -46,8 +46,11 @@ public class SetBlocksToMove extends StructureTargetCommand
     protected void handleDatabaseActionSuccess()
     {
         final var desc = getRetrievedStructureDescription();
-        getCommandSender().sendSuccess(textFactory, localizer.getMessage("commands.set_blocks_to_move.success",
-                                                                         desc.typeName(), desc.id()));
+
+        getCommandSender().sendMessage(textFactory.newText().append(
+            localizer.getMessage("commands.set_blocks_to_move.success"), TextType.SUCCESS,
+            arg -> arg.highlight(desc.localizedTypeName()),
+            arg -> arg.highlight(desc.id())));
     }
 
     @Override
@@ -55,10 +58,10 @@ public class SetBlocksToMove extends StructureTargetCommand
     {
         if (!(structure instanceof IDiscreteMovement))
         {
-            getCommandSender()
-                .sendMessage(textFactory, TextType.ERROR,
-                             localizer.getMessage("commands.set_blocks_to_move.error.invalid_structure_type",
-                                                  localizer.getStructureType(structure), structure.getBasicInfo()));
+            getCommandSender().sendMessage(textFactory.newText().append(
+                localizer.getMessage("commands.set_blocks_to_move.error.invalid_structure_type"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(structure)),
+                arg -> arg.highlight(structure.getBasicInfo())));
             return CompletableFuture.completedFuture(null);
         }
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/SetOpenDirection.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/SetOpenDirection.java
@@ -4,14 +4,14 @@ import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 import lombok.ToString;
-import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
-import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
-import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
-import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetrieverFactory;
-import nl.pim16aap2.animatedarchitecture.core.util.MovementDirection;
 import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
+import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
 import nl.pim16aap2.animatedarchitecture.core.text.TextType;
+import nl.pim16aap2.animatedarchitecture.core.util.MovementDirection;
+import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
+import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetrieverFactory;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -46,8 +46,10 @@ public class SetOpenDirection extends StructureTargetCommand
     protected void handleDatabaseActionSuccess()
     {
         final var desc = getRetrievedStructureDescription();
-        getCommandSender().sendSuccess(textFactory, localizer.getMessage("commands.set_open_direction.success",
-                                                                         desc.typeName(), desc.id()));
+        getCommandSender().sendMessage(textFactory.newText().append(
+            localizer.getMessage("commands.set_open_direction.success"), TextType.SUCCESS,
+            arg -> arg.highlight(desc.localizedTypeName()),
+            arg -> arg.highlight(desc.id())));
     }
 
     @Override
@@ -55,12 +57,11 @@ public class SetOpenDirection extends StructureTargetCommand
     {
         if (!structure.getType().isValidOpenDirection(movementDirection))
         {
-            getCommandSender().sendMessage(
-                textFactory, TextType.ERROR,
-                localizer.getMessage("commands.set_open_direction.error.invalid_rotation",
-                                     localizer.getMessage(movementDirection.getLocalizationKey()),
-                                     localizer.getStructureType(structure), structure.getBasicInfo()));
-
+            getCommandSender().sendMessage(textFactory.newText().append(
+                localizer.getMessage("commands.set_open_direction.error.invalid_rotation"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getMessage(movementDirection.getLocalizationKey())),
+                arg -> arg.highlight(localizer.getStructureType(structure)),
+                arg -> arg.highlight(structure.getBasicInfo())));
             return CompletableFuture.completedFuture(null);
         }
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/SetOpenStatus.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/SetOpenStatus.java
@@ -4,12 +4,13 @@ import dagger.assisted.Assisted;
 import dagger.assisted.AssistedFactory;
 import dagger.assisted.AssistedInject;
 import lombok.ToString;
+import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
+import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
 import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetrieverFactory;
-import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
-import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -44,8 +45,10 @@ public class SetOpenStatus extends StructureTargetCommand
     protected void handleDatabaseActionSuccess()
     {
         final var desc = getRetrievedStructureDescription();
-        getCommandSender().sendSuccess(textFactory, localizer.getMessage("commands.set_open_status.success",
-                                                                         desc.typeName(), desc.id()));
+        getCommandSender().sendMessage(textFactory.newText().append(
+            localizer.getMessage("commands.set_open_status.success"), TextType.SUCCESS,
+            arg -> arg.highlight(desc.localizedTypeName()),
+            arg -> arg.highlight(desc.id())));
     }
 
     @Override
@@ -53,14 +56,17 @@ public class SetOpenStatus extends StructureTargetCommand
     {
         if (structure.isOpen() == isOpen)
         {
-            getCommandSender().sendError(
-                textFactory,
-                localizer.getMessage("commands.set_open_status.error.status_not_changed",
-                                     localizer.getStructureType(structure), structure.getNameAndUid(),
-                                     localizer.getMessage(isOpen ?
-                                                          localizer.getMessage("constants.open_status.open") :
-                                                          localizer.getMessage("constants.open_status.closed")
-                                     )));
+            final String localizedIsOpen =
+                isOpen ?
+                localizer.getMessage("constants.open_status.open") :
+                localizer.getMessage("constants.open_status.closed");
+
+            getCommandSender().sendMessage(textFactory.newText().append(
+                localizer.getMessage("commands.set_open_status.error.status_not_changed"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(structure)),
+                arg -> arg.highlight(structure.getNameAndUid()),
+                arg -> arg.highlight(localizedIsOpen)));
+
             return CompletableFuture.completedFuture(null);
         }
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/StructureTargetCommand.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/StructureTargetCommand.java
@@ -5,14 +5,14 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
-import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
-import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
-import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
+import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.managers.DatabaseManager;
+import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
 import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.util.Util;
-import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
+import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
@@ -81,9 +81,8 @@ public abstract class StructureTargetCommand extends BaseCommand
         {
             log.atFine().log("Failed to find structure %s for command: %s", getStructureRetriever(), this);
 
-            getCommandSender()
-                .sendMessage(textFactory, TextType.ERROR,
-                             localizer.getMessage("commands.structure_target_command.base.error.structure_not_found"));
+            getCommandSender().sendError(
+                textFactory, localizer.getMessage("commands.structure_target_command.base.error.structure_not_found"));
             return;
         }
 
@@ -92,11 +91,10 @@ public abstract class StructureTargetCommand extends BaseCommand
             log.atFine()
                .log("%s does not have access to structure %s for command %s", getCommandSender(), structure, this);
 
-            getCommandSender()
-                .sendMessage(textFactory, TextType.ERROR,
-                             localizer.getMessage(
-                                 "commands.structure_target_command.base.error.no_permission_for_action",
-                                 localizer.getStructureType(structure.get())));
+            getCommandSender().sendMessage(textFactory.newText().append(
+                localizer.getMessage("commands.structure_target_command.base.error.no_permission_for_action"),
+                TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(structure.get()))));
             return;
         }
 
@@ -191,12 +189,12 @@ public abstract class StructureTargetCommand extends BaseCommand
     /**
      * A simple description of a structure.
      *
-     * @param typeName
+     * @param localizedTypeName
      *     The localized name of the structure's type.
      * @param id
      *     The user-friendly identifier of the structure.
      */
-    protected record StructureDescription(String typeName, String id)
+    protected record StructureDescription(String localizedTypeName, String id)
     {
         private static final StructureDescription EMPTY_DESCRIPTION = new StructureDescription("Structure", "null");
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Toggle.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Toggle.java
@@ -7,16 +7,16 @@ import lombok.ToString;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.animatedarchitecture.core.api.IMessageable;
 import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
+import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.events.StructureActionCause;
+import nl.pim16aap2.animatedarchitecture.core.events.StructureActionType;
+import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.moveblocks.AnimationType;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureAnimationRequestBuilder;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
-import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
-import nl.pim16aap2.animatedarchitecture.core.events.StructureActionType;
-import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.text.TextType;
-import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
+import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
 import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Named;
@@ -112,22 +112,26 @@ public class Toggle extends BaseCommand
     {
         if (!hasAccessToAttribute(structure, StructureAttribute.TOGGLE, hasBypassPermission))
         {
-            getCommandSender()
-                .sendMessage(textFactory, TextType.ERROR,
-                             localizer.getMessage("commands.toggle.error.no_access",
-                                                  localizer.getStructureType(structure), structure.getBasicInfo()));
+            getCommandSender().sendMessage(textFactory.newText().append(
+                localizer.getMessage("commands.toggle.error.no_access"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(structure)),
+                arg -> arg.highlight(structure.getBasicInfo())));
+
             log.atFine()
                .log("%s has no access for command %s for structure %s!", getCommandSender(), this, structure);
+
             return;
         }
         if (!canToggle(structure))
         {
-            getCommandSender()
-                .sendMessage(textFactory, TextType.ERROR,
-                             localizer.getMessage("commands.toggle.error.cannot_toggle",
-                                                  localizer.getStructureType(structure), structure.getBasicInfo()));
+            getCommandSender().sendMessage(textFactory.newText().append(
+                localizer.getMessage("commands.toggle.error.cannot_toggle"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(structure)),
+                arg -> arg.highlight(structure.getBasicInfo())));
+
             log.atFiner()
                .log("Blocked action for command %s for structure %s by %s", this, structure, getCommandSender());
+
             return;
         }
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Version.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Version.java
@@ -8,6 +8,7 @@ import nl.pim16aap2.animatedarchitecture.core.api.IAnimatedArchitecturePlatform;
 import nl.pim16aap2.animatedarchitecture.core.api.IAnimatedArchitecturePlatformProvider;
 import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -39,9 +40,13 @@ public class Version extends BaseCommand
     @Override
     protected CompletableFuture<?> executeCommand(PermissionsStatus permissions)
     {
-        final String version = platformProvider.getPlatform().map(IAnimatedArchitecturePlatform::getVersionName)
-                                               .orElse("ERROR");
-        getCommandSender().sendInfo(textFactory, localizer.getMessage("commands.version.success", version));
+        final String version =
+            platformProvider.getPlatform().map(IAnimatedArchitecturePlatform::getVersionName).orElse("ERROR");
+
+        getCommandSender().sendMessage(textFactory.newText().append(
+            localizer.getMessage("commands.version.success"), TextType.SUCCESS,
+            arg -> arg.highlight(version)));
+
         return CompletableFuture.completedFuture(null);
     }
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureOpeningHelper.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureOpeningHelper.java
@@ -32,6 +32,7 @@ import nl.pim16aap2.animatedarchitecture.core.moveblocks.IAnimationBlockManager;
 import nl.pim16aap2.animatedarchitecture.core.moveblocks.IAnimationComponent;
 import nl.pim16aap2.animatedarchitecture.core.moveblocks.StructureActivityManager;
 import nl.pim16aap2.animatedarchitecture.core.structures.structurearchetypes.IDiscreteMovement;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.util.Cuboid;
 import nl.pim16aap2.animatedarchitecture.core.util.Limit;
 import nl.pim16aap2.animatedarchitecture.core.util.MovementDirection;
@@ -143,11 +144,10 @@ public final class StructureOpeningHelper
         if (!result.equals(StructureToggleResult.NO_PERMISSION))
         {
             if (messageReceiver instanceof IPlayer)
-                messageReceiver.sendError(
-                    textFactory,
-                    localizer.getMessage(result.getLocalizationKey(),
-                                         localizer.getStructureType(structure.getType()),
-                                         structure.getName()));
+                messageReceiver.sendMessage(textFactory.newText().append(
+                    localizer.getMessage(result.getLocalizationKey()), TextType.ERROR,
+                    arg -> arg.highlight(localizer.getStructureType(structure.getType())),
+                    arg -> arg.highlight(structure.getName())));
             else
             {
                 final Level level = result == StructureToggleResult.BUSY ? Level.FINE : Level.INFO;

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/text/TextArgument.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/text/TextArgument.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
  *     The optional text component to use for the text. This can be used to override the decorations of the surrounding
  *     text for the argument.
  */
-public record TextArgument(Object argument, @Nullable TextComponent component)
+public record TextArgument(@Nullable Object argument, @Nullable TextComponent component)
 {
     @SuppressWarnings("unused")
     public TextArgument(String text)

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/tooluser/PowerBlockRelocator.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/tooluser/PowerBlockRelocator.java
@@ -9,6 +9,7 @@ import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.animatedarchitecture.core.api.ILocation;
 import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.stepexecutor.StepExecutorLocation;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.stepexecutor.StepExecutorVoid;
 import org.jetbrains.annotations.Nullable;
@@ -47,9 +48,9 @@ public class PowerBlockRelocator extends ToolUser
     {
         if (!loc.getWorld().equals(structure.getWorld()))
         {
-            getPlayer().sendError(textFactory,
-                                  localizer.getMessage("tool_user.powerblock_relocator.error.world_mismatch",
-                                                       localizer.getStructureType(structure.getType())));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("tool_user.powerblock_relocator.error.world_mismatch"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(structure.getType()))));
             return false;
         }
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/tooluser/creator/Creator.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/tooluser/creator/Creator.java
@@ -198,7 +198,7 @@ public abstract class Creator extends ToolUser
             .textSupplier(
                 text -> text.append(
                     localizer.getMessage("creator.base.give_name"), TextType.INFO,
-                    text.newTextArgument(localizer.getStructureType(getStructureType()), TextType.HIGHLIGHT)));
+                    arg -> arg.highlight(localizer.getStructureType(getStructureType()))));
 
         factorySetFirstPos = stepFactory
             .stepName("SET_FIRST_POS")
@@ -325,9 +325,10 @@ public abstract class Creator extends ToolUser
         if (!Util.isValidStructureName(str))
         {
             log.atFine().log("Invalid name '%s' for selected Creator: %s", str, this);
-            getPlayer().sendMessage(textFactory, TextType.ERROR,
-                                    localizer.getMessage("creator.base.error.invalid_name",
-                                                         str, localizer.getStructureType(getStructureType())));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.base.error.invalid_name"), TextType.ERROR,
+                arg -> arg.highlight(str),
+                arg -> arg.highlight(localizer.getStructureType(getStructureType()))));
             return false;
         }
 
@@ -374,12 +375,11 @@ public abstract class Creator extends ToolUser
         final OptionalInt sizeLimit = limitsManager.getLimit(getPlayer(), Limit.STRUCTURE_SIZE);
         if (sizeLimit.isPresent() && newCuboid.getVolume() > sizeLimit.getAsInt())
         {
-            getPlayer().sendMessage(
-                textFactory, TextType.ERROR,
-                localizer.getMessage("creator.base.error.area_too_big",
-                                     localizer.getStructureType(getStructureType()),
-                                     Integer.toString(newCuboid.getVolume()),
-                                     Integer.toString(sizeLimit.getAsInt())));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.base.error.area_too_big"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(getStructureType())),
+                arg -> arg.highlight(newCuboid.getVolume()),
+                arg -> arg.highlight(sizeLimit.getAsInt())));
             return false;
         }
 
@@ -413,10 +413,10 @@ public abstract class Creator extends ToolUser
         }
         if (!buyStructure())
         {
-            getPlayer().sendMessage(textFactory, TextType.ERROR,
-                                    localizer.getMessage("creator.base.error.insufficient_funds",
-                                                         localizer.getStructureType(getStructureType()),
-                                                         DECIMAL_FORMAT.format(getPrice().orElse(0))));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.base.error.insufficient_funds"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(getStructureType())),
+                arg -> arg.highlight(DECIMAL_FORMAT.format(getPrice().orElse(0)))));
             abort();
             return true;
         }
@@ -451,8 +451,9 @@ public abstract class Creator extends ToolUser
     {
         if (!getValidOpenDirections().contains(direction))
         {
-            getPlayer().sendMessage(textFactory, TextType.ERROR,
-                                    localizer.getMessage("creator.base.error.invalid_option", direction.name()));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.base.error.invalid_option"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getMessage(direction.getLocalizationKey()))));
             prepareSetOpenDirection();
             return false;
         }
@@ -495,15 +496,15 @@ public abstract class Creator extends ToolUser
             {
                 if (result.cancelled())
                 {
-                    getPlayer().sendMessage(textFactory, TextType.ERROR,
-                                            localizer.getMessage("creator.base.error.creation_cancelled"));
+                    getPlayer().sendError(
+                        textFactory, localizer.getMessage("creator.base.error.creation_cancelled"));
                     return;
                 }
 
                 if (result.structure().isEmpty())
                 {
-                    getPlayer().sendMessage(textFactory, TextType.ERROR,
-                                            localizer.getMessage("constants.error.generic"));
+                    getPlayer().sendError(
+                        textFactory, localizer.getMessage("constants.error.generic"));
                     log.atSevere().log("Failed to insert structure after creation!");
                 }
             }).exceptionally(Util::exceptionally);
@@ -586,9 +587,9 @@ public abstract class Creator extends ToolUser
         final Vector3Di pos = loc.getPosition();
         if (Util.requireNonNull(cuboid, "cuboid").isPosInsideCuboid(pos))
         {
-            getPlayer().sendError(textFactory,
-                                  localizer.getMessage("creator.base.error.powerblock_inside_structure",
-                                                       localizer.getStructureType(getStructureType())));
+            getPlayer().sendMessage(textFactory.newText().append(
+                "creator.base.error.powerblock_inside_structure", TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(getStructureType()))));
             return false;
         }
         final OptionalInt distanceLimit = limitsManager.getLimit(getPlayer(), Limit.POWERBLOCK_DISTANCE);
@@ -596,11 +597,11 @@ public abstract class Creator extends ToolUser
         if (distanceLimit.isPresent() &&
             (distance = cuboid.getCenter().getDistance(pos)) > distanceLimit.getAsInt())
         {
-            getPlayer().sendError(textFactory,
-                                  localizer.getMessage("creator.base.error.powerblock_too_far",
-                                                       localizer.getStructureType(getStructureType()),
-                                                       DECIMAL_FORMAT.format(distance),
-                                                       Integer.toString(distanceLimit.getAsInt())));
+            getPlayer().sendMessage(textFactory.newText().append(
+                "creator.base.error.powerblock_too_far", TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(getStructureType())),
+                arg -> arg.highlight(DECIMAL_FORMAT.format(distance)),
+                arg -> arg.highlight(distanceLimit.getAsInt())));
             return false;
         }
 
@@ -628,8 +629,8 @@ public abstract class Creator extends ToolUser
 
         if (!Util.requireNonNull(cuboid, "cuboid").isInRange(loc, 1))
         {
-            getPlayer().sendMessage(textFactory, TextType.ERROR,
-                                    localizer.getMessage("creator.base.error.invalid_rotation_point"));
+            getPlayer().sendError(
+                textFactory, localizer.getMessage("creator.base.error.invalid_rotation_point"));
             return false;
         }
 
@@ -642,15 +643,15 @@ public abstract class Creator extends ToolUser
         return text.append(
             localizer.getMessage("creator.base.set_open_status"), TextType.INFO,
 
-            text.newTextArgument(localizer.getStructureType(getStructureType()), TextType.HIGHLIGHT),
+            arg -> arg.highlight(localizer.getStructureType(getStructureType())),
 
-            text.newClickableTextArgument(
-                localizer.getMessage("constants.open_status.open"), TextType.CLICKABLE,
+            arg -> arg.clickable(
+                localizer.getMessage("constants.open_status.open"),
                 "/animatedarchitecture SetOpenStatus " + localizer.getMessage("constants.open_status.open"),
                 localizer.getMessage("interaction.clickable_command.default_highlight")),
 
-            text.newClickableTextArgument(
-                localizer.getMessage("constants.open_status.closed"), TextType.CLICKABLE,
+            arg -> arg.clickable(
+                localizer.getMessage("constants.open_status.closed"),
                 "/animatedarchitecture SetOpenStatus " + localizer.getMessage("constants.open_status.closed"),
                 localizer.getMessage("interaction.clickable_command.default_highlight")));
     }
@@ -658,7 +659,7 @@ public abstract class Creator extends ToolUser
     protected Text setOpenDirectionTextSupplier(Text text)
     {
         text.append(localizer.getMessage("creator.base.set_open_direction") + "\n", TextType.INFO,
-                    text.newTextArgument(localizer.getStructureType(getStructureType()), TextType.HIGHLIGHT));
+                    arg -> arg.highlight(localizer.getStructureType(getStructureType())));
 
         getValidOpenDirections().stream().map(dir -> localizer.getMessage(dir.getLocalizationKey())).sorted().forEach(
             dir -> text.appendClickableText(
@@ -674,15 +675,15 @@ public abstract class Creator extends ToolUser
         return text.append(
             localizer.getMessage("creator.base.confirm_structure_price"), TextType.INFO,
 
-            text.newTextArgument(localizer.getStructureType(getStructureType()), TextType.INFO),
-            text.newTextArgument(DECIMAL_FORMAT.format(getPrice().orElse(0)), TextType.HIGHLIGHT),
+            arg -> arg.info(localizer.getStructureType(getStructureType())),
+            arg -> arg.highlight(DECIMAL_FORMAT.format(getPrice().orElse(0))),
 
-            text.newClickableTextArgument(
+            arg -> arg.clickable(
                 localizer.getMessage("creator.base.confirm_structure_price.confirm"), TextType.CLICKABLE_CONFIRM,
                 "/animatedarchitecture confirm",
                 localizer.getMessage("interaction.clickable_command.default_highlight")),
 
-            text.newClickableTextArgument(
+            arg -> arg.clickable(
                 localizer.getMessage("creator.base.confirm_structure_price.refuse"), TextType.CLICKABLE_REFUSE,
                 "/animatedarchitecture cancel",
                 localizer.getMessage("interaction.clickable_command.default_highlight"))

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/UnitTestUtil.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/UnitTestUtil.java
@@ -1,8 +1,8 @@
 package nl.pim16aap2.animatedarchitecture.core;
 
+import lombok.AllArgsConstructor;
 import nl.pim16aap2.animatedarchitecture.core.api.ILocation;
 import nl.pim16aap2.animatedarchitecture.core.api.IWorld;
-import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureBaseBuilder;
 import nl.pim16aap2.animatedarchitecture.core.text.Text;
@@ -14,6 +14,7 @@ import nl.pim16aap2.testing.AssistedFactoryMocker;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -288,17 +289,18 @@ public class UnitTestUtil
     }
 
     /**
-     * Creates a new un-styled {@link Text} object from an input String.
+     * Creates a new argument matcher that matches a Text argument using its {@link Text#toString()} method against an
+     * input string.
      * <p>
-     * The created Text is not mocked and can be used as a normal Text object.
+     * See {@link TextArgumentMatcher} and {@link Mockito#argThat(ArgumentMatcher)}.
      *
      * @param string
-     *     The string to use to create a new Text object.
-     * @return The new Text object.
+     *     The input string.
+     * @return null.
      */
-    public static Text toText(String string)
+    public static Text textArgumentMatcher(String string)
     {
-        return ITextFactory.getSimpleTextFactory().newText().append(string);
+        return Mockito.argThat(new TextArgumentMatcher(string));
     }
 
     /**
@@ -312,4 +314,16 @@ public class UnitTestUtil
     public record StructureBaseBuilderResult(
         StructureBaseBuilder structureBaseBuilder, AssistedFactoryMocker<?, ?> assistedFactoryMocker)
     {}
+
+    @AllArgsConstructor
+    public static final class TextArgumentMatcher implements ArgumentMatcher<Text>
+    {
+        private final String base;
+
+        @Override
+        public boolean matches(Text argument)
+        {
+            return base.equals(argument.toString());
+        }
+    }
 }

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/commands/DelayedCommandTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/commands/DelayedCommandTest.java
@@ -3,12 +3,12 @@ package nl.pim16aap2.animatedarchitecture.core.commands;
 import nl.pim16aap2.animatedarchitecture.core.UnitTestUtil;
 import nl.pim16aap2.animatedarchitecture.core.api.debugging.DebuggableRegistry;
 import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
+import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.managers.DelayedCommandInputManager;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
+import nl.pim16aap2.animatedarchitecture.core.util.functional.TriFunction;
 import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetriever;
 import nl.pim16aap2.animatedarchitecture.core.util.structureretriever.StructureRetrieverFactory;
-import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
-import nl.pim16aap2.animatedarchitecture.core.util.functional.TriFunction;
 import nl.pim16aap2.testing.logging.LogInspector;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -92,7 +92,7 @@ class DelayedCommandTest
 
         delayedCommand.runDelayed(commandSender, structureRetriever);
         Mockito.verify(commandSender, Mockito.times(1))
-               .sendMessage(UnitTestUtil.toText(DelayedCommandImpl.INPUT_REQUEST_MSG));
+               .sendMessage(UnitTestUtil.textArgumentMatcher(DelayedCommandImpl.INPUT_REQUEST_MSG));
         Mockito.verify(inputRequestFactory, Mockito.times(1)).create(
             Mockito.anyLong(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
         Mockito.verify(delayedFunction, Mockito.never()).apply(Mockito.any(), Mockito.any(), Mockito.any());
@@ -103,7 +103,7 @@ class DelayedCommandTest
 
         delayedCommand.provideDelayedInput(commandSender, new Object());
         Mockito.verify(commandSender, Mockito.times(1))
-               .sendMessage(UnitTestUtil.toText("commands.base.error.not_waiting"));
+               .sendMessage(UnitTestUtil.textArgumentMatcher("commands.base.error.not_waiting"));
     }
 
     @Test
@@ -113,7 +113,7 @@ class DelayedCommandTest
 
         delayedCommand.provideDelayedInput(commandSender, new Object());
         Mockito.verify(commandSender, Mockito.times(1))
-               .sendMessage(UnitTestUtil.toText("commands.base.error.not_waiting"));
+               .sendMessage(UnitTestUtil.textArgumentMatcher("commands.base.error.not_waiting"));
     }
 
     @Test

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/commands/ListMovablesTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/commands/ListMovablesTest.java
@@ -63,7 +63,7 @@ class ListStructuresTest
         Assertions.assertDoesNotThrow(
             () -> factory.newListStructures(playerCommandSender, retriever).run().get(1, TimeUnit.SECONDS));
         Mockito.verify(playerCommandSender)
-               .sendMessage(UnitTestUtil.toText("commands.list_structures.error.no_structures_found"));
+               .sendMessage(UnitTestUtil.textArgumentMatcher("commands.list_structures.error.no_structures_found"));
 
         // Run it again, but now do so with admin permissions enabled.
         // As a result, we should NOT get the "No structures found!" message again.
@@ -71,12 +71,12 @@ class ListStructuresTest
         Assertions.assertDoesNotThrow(
             () -> factory.newListStructures(playerCommandSender, retriever).run().get(1, TimeUnit.SECONDS));
         Mockito.verify(playerCommandSender)
-               .sendMessage(UnitTestUtil.toText("commands.list_structures.error.no_structures_found"));
+               .sendMessage(UnitTestUtil.textArgumentMatcher("commands.list_structures.error.no_structures_found"));
 
 
         Assertions.assertDoesNotThrow(
             () -> factory.newListStructures(serverCommandSender, retriever).run().get(1, TimeUnit.SECONDS));
         Mockito.verify(serverCommandSender, Mockito.never())
-               .sendMessage(UnitTestUtil.toText("commands.list_structures.error.no_structures_found"));
+               .sendMessage(UnitTestUtil.textArgumentMatcher("commands.list_structures.error.no_structures_found"));
     }
 }

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/tooluser/PowerBlockRelocatorTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/tooluser/PowerBlockRelocatorTest.java
@@ -1,19 +1,22 @@
 package nl.pim16aap2.animatedarchitecture.core.tooluser;
 
+import nl.pim16aap2.animatedarchitecture.core.UnitTestUtil;
 import nl.pim16aap2.animatedarchitecture.core.api.ILocation;
 import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
 import nl.pim16aap2.animatedarchitecture.core.api.IProtectionCompatManager;
 import nl.pim16aap2.animatedarchitecture.core.api.IWorld;
-import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
-import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
-import nl.pim16aap2.animatedarchitecture.core.UnitTestUtil;
 import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
+import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
+import nl.pim16aap2.animatedarchitecture.core.text.Text;
 import nl.pim16aap2.animatedarchitecture.core.util.vector.Vector3Di;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -24,6 +27,9 @@ class PowerBlockRelocatorTest
 {
     @Mock
     private AbstractStructure structure;
+
+    @Captor
+    private ArgumentCaptor<Text> textCaptor;
 
     @Mock
     private IWorld world;
@@ -85,8 +91,9 @@ class PowerBlockRelocatorTest
         Mockito.when(location.getWorld()).thenReturn(Mockito.mock(IWorld.class));
 
         Assertions.assertFalse(relocator.moveToLoc(location));
-        Mockito.verify(player)
-               .sendMessage(UnitTestUtil.toText("tool_user.powerblock_relocator.error.world_mismatch StructureType"));
+
+        Mockito.verify(player).sendMessage(
+            UnitTestUtil.textArgumentMatcher("tool_user.powerblock_relocator.error.world_mismatch"));
 
         Mockito.when(location.getWorld()).thenReturn(Mockito.mock(IWorld.class));
     }

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/tooluser/creator/CreatorTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/tooluser/creator/CreatorTest.java
@@ -33,7 +33,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.lang.reflect.Field;
 import java.util.EnumSet;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -109,8 +108,7 @@ public class CreatorTest
         final String input = "1";
         // Numerical names are not allowed.
         Assertions.assertFalse(creator.completeNamingStep(input));
-        Mockito.verify(player)
-               .sendMessage(UnitTestUtil.toText("creator.base.error.invalid_name " + input + " StructureType"));
+        Mockito.verify(player).sendMessage(UnitTestUtil.textArgumentMatcher("creator.base.error.invalid_name"));
 
         Assertions.assertTrue(creator.completeNamingStep("newDoor"));
         Mockito.verify(creator).giveTool();
@@ -177,10 +175,8 @@ public class CreatorTest
                .thenReturn(OptionalInt.of(cuboid.getVolume() - 1));
         // Not allowed, because the selected area is too big.
         Assertions.assertFalse(creator.setSecondPos(loc));
-        Mockito.verify(player)
-               .sendMessage(
-                   UnitTestUtil.toText(String.format(Locale.ROOT, "creator.base.error.area_too_big StructureType %d %d",
-                                                     cuboid.getVolume(), cuboid.getVolume() - 1)));
+        Mockito.verify(player).sendMessage(
+            UnitTestUtil.textArgumentMatcher("creator.base.error.area_too_big"));
 
         Mockito.when(limitsManager.getLimit(Mockito.any(), Mockito.any()))
                .thenReturn(OptionalInt.of(cuboid.getVolume() + 1));
@@ -202,22 +198,21 @@ public class CreatorTest
         Mockito.doReturn(procedure).when(creator).getProcedure();
 
         Assertions.assertTrue(creator.confirmPrice(false));
-        Mockito.verify(player).sendMessage(UnitTestUtil.toText("creator.base.error.creation_cancelled"));
+        Mockito.verify(player).sendMessage(UnitTestUtil.textArgumentMatcher("creator.base.error.creation_cancelled"));
 
         Mockito.doReturn(OptionalDouble.empty()).when(creator).getPrice();
         Mockito.doReturn(false).when(creator).buyStructure();
 
         Assertions.assertTrue(creator.confirmPrice(true));
-        Mockito.verify(player)
-               .sendMessage(UnitTestUtil.toText("creator.base.error.insufficient_funds StructureType 0"));
+        Mockito.verify(player).sendMessage(
+            UnitTestUtil.textArgumentMatcher("creator.base.error.insufficient_funds"));
 
-        double price = 123.41;
+        final double price = 123.41;
         Mockito.doReturn(OptionalDouble.of(price)).when(creator).getPrice();
         Mockito.doReturn(false).when(creator).buyStructure();
         Assertions.assertTrue(creator.confirmPrice(true));
-        Mockito.verify(player).sendMessage(
-            UnitTestUtil.toText(
-                String.format(Locale.ROOT, "creator.base.error.insufficient_funds StructureType %.2f", price)));
+        Mockito.verify(player, Mockito.times(2)).sendMessage(
+            UnitTestUtil.textArgumentMatcher("creator.base.error.insufficient_funds"));
 
         Mockito.doReturn(true).when(creator).buyStructure();
         Assertions.assertTrue(creator.confirmPrice(true));
@@ -319,8 +314,8 @@ public class CreatorTest
         Mockito.doReturn(true).when(creator).playerHasAccessToLocation(Mockito.any());
         Assertions.assertFalse(creator.completeSetPowerBlockStep(insideCuboid));
 
-        Mockito.verify(player)
-               .sendMessage(UnitTestUtil.toText("creator.base.error.powerblock_inside_structure StructureType"));
+        Mockito.verify(player).sendMessage(
+            UnitTestUtil.textArgumentMatcher("creator.base.error.powerblock_inside_structure"));
 
         final double distance = cuboid.getCenter().getDistance(outsideCuboid.getPosition());
         final int lowLimit = (int) (distance - 1);
@@ -328,9 +323,7 @@ public class CreatorTest
 
         Assertions.assertFalse(creator.completeSetPowerBlockStep(outsideCuboid));
         Mockito.verify(player).sendMessage(
-            UnitTestUtil.toText(
-                String.format(Locale.ROOT, "creator.base.error.powerblock_too_far StructureType %.2f %d",
-                              distance, lowLimit)));
+            UnitTestUtil.textArgumentMatcher("creator.base.error.powerblock_too_far"));
 
         Mockito.when(limitsManager.getLimit(Mockito.any(), Mockito.any())).thenReturn(OptionalInt.of(lowLimit + 10));
         Assertions.assertTrue(creator.completeSetPowerBlockStep(outsideCuboid));
@@ -358,7 +351,8 @@ public class CreatorTest
         Mockito.doReturn(true).when(creator).playerHasAccessToLocation(Mockito.any());
         // Point too far away
         Assertions.assertFalse(creator.completeSetRotationPointStep(UnitTestUtil.getLocation(1, 1, 1, world)));
-        Mockito.verify(player).sendMessage(UnitTestUtil.toText("creator.base.error.invalid_rotation_point"));
+        Mockito.verify(player).sendMessage(
+            UnitTestUtil.textArgumentMatcher("creator.base.error.invalid_rotation_point"));
 
         Assertions.assertTrue(creator.completeSetRotationPointStep(UnitTestUtil.getLocation(11, 21, 31, world)));
     }

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/gui/MainGui.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/gui/MainGui.java
@@ -17,6 +17,7 @@ import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
 import nl.pim16aap2.animatedarchitecture.core.structures.IStructureConst;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.util.Util;
 import nl.pim16aap2.animatedarchitecture.spigot.core.AnimatedArchitecturePlugin;
 import nl.pim16aap2.animatedarchitecture.spigot.core.config.ConfigSpigot;
@@ -214,8 +215,9 @@ class MainGui implements IGuiPage.IGuiStructureDeletionListener
             if (selectedStructure == null || selectedStructure.getUid() == structure.getUid())
                 this.redraw();
             if (notify)
-                inventoryHolder.sendInfo(textFactory, localizer.getMessage("gui.notification.structure_inaccessible",
-                                                                           structure.getNameAndUid()));
+                inventoryHolder.sendMessage(textFactory.newText().append(
+                    localizer.getMessage("gui.notification.structure_inaccessible"), TextType.ERROR,
+                    arg -> arg.highlight(structure.getName())));
         }
     }
 

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/managers/VaultManager.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/managers/VaultManager.java
@@ -16,6 +16,7 @@ import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.managers.StructureTypeManager;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.util.Constants;
 import nl.pim16aap2.animatedarchitecture.core.util.Util;
 import nl.pim16aap2.animatedarchitecture.spigot.util.SpigotAdapter;
@@ -92,13 +93,15 @@ public final class VaultManager implements IRestartable, IEconomyManager, IPermi
         final double price = priceOpt.getAsDouble();
         if (withdrawPlayer(spigotPlayer, world.worldName(), price))
         {
-            player.sendInfo(textFactory, localizer.getMessage("creator.base.money_withdrawn", Double.toString(price)));
+            player.sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.base.money_withdrawn"), TextType.SUCCESS,
+                arg -> arg.highlight(price)));
             return true;
         }
-
-        player.sendError(textFactory,
-                         localizer.getMessage("creator.base.error.insufficient_funds",
-                                              localizer.getMessage(type.getLocalizationKey()), Double.toString(price)));
+        player.sendMessage(textFactory.newText().append(
+            localizer.getMessage("creator.base.error.insufficient_funds"), TextType.ERROR,
+            arg -> arg.highlight(localizer.getMessage(type.getLocalizationKey())),
+            arg -> arg.highlight(price)));
         return false;
     }
 

--- a/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/animatearchitecture/creator/CreatorTestsUtil.java
+++ b/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/animatearchitecture/creator/CreatorTestsUtil.java
@@ -286,7 +286,7 @@ public class CreatorTestsUtil
     {
         applySteps(creator, input);
         Mockito.verify(creator.getPlayer(), Mockito.never())
-               .sendMessage(UnitTestUtil.toText("creator.base.error.creation_cancelled"));
+               .sendMessage(UnitTestUtil.textArgumentMatcher("creator.base.error.creation_cancelled"));
         Mockito.verify(databaseManager).addStructure(actualStructure, player);
     }
 }

--- a/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/animatearchitecture/structures/portcullis/CreatorPortcullisTest.java
+++ b/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/animatearchitecture/structures/portcullis/CreatorPortcullisTest.java
@@ -53,9 +53,7 @@ class CreatorPortcullisTest extends CreatorTestsUtil
 
         Assertions.assertFalse(creator.setBlocksToMove(blocksToMove));
         Mockito.verify(player).sendMessage(
-            UnitTestUtil.toText(
-                String.format("creator.base.error.blocks_to_move_too_far structure.type.portcullis %d %d",
-                              blocksToMove, blocksToMoveLimit)));
+            UnitTestUtil.textArgumentMatcher("creator.base.error.blocks_to_move_too_far"));
 
         Mockito.when(config.maxBlocksToMove()).thenReturn(OptionalInt.of(blocksToMove));
         Assertions.assertTrue(creator.setBlocksToMove(blocksToMove));

--- a/structures/structure-clock/src/main/java/nl/pim16aap2/animatedarchitecture/structures/clock/CreatorClock.java
+++ b/structures/structure-clock/src/main/java/nl/pim16aap2/animatedarchitecture/structures/clock/CreatorClock.java
@@ -5,6 +5,7 @@ import nl.pim16aap2.animatedarchitecture.core.api.ILocation;
 import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.Step;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.creator.Creator;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.stepexecutor.StepExecutorLocation;
@@ -105,30 +106,38 @@ public class CreatorClock extends Creator
         final int maxHorizontalDim = Math.max(cuboidDims.x(), cuboidDims.z());
         if (height < 3 || maxHorizontalDim < 3)
         {
-            getPlayer().sendError(textFactory, localizer
-                .getMessage("creator.clock.error.too_small", maxHorizontalDim, height));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.clock.error.too_small"), TextType.ERROR,
+                arg -> arg.highlight(maxHorizontalDim),
+                arg -> arg.highlight(height)));
             return false;
         }
 
         if (height != maxHorizontalDim)
         {
-            getPlayer().sendError(textFactory, localizer
-                .getMessage("creator.clock.error.not_square", maxHorizontalDim, height));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.clock.error.not_square"), TextType.ERROR,
+                arg -> arg.highlight(maxHorizontalDim),
+                arg -> arg.highlight(height)));
             return false;
         }
 
         // The clock has to be an odd number of blocks tall.
         if (height % 2 == 0)
         {
-            getPlayer().sendError(textFactory, localizer
-                .getMessage("creator.clock.error.not_odd", maxHorizontalDim, height));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.clock.error.not_odd"), TextType.ERROR,
+                arg -> arg.highlight(maxHorizontalDim),
+                arg -> arg.highlight(height)));
             return false;
         }
 
         final int depth = Math.min(cuboidDims.x(), cuboidDims.z());
         if (depth != 2)
         {
-            getPlayer().sendError(textFactory, localizer.getMessage("creator.clock.error.not_2_deep", depth));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.clock.error.not_2_deep"), TextType.ERROR,
+                arg -> arg.highlight(depth)));
             return false;
         }
 

--- a/structures/structure-portcullis/src/main/java/nl/pim16aap2/animatedarchitecture/structures/portcullis/CreatorPortcullis.java
+++ b/structures/structure-portcullis/src/main/java/nl/pim16aap2/animatedarchitecture/structures/portcullis/CreatorPortcullis.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.animatedarchitecture.structures.portcullis;
 import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.Step;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.creator.Creator;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.stepexecutor.StepExecutorInteger;
@@ -65,10 +66,11 @@ public class CreatorPortcullis extends Creator
         final OptionalInt blocksToMoveLimit = limitsManager.getLimit(getPlayer(), Limit.BLOCKS_TO_MOVE);
         if (blocksToMoveLimit.isPresent() && blocksToMove > blocksToMoveLimit.getAsInt())
         {
-            getPlayer().sendError(textFactory, localizer.getMessage("creator.base.error.blocks_to_move_too_far",
-                                                                    localizer.getStructureType(getStructureType()),
-                                                                    Integer.toString(blocksToMove),
-                                                                    Integer.toString(blocksToMoveLimit.getAsInt())));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.base.error.blocks_to_move_too_far"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(getStructureType())),
+                arg -> arg.highlight(blocksToMove),
+                arg -> arg.highlight(blocksToMoveLimit.getAsInt())));
             return false;
         }
 

--- a/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/animatedarchitecture/structures/slidingdoor/CreatorSlidingDoor.java
+++ b/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/animatedarchitecture/structures/slidingdoor/CreatorSlidingDoor.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.animatedarchitecture.structures.slidingdoor;
 import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
+import nl.pim16aap2.animatedarchitecture.core.text.TextType;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.Step;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.creator.Creator;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.stepexecutor.StepExecutorInteger;
@@ -65,10 +66,11 @@ public class CreatorSlidingDoor extends Creator
         final OptionalInt blocksToMoveLimit = limitsManager.getLimit(getPlayer(), Limit.BLOCKS_TO_MOVE);
         if (blocksToMoveLimit.isPresent() && blocksToMove > blocksToMoveLimit.getAsInt())
         {
-            getPlayer().sendError(textFactory, localizer.getMessage("creator.base.error.blocks_to_move_too_far",
-                                                                    localizer.getStructureType(getStructureType()),
-                                                                    Integer.toString(blocksToMove),
-                                                                    Integer.toString(blocksToMoveLimit.getAsInt())));
+            getPlayer().sendMessage(textFactory.newText().append(
+                localizer.getMessage("creator.base.error.blocks_to_move_too_far"), TextType.ERROR,
+                arg -> arg.highlight(localizer.getStructureType(getStructureType())),
+                arg -> arg.highlight(blocksToMove),
+                arg -> arg.highlight(blocksToMoveLimit.getAsInt())));
             return false;
         }
 


### PR DESCRIPTION
- The old usage of variable substitution via the localizer has been (mostly) replaced by the new variable substitution system in the Text class, which allows us to do stuff like add styling and clickable text etc. The old system is still used for situations where Text objects aren't used (e.g. GUI).