### PR TITLE
Fix incorrect sliding door animation

### DIFF
--- a/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/animatedarchitecture/structures/slidingdoor/SlidingDoorAnimationComponent.java
+++ b/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/animatedarchitecture/structures/slidingdoor/SlidingDoorAnimationComponent.java
@@ -37,15 +37,19 @@ public class SlidingDoorAnimationComponent implements IAnimationComponent
         this.snapshot = data.getStructureSnapshot();
         this.blocksToMove = blocksToMove;
 
+        int blocksToMove0 = Math.abs(blocksToMove);
+        if (movementDirection.equals(MovementDirection.NORTH) || movementDirection.equals(MovementDirection.WEST))
+            blocksToMove0 = -blocksToMove0;
+
         northSouth =
             movementDirection.equals(MovementDirection.NORTH) || movementDirection.equals(MovementDirection.SOUTH);
 
-        moveX = northSouth ? 0 : blocksToMove;
-        moveZ = northSouth ? blocksToMove : 0;
+        moveX = northSouth ? 0 : blocksToMove0;
+        moveZ = northSouth ? blocksToMove0 : 0;
 
         final double animationDuration =
             AnimationUtil.getAnimationTicks(data.getAnimationTime(), data.getServerTickTime());
-        step = blocksToMove / animationDuration;
+        step = blocksToMove0 / animationDuration;
     }
 
     @Override


### PR DESCRIPTION
- The direction of the sliding door's animation was always towards posivitve values. The blocks were also placed at the final position. However, when the structure was supposed to move in the other direction, it would still move the blocks in the positive direction, but update it to the negative direction.