### PR TITLE
Rename StructureOpeningHelper

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureBase.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureBase.java
@@ -134,7 +134,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
     @EqualsAndHashCode.Exclude
     @Getter(AccessLevel.PACKAGE)
-    private final StructureOpeningHelper structureOpeningHelper;
+    private final StructureToggleHelper structureOpeningHelper;
 
     @EqualsAndHashCode.Exclude
     @Getter(AccessLevel.PACKAGE)
@@ -162,7 +162,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
         ILocalizer localizer,
         DatabaseManager databaseManager,
         StructureRegistry structureRegistry,
-        StructureOpeningHelper structureOpeningHelper,
+        StructureToggleHelper structureOpeningHelper,
         StructureAnimationRequestBuilder structureToggleRequestBuilder,
         IPlayerFactory playerFactory,
         IExecutor executor,

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureToggleHelper.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureToggleHelper.java
@@ -52,8 +52,7 @@ import java.util.logging.Level;
  *
  * @author Pim
  */
-@Flogger
-public final class StructureOpeningHelper
+@Flogger final class StructureToggleHelper
 {
     private final ILocalizer localizer;
     private final ITextFactory textFactory;
@@ -74,7 +73,7 @@ public final class StructureOpeningHelper
     private final AnimationRequestData.IFactory movementRequestDataFactory;
 
     @Inject //
-    StructureOpeningHelper(
+    StructureToggleHelper(
         ILocalizer localizer,
         ITextFactory textFactory,
         StructureActivityManager structureActivityManager,


### PR DESCRIPTION
- The StructureOpeningHelper isn't just used for opening structures, but for any kind of toggle. As such, it was renamed to StructureToggleHelper.
- Reduced the visibility of StructureToggleHelper from public to package-private, because no classes outside the package should need it for anything.