### PR TITLE
Fix leaky abstraction of time in core module

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/IExecutor.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/IExecutor.java
@@ -88,9 +88,9 @@ public interface IExecutor
      * @param timerTask
      *     The task to run.
      * @param delay
-     *     The delay in ticks before the task is to be executed.
+     *     The delay in milliseconds before the task is to be executed.
      * @param period
-     *     The time in ticks between successive task executions.
+     *     The time in milliseconds between successive task executions.
      * @return The ID of the task.
      */
     int runAsyncRepeated(TimerTask timerTask, long delay, long period);
@@ -101,9 +101,9 @@ public interface IExecutor
      * @param runnable
      *     The task to run.
      * @param delay
-     *     The delay in ticks before the task is to be executed.
+     *     The delay in milliseconds before the task is to be executed.
      * @param period
-     *     The time in ticks between successive task executions.
+     *     The time in milliseconds between successive task executions.
      * @return The ID of the task.
      */
     int runAsyncRepeated(Runnable runnable, long delay, long period);
@@ -114,9 +114,9 @@ public interface IExecutor
      * @param timerTask
      *     The task to run.
      * @param delay
-     *     The delay in ticks before the task is to be executed.
+     *     The delay in milliseconds before the task is to be executed.
      * @param period
-     *     The time in ticks between successive task executions.
+     *     The time in milliseconds between successive task executions.
      * @return The ID of the task.
      */
     int runSyncRepeated(TimerTask timerTask, long delay, long period);
@@ -127,9 +127,9 @@ public interface IExecutor
      * @param runnable
      *     The task to run.
      * @param delay
-     *     The delay in ticks before the task is to be executed.
+     *     The delay in milliseconds before the task is to be executed.
      * @param period
-     *     The time in ticks between successive task executions.
+     *     The time in milliseconds between successive task executions.
      * @return The ID of the task.
      */
     int runSyncRepeated(Runnable runnable, long delay, long period);
@@ -140,7 +140,7 @@ public interface IExecutor
      * @param timerTask
      *     The task to run.
      * @param delay
-     *     The delay in ticks before the task is to be executed.
+     *     The delay in milliseconds before the task is to be executed.
      */
     void runAsyncLater(TimerTask timerTask, long delay);
 
@@ -150,7 +150,7 @@ public interface IExecutor
      * @param runnable
      *     The task to run.
      * @param delay
-     *     The delay in ticks before the task is to be executed.
+     *     The delay in milliseconds before the task is to be executed.
      */
     void runAsyncLater(Runnable runnable, long delay);
 
@@ -160,7 +160,7 @@ public interface IExecutor
      * @param timerTask
      *     The task to run.
      * @param delay
-     *     The delay in ticks before the task is to be executed.
+     *     The delay in milliseconds before the task is to be executed.
      */
     void runSyncLater(TimerTask timerTask, long delay);
 
@@ -170,7 +170,7 @@ public interface IExecutor
      * @param runnable
      *     The task to run.
      * @param delay
-     *     The delay in ticks before the task is to be executed.
+     *     The delay in milliseconds before the task is to be executed.
      */
     void runSyncLater(Runnable runnable, long delay);
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/AnimatedPreviewBlock.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/AnimatedPreviewBlock.java
@@ -20,11 +20,11 @@ public class AnimatedPreviewBlock implements IAnimatedBlock
     private static final IAnimatedBlockData ANIMATED_BLOCK_DATA = new PreviewAnimatedBlockData();
 
     /**
-     * The lifetime of a glowing block (in ticks).
+     * The lifetime of a glowing block (in milliseconds).
      * <p>
      * Glowing blocks will be respawned after e
      */
-    private static final int LIFETIME = 1200; // 1 minute
+    private static final int LIFETIME = 60_000;
 
     private volatile int processedTicks = 0;
     private volatile @Nullable IGlowingBlock glowingBlock;
@@ -140,7 +140,8 @@ public class AnimatedPreviewBlock implements IAnimatedBlock
         this.glowingBlock = glowingBlockSpawner
             .builder()
             .forPlayer(player)
-            .forDuration(Duration.ofMillis(20 * LIFETIME + 100))
+            // add 100ms to have a small overlap when resetting the glowing block.
+            .forDuration(Duration.ofMillis(LIFETIME + 100))
             .inWorld(world)
             .atPosition(currentTarget)
             .withColor(color)

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/managers/ToolUserManager.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/managers/ToolUserManager.java
@@ -148,7 +148,7 @@ public final class ToolUserManager extends Restartable
      * @param toolUser
      *     The {@link ToolUser} for which to start the timer.
      * @param time
-     *     The amount of time (in seconds).
+     *     The amount of time (in milliseconds).
      */
     public void startToolUser(ToolUser toolUser, int time)
     {

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/moveblocks/AnimationUtil.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/moveblocks/AnimationUtil.java
@@ -17,6 +17,6 @@ public final class AnimationUtil
      */
     public static int getAnimationTicks(double animationDuration, int serverTickTime)
     {
-        return (int) Math.min(Integer.MAX_VALUE, Math.round(1000 * animationDuration / serverTickTime));
+        return (int) Math.min(Integer.MAX_VALUE, Math.round(1_000 * animationDuration / serverTickTime));
     }
 }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/moveblocks/Animator.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/moveblocks/Animator.java
