### PR TITLE
Avoid potentially blocking main thread

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/IExecutor.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/IExecutor.java
@@ -39,6 +39,25 @@ public interface IExecutor
     }
 
     /**
+     * Ensures a runnable is run on the main thread.
+     * <p>
+     * When called from the main thread, it will be executed immediately. When called from another thread, the supplier
+     * is scheduled to run on the next tick of the main thread instead.
+     *
+     * @return The CompletableFuture that is completed when the runnable has finished running.
+     */
+    default CompletableFuture<Void> runOnMainThreadWithResponse(Runnable runnable)
+    {
+        return runOnMainThread(
+            () ->
+            {
+                runnable.run();
+                //noinspection DataFlowIssue
+                return null;
+            });
+    }
+
+    /**
      * Schedules an action to be run on the main thread.
      */
     void scheduleOnMainThread(Runnable runnable);


### PR DESCRIPTION
When an animation finishes, it needs to place the blocks in the final position and then (for read-write animations) update the coordinates of the structure under a write lock. Acquiring the write lock will block the thread if any other threads already have any read/write locks on the structure.

We want to avoid running blocking operations on the main thread, so we now execute only the block placement on the main thread and update the coordinates asynchronously.