@@ -45,9 +45,9 @@ public final class Animator implements IAnimator
     private static final int START_DELAY = 700;
 
     /**
-     * The delay (in ticks) before verifying the redstone state after the animation has ended.
+     * The delay (in milliseconds) before verifying the redstone state after the animation has ended.
      */
-    private static final long VERIFY_REDSTONE_DELAY = 20;
+    private static final long VERIFY_REDSTONE_DELAY = 1_000L;
 
     /**
      * The structure whose blocks are going to be moved.
@@ -473,25 +473,16 @@ public final class Animator implements IAnimator
         forEachHook("onPrepare", IAnimationHook::onPrepare);
 
         final int stopCount = getStopCount();
-        final int initialDelay = Math.round((float) START_DELAY / serverTickTime);
 
         final TimerTask moverTask0 = new TimerTask()
         {
             private int counter = 0;
-            private @Nullable Long startTime = null; // Initialize on the first run.
-            private long currentTime = System.nanoTime();
 
             @Override
             public void run()
             {
-                if (startTime == null)
-                    startTime = System.nanoTime();
                 forEachHook("onPreAnimationStep", IAnimationHook::onPreAnimationStep);
                 ++counter;
-
-                final long lastTime = currentTime;
-                currentTime = System.nanoTime();
-                startTime += currentTime - lastTime;
 
                 if (perpetualMovement || counter <= animationDuration)
                     executeAnimationStep(counter, animation);
@@ -505,7 +496,7 @@ public final class Animator implements IAnimator
             }
         };
         moverTask = moverTask0;
-        moverTaskID = executor.runAsyncRepeated(moverTask0, initialDelay, 1);
+        moverTaskID = executor.runAsyncRepeated(moverTask0, START_DELAY, this.serverTickTime);
     }
 
     private void putBlocks0()

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/moveblocks/StructureActivityManager.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/moveblocks/StructureActivityManager.java
@@ -40,6 +40,13 @@ import java.util.stream.Stream;
 @Flogger
 public final class StructureActivityManager extends Restartable implements StructureDeletionManager.IDeletionListener
 {
+    /**
+     * The amount of time (in milliseconds) to wait when performing a delayed redstone check.
+     * <p>
+     * This is used to verify the redstone state after active animations were aborted for e.g. a shutdown.
+     */
+    private static final long DELAYED_REDSTONE_VERIFICATION_TIME = 1_000L;
+
     private final Map<Long, RegisteredAnimatorEntry> animators = new ConcurrentHashMap<>();
 
     private final IAnimatedArchitectureEventFactory eventFactory;
@@ -332,7 +339,8 @@ public final class StructureActivityManager extends Restartable implements Struc
 
     private void delayedRedstoneVerification(List<AbstractStructure> lst)
     {
-        executor.runAsyncLater(() -> lst.forEach(AbstractStructure::verifyRedstoneState), 40L);
+        executor.runAsyncLater(
+            () -> lst.forEach(AbstractStructure::verifyRedstoneState), DELAYED_REDSTONE_VERIFICATION_TIME);
     }
 
     @GuardedBy("this")

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Constants.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Constants.java
@@ -18,19 +18,13 @@ public final class Constants
     /**
      * The amount of time (in ms) a user gets to complete a command waiter.
      */
-    public static final int COMMAND_WAITER_TIMEOUT = 60 * 1000;
+    public static final int COMMAND_WAITER_TIMEOUT = 60_000;
 
     /**
      * Whether the current build is a dev build. Certain options are enabled, disabled, or overridden depending on this
      * variable.
      */
     public static final boolean DEV_BUILD = true;
-
-    /**
-     * Minimum number of ticks a structure needs to cool down before it can be toggled again. This should help with some
-     * rare cases of overlapping processes and whatnot.
-     */
-    public static final int MINIMUM_STRUCTURE_DELAY = 10;
 
     /**
      * The name of this plugin.
@@ -43,9 +37,9 @@ public final class Constants
     public static final String ANIMATE_ARCHITECTURE_EXTENSIONS_FOLDER_NAME = "extensions";
 
     /**
-     * The amount of time (in seconds) a user has to complete the structure creation process.
+     * The amount of time (in milliseconds) a user has to complete the structure creation process.
      */
-    public static final int STRUCTURE_CREATOR_TIME_LIMIT = 120 * 20;
+    public static final int STRUCTURE_CREATOR_TIME_LIMIT = 180_000; // 3 minutes
 
     /**
      * The prefix for the {@link StructureAttribute}-specific bypass permissions.

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/listeners/ChunkListener.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/listeners/ChunkListener.java
@@ -37,9 +37,9 @@ import java.util.concurrent.CompletableFuture;
 public class ChunkListener extends AbstractListener
 {
     /**
-     * Add a delay to give the chunks surrounding the structure a chance to load as well.
+     * Add a delay (in milliseconds) to give the chunks surrounding the structure a chance to load as well.
      */
-    private static final int PROCESS_LOAD_DELAY = 40;
+    private static final int PROCESS_LOAD_DELAY = 2_000;
 
     private final DatabaseManager databaseManager;
     private final PowerBlockManager powerBlockManager;

--- a/animatedarchitecture-spigot/spigot-util/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/util/implementations/ExecutorSpigot.java
+++ b/animatedarchitecture-spigot/spigot-util/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/util/implementations/ExecutorSpigot.java
@@ -66,13 +66,18 @@ public final class ExecutorSpigot implements IExecutor
         return Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, runnable, 0);
     }
 
+    private static long toTicks(long milliseconds)
+    {
+        return Math.round(milliseconds / 50D);
+    }
+
     @Override
     public int runAsyncRepeated(TimerTask timerTask, long delay, long period)
     {
         // This is deprecated only because the name is supposedly confusing
         // (one might read it as scheduling "a sync" task).
         //noinspection deprecation
-        return Bukkit.getScheduler().scheduleAsyncRepeatingTask(plugin, timerTask, delay, period);
+        return Bukkit.getScheduler().scheduleAsyncRepeatingTask(plugin, timerTask, toTicks(delay), toTicks(period));
     }
 
     @Override
@@ -81,43 +86,43 @@ public final class ExecutorSpigot implements IExecutor
         // This is deprecated only because the name is supposedly confusing
         // (one might read it as scheduling "a sync" task).
         //noinspection deprecation
-        return Bukkit.getScheduler().scheduleAsyncRepeatingTask(plugin, runnable, delay, period);
+        return Bukkit.getScheduler().scheduleAsyncRepeatingTask(plugin, runnable, toTicks(delay), toTicks(period));
     }
 
     @Override
     public int runSyncRepeated(TimerTask timerTask, long delay, long period)
     {
-        return Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, timerTask, delay, period);
+        return Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, timerTask, toTicks(delay), toTicks(period));
     }
 
     @Override
     public int runSyncRepeated(Runnable runnable, long delay, long period)
     {
-        return Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, runnable, delay, period);
+        return Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, runnable, toTicks(delay), toTicks(period));
     }
 
     @Override
     public void runAsyncLater(TimerTask runnable, long delay)
     {
-        Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, runnable, delay);
+        Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, runnable, toTicks(delay));
     }
 
     @Override
     public void runAsyncLater(Runnable runnable, long delay)
     {
-        Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, runnable, delay);
+        Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, runnable, toTicks(delay));
     }
 
     @Override
     public void runSyncLater(TimerTask timerTask, long delay)
     {
-        Bukkit.getScheduler().runTaskLater(plugin, timerTask, delay);
+        Bukkit.getScheduler().runTaskLater(plugin, timerTask, toTicks(delay));
     }
 
     @Override
     public void runSyncLater(Runnable runnable, long delay)
     {
-        Bukkit.getScheduler().runTaskLater(plugin, runnable, delay);
+        Bukkit.getScheduler().runTaskLater(plugin, runnable, toTicks(delay));
     }
 
     @Override

--- a/animatedarchitecture-spigot/spigot-util/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/util/implementations/GlowingBlockSpawnerSpigot.java
+++ b/animatedarchitecture-spigot/spigot-util/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/util/implementations/GlowingBlockSpawnerSpigot.java
@@ -74,7 +74,7 @@ public class GlowingBlockSpawnerSpigot extends GlowingBlockSpawner implements IR
             return Optional.empty();
         }
 
-        final @Nullable Long ticks = duration == null ? null : SpigotUtil.durationToTicks(duration);
+        final @Nullable Long time = duration == null ? null : Math.max(50, duration.toMillis());
 
         final @Nullable Player spigotPlayer = SpigotAdapter.getBukkitPlayer(player);
         if (spigotPlayer == null)
@@ -94,13 +94,13 @@ public class GlowingBlockSpawnerSpigot extends GlowingBlockSpawner implements IR
 
         final Optional<IGlowingBlock> blockOpt =
             glowingBlockFactory.createGlowingBlock(spigotPlayer, spigotWorld, color, x, y, z, teams);
-        blockOpt.ifPresent(block -> onBlockSpawn(block, ticks));
+        blockOpt.ifPresent(block -> onBlockSpawn(block, time));
         return blockOpt;
     }
 
-    private void onBlockSpawn(IGlowingBlock block, @Nullable Long ticks)
+    private void onBlockSpawn(IGlowingBlock block, @Nullable Long time)
     {
-        if (ticks == null)
+        if (time == null)
             spawnedBlocks.put(block, null);
         else
         {
@@ -113,7 +113,7 @@ public class GlowingBlockSpawnerSpigot extends GlowingBlockSpawner implements IR
                     spawnedBlocks.remove(block);
                 }
             };
-            executor.runAsyncLater(killTask, ticks);
+            executor.runAsyncLater(killTask, time);
             spawnedBlocks.put(block, killTask);
         }
     }


### PR DESCRIPTION
- The IExecutor methods now use milliseconds instead of ticks when scheduling tasks.