### PR TITLE
Improve StructureTypeRegistry

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/audio/AudioConfigurator.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/audio/AudioConfigurator.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Represents a class used to read and access the audio configuration.
@@ -119,12 +120,19 @@ public final class AudioConfigurator implements IRestartable, IDebuggable
     private Map<StructureType, @Nullable AudioSet> mergeMaps(
         Map<String, @Nullable AudioSet> parsed, Map<StructureType, @Nullable AudioSet> defaults)
     {
+        final Map<String, StructureType> types = structureTypeManager
+            .getEnabledStructureTypes().stream()
+            .collect(Collectors.toMap(StructureType::getSimpleName, type -> type));
+
         final LinkedHashMap<StructureType, @Nullable AudioSet> merged = new LinkedHashMap<>(defaults);
         for (final Map.Entry<String, @Nullable AudioSet> entry : parsed.entrySet())
         {
             if (KEY_DEFAULT.equals(entry.getKey()))
                 continue;
-            structureTypeManager.getStructureType(entry.getKey()).ifPresent(type -> merged.put(type, entry.getValue()));
+
+            final @Nullable StructureType type = types.get(entry.getKey());
+            if (type != null)
+                merged.put(type, entry.getValue());
         }
         return merged;
     }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoader.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoader.java
@@ -3,11 +3,11 @@ package nl.pim16aap2.animatedarchitecture.core.extensions;
 import com.google.common.flogger.StackSize;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.animatedarchitecture.core.api.IConfig;
-import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
-import nl.pim16aap2.animatedarchitecture.core.util.Constants;
 import nl.pim16aap2.animatedarchitecture.core.api.restartable.Restartable;
 import nl.pim16aap2.animatedarchitecture.core.api.restartable.RestartableHolder;
 import nl.pim16aap2.animatedarchitecture.core.managers.StructureTypeManager;
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
+import nl.pim16aap2.animatedarchitecture.core.util.Constants;
 import nl.pim16aap2.animatedarchitecture.core.util.Util;
 import org.jetbrains.annotations.Nullable;
 
@@ -208,7 +208,7 @@ public final class StructureTypeLoader extends Restartable
         final List<StructureType> types =
             new StructureTypeInitializer(typeInfoList, structureTypeClassLoader, config.debug()).loadStructureTypes();
 
-        structureTypeManager.registerStructureTypes(types);
+        structureTypeManager.register(types);
         return types;
     }
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/managers/StructureTypeManager.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/managers/StructureTypeManager.java
@@ -1,8 +1,8 @@
 package nl.pim16aap2.animatedarchitecture.core.managers;
 
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import lombok.Getter;
-import lombok.Value;
-import lombok.experimental.NonFinal;
+import lombok.experimental.Locked;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.animatedarchitecture.core.api.debugging.DebuggableRegistry;
 import nl.pim16aap2.animatedarchitecture.core.api.debugging.IDebuggable;
@@ -11,35 +11,98 @@ import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
 import nl.pim16aap2.util.SafeStringBuilder;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * This class manages all {@link StructureType}s. Before a type can be used, it will have to be registered here.
- *
- * @author Pim
+ * <p>
+ * Structure types can be enabled and disabled. When a type is disabled, it will not be available for use, but it is
+ * still registered and can still be used by other types that may depend on it.
  */
-@SuppressWarnings("unused")
 @Singleton
 @Flogger
+@ThreadSafe
 public final class StructureTypeManager implements IDebuggable
 {
     private static final boolean DEFAULT_IS_ENABLED = true;
 
-    private final Map<StructureType, StructureRegistrationStatus> structureTypeStatus = new ConcurrentHashMap<>();
-    private final Map<String, StructureType> structureTypeFromName = new ConcurrentHashMap<>();
-    private final Map<String, StructureType> structureTypeFromFullName = new ConcurrentHashMap<>();
     private final LocalizationManager localizationManager;
+
+    /**
+     * Private, modifiable list of all {@link StructureType}s that are currently enabled.
+     */
+    @GuardedBy("lock")
+    private final List<StructureType> enabledStructureTypes0 = new ArrayList<>()
+    {
+        @Override
+        public boolean add(StructureType structureType)
+        {
+            super.add(structureType);
+            enabledStructureTypes0.sort(Comparator.comparing(StructureType::getSimpleName));
+            return true;
+        }
+    };
+
+    /**
+     * Private, modifiable list of all {@link StructureType}s that are currently disabled.
+     */
+    @GuardedBy("lock")
+    private final List<StructureType> disabledStructureTypes0 = new ArrayList<>()
+    {
+        @Override
+        public boolean add(StructureType structureType)
+        {
+            super.add(structureType);
+            disabledStructureTypes0.sort(Comparator.comparing(StructureType::getSimpleName));
+            return true;
+        }
+    };
+
+    /**
+     * Gets all {@link StructureType}s that are currently enabled.
+     *
+     * @return All {@link StructureType}s that are currently enabled.
+     */
+    @Getter
+    private final List<StructureType> enabledStructureTypes = Collections.unmodifiableList(enabledStructureTypes0);
+
+    /**
+     * Gets all {@link StructureType}s that are currently disabled.
+     *
+     * @return All {@link StructureType}s that are currently disabled.
+     */
+    @Getter
+    private final List<StructureType> disabledStructureTypes = Collections.unmodifiableList(disabledStructureTypes0);
+
+    /**
+     * Private, modifiable map of all {@link StructureType}s that are currently registered and whether they are
+     * enabled.
+     */
+    @GuardedBy("lock")
+    private final Map<StructureType, Boolean> registeredStructureTypes0 = new IdentityHashMap<>();
+
+    /**
+     * Gets all {@link StructureType}s that are currently registered.
+     *
+     * @return All {@link StructureType}s that are currently registered.
+     */
+    @Getter
+    private final Set<StructureType> registeredStructureTypes = Collections.unmodifiableSet(
+        registeredStructureTypes0.keySet());
+
+    @GuardedBy("lock")
+    private final Map<String, StructureType> structureTypeFromFullName = new HashMap<>();
 
     @Inject
     public StructureTypeManager(DebuggableRegistry debuggableRegistry, LocalizationManager localizationManager)
@@ -49,83 +112,16 @@ public final class StructureTypeManager implements IDebuggable
     }
 
     /**
-     * All registered AND enabled {@link StructureType}s.
-     */
-    @Getter
-    private final List<StructureType> sortedStructureTypes = new CopyOnWriteArrayList<>()
-    {
-        @Override
-        public boolean add(StructureType structureType)
-        {
-            super.add(structureType);
-            sortedStructureTypes.sort(Comparator.comparing(StructureType::getSimpleName));
-            return true;
-        }
-    };
-
-    /**
-     * Gets all {@link StructureType}s that are currently registered.
-     *
-     * @return All {@link StructureType}s that are currently registered.
-     */
-    public Set<StructureType> getRegisteredStructureTypes()
-    {
-        return Collections.unmodifiableSet(structureTypeStatus.keySet());
-    }
-
-    private List<StructureType> getStructureTypesWithStatus(boolean status)
-    {
-        final List<StructureType> enabledStructureTypes = new ArrayList<>();
-        for (final Map.Entry<StructureType, StructureRegistrationStatus> structureType : structureTypeStatus.entrySet())
-            if (structureType.getValue().status == status)
-                enabledStructureTypes.add(structureType.getKey());
-        enabledStructureTypes.sort(Comparator.comparing(StructureType::getSimpleName));
-        return enabledStructureTypes;
-    }
-
-    /**
-     * Gets all {@link StructureType}s that are currently enabled.
-     *
-     * @return All {@link StructureType}s that are currently enabled.
-     */
-    public List<StructureType> getEnabledStructureTypes()
-    {
-        return getStructureTypesWithStatus(true);
-    }
-
-    /**
-     * Gets all {@link StructureType}s that are currently disabled.
-     *
-     * @return All {@link StructureType}s that are currently disabled.
-     */
-    public List<StructureType> getDisabledStructureTypes()
-    {
-        return getStructureTypesWithStatus(false);
-    }
-
-    /**
      * Checks if an {@link StructureType} is enabled.
      *
      * @param structureType
      *     The {@link StructureType} to check.
      * @return True if the {@link StructureType} is enabled, otherwise false.
      */
+    @Locked.Read
     public boolean isRegistered(StructureType structureType)
     {
-        return structureTypeStatus.containsKey(structureType);
-    }
-
-    /**
-     * Tries to get a {@link StructureType} from it name as defined by {@link StructureType#getSimpleName()}. This
-     * method is case-insensitive.
-     *
-     * @param typeName
-     *     The name of the type.
-     * @return The {@link StructureType} to retrieve, if possible.
-     */
-    public Optional<StructureType> getStructureType(String typeName)
-    {
-        return Optional.ofNullable(structureTypeFromName.get(typeName.toLowerCase(Locale.ENGLISH)));
+        return registeredStructureTypes0.containsKey(structureType);
     }
 
     /**
@@ -136,7 +132,8 @@ public final class StructureTypeManager implements IDebuggable
      *     The fully qualified name of the type.
      * @return The {@link StructureType} to retrieve, if possible.
      */
-    public Optional<StructureType> getStructureTypeFromFullName(@Nullable String fullName)
+    @Locked.Read
+    public Optional<StructureType> getFromFullName(@Nullable String fullName)
     {
         if (fullName == null)
             return Optional.empty();
@@ -153,22 +150,36 @@ public final class StructureTypeManager implements IDebuggable
      *     The {@link StructureType} to check.
      * @return True if this {@link StructureType} is both registered and enabled.
      */
+    @Locked.Read
     public boolean isStructureTypeEnabled(StructureType structureType)
     {
-        final @Nullable StructureTypeManager.StructureRegistrationStatus info = structureTypeStatus.get(structureType);
-        return info != null && info.status;
+        final @Nullable Boolean result = registeredStructureTypes0.get(structureType);
+        return result != null && result;
     }
 
-    private void registerStructureType0(StructureType structureType, boolean isEnabled)
+    @GuardedBy("lock")
+    private void register0(StructureType structureType, boolean isEnabled)
     {
-        log.atInfo().log("Registering structure type: %s...", structureType.getFullNameWithVersion());
+        log.atInfo()
+           .log("Registering structure type: '%s'. Enabled: %s", structureType.getFullNameWithVersion(), isEnabled);
 
-        structureTypeStatus.put(structureType, new StructureRegistrationStatus(structureType.getFullName(), isEnabled));
-        structureTypeFromName.put(structureType.getSimpleName(), structureType);
+        final @Nullable Boolean result = registeredStructureTypes0.put(structureType, isEnabled);
+        if (result != null && result == isEnabled)
+            return;
+
+        final var from = isEnabled ? disabledStructureTypes0 : enabledStructureTypes0;
+        final var to = isEnabled ? enabledStructureTypes0 : disabledStructureTypes0;
+
+        to.add(structureType);
+
+        // If the structure type was already registered, we only need to remove it from the other list.
+        if (result != null)
+        {
+            from.remove(structureType);
+            return;
+        }
+
         structureTypeFromFullName.put(structureType.getFullName(), structureType);
-
-        if (isEnabled)
-            sortedStructureTypes.add(structureType);
     }
 
     /**
@@ -179,7 +190,8 @@ public final class StructureTypeManager implements IDebuggable
      * @param types
      *     The type(s) to register with the localization manager.
      */
-    private void registerTypeWithLocalizer(List<StructureType> types)
+    @GuardedBy("lock")
+    private void registerWithLocalizer(List<StructureType> types)
     {
         if (types.isEmpty())
             return;
@@ -195,9 +207,24 @@ public final class StructureTypeManager implements IDebuggable
      * @param structureType
      *     The {@link StructureType} to register.
      */
-    public void registerStructureType(StructureType structureType)
+    @Locked.Write
+    public void register(StructureType structureType)
     {
-        registerStructureType(structureType, DEFAULT_IS_ENABLED);
+        register(structureType, DEFAULT_IS_ENABLED);
+    }
+
+    /**
+     * Enables or disables a {@link StructureType}.
+     *
+     * @param structureType
+     *     The {@link StructureType} to enable or disable.
+     * @param isEnabled
+     *     Whether this {@link StructureType} should be enabled or not.
+     */
+    @Locked.Write
+    public void setEnabledState(StructureType structureType, boolean isEnabled)
+    {
+        register0(structureType, isEnabled);
     }
 
     /**
@@ -208,94 +235,40 @@ public final class StructureTypeManager implements IDebuggable
      * @param isEnabled
      *     Whether this {@link StructureType} should be enabled or not. Default = true.
      */
-    public void registerStructureType(StructureType structureType, boolean isEnabled)
+    @Locked.Write
+    public void register(StructureType structureType, boolean isEnabled)
     {
-        registerTypeWithLocalizer(List.of(structureType));
-        registerStructureType0(structureType, isEnabled);
+        registerWithLocalizer(List.of(structureType));
+        register0(structureType, isEnabled);
     }
 
     /**
-     * Unregisters a structure type. Note that it does <b>NOT</b> remove it or its structures from the database and that
-     * after unregistering it, that won't be possible anymore either.
-     * <p>
-     * Once unregistered, this type will be completely disabled and structures of this type cannot be used for
-     * anything.
-     *
-     * @param structureType
-     *     The type to unregister.
-     */
-    public void unregisterStructureType(StructureType structureType)
-    {
-        if (structureTypeStatus.remove(structureType) == null)
-        {
-            log.atWarning().log("Trying to unregister structure of type: %s, but it isn't registered already!",
-                                structureType.getSimpleName());
-            return;
-        }
-        structureTypeFromName.remove(structureType.getSimpleName());
-        structureTypeFromFullName.remove(structureType.getFullName());
-        sortedStructureTypes.remove(structureType);
-    }
-
-    /**
-     * Changes the status of a {@link StructureType}. If disabled, this type cannot be toggled or created.
-     *
-     * @param structureType
-     *     The {@link StructureType} to enabled or disable.
-     * @param isEnabled
-     *     True to enable this {@link StructureType} (default), or false to disable it.
-     */
-    @SuppressWarnings("unused")
-    public void setStructureTypeEnabled(StructureType structureType, boolean isEnabled)
-    {
-        final @Nullable StructureTypeManager.StructureRegistrationStatus info = structureTypeStatus.get(structureType);
-        if (info != null)
-        {
-            info.status = isEnabled;
-            if (!isEnabled)
-                sortedStructureTypes.remove(structureType);
-        }
-    }
-
-    /**
-     * Registers a list of {@link StructureType}s. See {@link #registerStructureType(StructureType)}.
+     * Registers a list of {@link StructureType}s. See {@link #register(StructureType)}.
      *
      * @param structureTypes
      *     The list of {@link StructureType}s to register.
      */
-    public void registerStructureTypes(List<StructureType> structureTypes)
+    @Locked.Write
+    public void register(List<StructureType> structureTypes)
     {
-        registerTypeWithLocalizer(structureTypes);
-        structureTypes.forEach(structureType -> registerStructureType0(structureType, DEFAULT_IS_ENABLED));
+        registerWithLocalizer(structureTypes);
+        structureTypes.forEach(structureType -> register0(structureType, DEFAULT_IS_ENABLED));
     }
 
     @Override
+    @Locked.Read
     public String getDebugInformation()
     {
         final SafeStringBuilder sb = new SafeStringBuilder("Registered structure types:\n");
-        for (final Map.Entry<StructureType, StructureRegistrationStatus> entry : structureTypeStatus.entrySet())
-        {
-            final StructureType structureType = entry.getKey();
-            sb.append("- ").append(structureType::toString).append(": ");
-            if (!entry.getValue().status)
-                sb.append("DISABLED");
-            else
-                sb.append("\n").appendIndented(2, structureType::getStructureSerializer);
-            sb.append('\n');
-        }
-        return sb.toString();
-    }
 
-    /**
-     * Describes the full name and the enabled status of a {@link StructureType}.
-     *
-     * @author Pim
-     */
-    @Value
-    private static class StructureRegistrationStatus
-    {
-        String fullName;
-        @NonFinal
-        boolean status;
+        sb.append("* Enabled:\n");
+        for (final StructureType structureType : enabledStructureTypes)
+            sb.append("  - ").append(structureType).append('\n');
+
+        sb.append("* Disabled:\n");
+        for (final StructureType structureType : disabledStructureTypes)
+            sb.append("  - ").append(structureType).append('\n');
+
+        return sb.toString();
     }
 }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/storage/sqlite/SQLiteJDBCDriverConnection.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/storage/sqlite/SQLiteJDBCDriverConnection.java
@@ -305,8 +305,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
         throws Exception
     {
         final @Nullable String structureTypeResult = structureBaseRS.getString("type");
-        final Optional<StructureType> structureType = structureTypeManager.getStructureTypeFromFullName(
-            structureTypeResult);
+        final Optional<StructureType> structureType = structureTypeManager.getFromFullName(structureTypeResult);
 
         if (!structureType.map(structureTypeManager::isRegistered).orElse(false))
         {
@@ -395,7 +394,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
                                       .setNextString(structureType.getFullName())) > 0, false);
 
         if (removed)
-            structureTypeManager.unregisterStructureType(structureType);
+            structureTypeManager.setEnabledState(structureType, false);
         return removed;
     }
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureType.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureType.java
@@ -81,7 +81,7 @@ public abstract class StructureType
 
     /**
      * Constructs a new {@link StructureType}. Don't forget to also register it using
-     * {@link StructureTypeManager#registerStructureType(StructureType)}.
+     * {@link StructureTypeManager#register(StructureType)}.
      *
      * @param pluginName
      *     The name of the plugin that owns this {@link StructureType}.
@@ -101,7 +101,7 @@ public abstract class StructureType
             validOpenDirections.isEmpty() ? EnumSet.noneOf(MovementDirection.class) :
             EnumSet.copyOf(validOpenDirections);
         this.localizationKey = localizationKey;
-        this.fullName = String.format("%s:%s", getPluginName(), getSimpleName()).toLowerCase(Locale.ENGLISH);
+        this.fullName = formatFullName(getPluginName(), getSimpleName());
         this.fullNameWithVersion = fullName + ":" + version;
 
         lazyStructureSerializer = new LazyValue<>(() -> new StructureSerializer<>(this));
@@ -166,6 +166,20 @@ public abstract class StructureType
     public @Nullable AudioSet getAudioSet()
     {
         return null;
+    }
+
+    /**
+     * Formats the given pluginName and simpleName into a fully-qualified name.
+     *
+     * @param pluginName
+     *     The name of the plugin that owns this {@link StructureType}.
+     * @param simpleName
+     *     The 'simple' name of this {@link StructureType}. E.g. "Flag", or "Windmill".
+     * @return The fully-qualified name of this {@link StructureType} formatted as
+     */
+    public static String formatFullName(String pluginName, String simpleName)
+    {
+        return String.format("%s:%s", pluginName, simpleName).toLowerCase(Locale.ENGLISH);
     }
 
     @Override

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/audio/AudioConfiguratorTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/audio/AudioConfiguratorTest.java
@@ -1,9 +1,9 @@
 package nl.pim16aap2.animatedarchitecture.core.audio;
 
 import nl.pim16aap2.animatedarchitecture.core.api.debugging.DebuggableRegistry;
-import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
-import nl.pim16aap2.animatedarchitecture.core.managers.StructureTypeManager;
 import nl.pim16aap2.animatedarchitecture.core.api.restartable.RestartableHolder;
+import nl.pim16aap2.animatedarchitecture.core.managers.StructureTypeManager;
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Set;
 
 class AudioConfiguratorTest
 {
@@ -38,12 +38,12 @@ class AudioConfiguratorTest
     static final String KEY_4 = "type_4";
     static final String KEY_5 = "type_5";
 
-    static final StructureType TYPE_0 = newDoorType(KEY_0);
-    static final StructureType TYPE_1 = newDoorType(KEY_1);
-    static final StructureType TYPE_2 = newDoorType(KEY_2);
-    static final StructureType TYPE_3 = newDoorType(KEY_3);
-    static final StructureType TYPE_4 = newDoorType(KEY_4);
-    static final StructureType TYPE_5 = newDoorType(KEY_5);
+    static final StructureType TYPE_0 = newStructureType(KEY_0);
+    static final StructureType TYPE_1 = newStructureType(KEY_1);
+    static final StructureType TYPE_2 = newStructureType(KEY_2);
+    static final StructureType TYPE_3 = newStructureType(KEY_3);
+    static final StructureType TYPE_4 = newStructureType(KEY_4);
+    static final StructureType TYPE_5 = newStructureType(KEY_5);
 
     @Mock
     AudioConfigIO audioConfigIO;
@@ -52,23 +52,14 @@ class AudioConfiguratorTest
     @Mock
     DebuggableRegistry debuggableRegistry;
     @Mock
-    StructureTypeManager doorTypeManager;
+    StructureTypeManager structureTypeManager;
 
     @BeforeEach
     void init()
     {
         MockitoAnnotations.openMocks(this);
-        Mockito.when(doorTypeManager.getStructureType(Mockito.anyString())).thenAnswer(
-            invocation -> switch (invocation.getArgument(0, String.class))
-                {
-                    case KEY_0 -> Optional.of(TYPE_0);
-                    case KEY_1 -> Optional.of(TYPE_1);
-                    case KEY_2 -> Optional.of(TYPE_2);
-                    case KEY_3 -> Optional.of(TYPE_3);
-                    case KEY_4 -> Optional.of(TYPE_4);
-                    case KEY_5 -> Optional.of(TYPE_5);
-                    default -> Optional.empty();
-                });
+        Mockito.when(structureTypeManager.getRegisteredStructureTypes())
+               .thenReturn(Set.of(TYPE_0, TYPE_1, TYPE_2, TYPE_3, TYPE_4, TYPE_5));
     }
 
     @SuppressWarnings("ConstantConditions") @Test
@@ -88,9 +79,9 @@ class AudioConfiguratorTest
         parsed.put(KEY_4, null); // Null for both
 
         final AudioConfigurator configurator = new AudioConfigurator(audioConfigIO, restartableHolder,
-                                                                     debuggableRegistry, doorTypeManager);
+                                                                     debuggableRegistry, structureTypeManager);
         Mockito.when(audioConfigIO.readConfig()).thenReturn(parsed);
-        Mockito.when(doorTypeManager.getEnabledStructureTypes())
+        Mockito.when(structureTypeManager.getEnabledStructureTypes())
                .thenReturn(List.of(TYPE_0, TYPE_1, TYPE_2, TYPE_3, TYPE_4, TYPE_5));
 
         final AudioConfigurator.ConfigData configData = configurator.generateConfigData();
@@ -111,7 +102,7 @@ class AudioConfiguratorTest
     void getFinalMap()
     {
         final AudioConfigurator configurator = new AudioConfigurator(audioConfigIO, restartableHolder,
-                                                                     debuggableRegistry, doorTypeManager);
+                                                                     debuggableRegistry, structureTypeManager);
 
         final Map<StructureType, @Nullable AudioSet> merged = new LinkedHashMap<>();
         merged.put(TYPE_0, SET_0);
@@ -128,10 +119,10 @@ class AudioConfiguratorTest
         Assertions.assertEquals(List.of(SET_0, SET_1, SET_EMPTY), new ArrayList<>(result.values()));
     }
 
-    private static StructureType newDoorType(String simpleName)
+    private static StructureType newStructureType(String simpleName)
     {
-        final StructureType doorType = Mockito.mock(StructureType.class);
-        Mockito.when(doorType.getSimpleName()).thenReturn(simpleName);
-        return doorType;
+        final StructureType structureType = Mockito.mock(StructureType.class);
+        Mockito.when(structureType.getSimpleName()).thenReturn(simpleName);
+        return structureType;
     }
 }

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/managers/StructureTypeManagerTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/managers/StructureTypeManagerTest.java
@@ -1,0 +1,82 @@
+package nl.pim16aap2.animatedarchitecture.core.managers;
+
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.Locale;
+
+class StructureTypeManagerTest
+{
+    private final StructureType type0 = newMockedStructureType("TestType0");
+    private final StructureType type1 = newMockedStructureType("TestType1");
+    private final StructureType type2 = newMockedStructureType("TestType2");
+    private final StructureType type3 = newMockedStructureType("TestType3");
+
+    @Test
+    void testRegistry()
+    {
+        final var manager = new StructureTypeManager(Mockito.mock(), Mockito.mock());
+        manager.register(type0, true);
+        manager.register(type1);
+        manager.register(type2, false);
+
+        Assertions.assertTrue(manager.isRegistered(type0));
+        Assertions.assertTrue(manager.isRegistered(type1));
+        Assertions.assertTrue(manager.isRegistered(type2));
+        Assertions.assertFalse(manager.isRegistered(type3));
+
+        Assertions.assertTrue(manager.isStructureTypeEnabled(type0));
+        Assertions.assertTrue(manager.isStructureTypeEnabled(type1));
+        Assertions.assertFalse(manager.isStructureTypeEnabled(type2));
+        Assertions.assertFalse(manager.isStructureTypeEnabled(type3));
+    }
+
+    @Test
+    void testUpdateEnabledStatus()
+    {
+        final var manager = new StructureTypeManager(Mockito.mock(), Mockito.mock());
+
+        manager.register(type0);
+        Assertions.assertTrue(manager.isStructureTypeEnabled(type0));
+        Assertions.assertEquals(1, manager.getEnabledStructureTypes().size());
+        Assertions.assertEquals(0, manager.getDisabledStructureTypes().size());
+
+        manager.setEnabledState(type0, false);
+        Assertions.assertFalse(manager.isStructureTypeEnabled(type0));
+        Assertions.assertEquals(0, manager.getEnabledStructureTypes().size());
+        Assertions.assertEquals(1, manager.getDisabledStructureTypes().size());
+
+        manager.setEnabledState(type0, true);
+        Assertions.assertTrue(manager.isStructureTypeEnabled(type0));
+        Assertions.assertEquals(1, manager.getEnabledStructureTypes().size());
+        Assertions.assertEquals(0, manager.getDisabledStructureTypes().size());
+
+        Assertions.assertEquals(1, manager.getRegisteredStructureTypes().size());
+    }
+
+    private static StructureType newMockedStructureType(String simpleName)
+    {
+        final String simpleName0 = simpleName.toLowerCase(Locale.ENGLISH);
+        final String pluginName = "AnimatedArchitecture";
+        final String fullName = String.format("%s:%s", pluginName, simpleName0).toLowerCase(Locale.ENGLISH);
+        final int version = 1;
+
+        final var structureType = Mockito.mock(StructureType.class);
+
+        Mockito.when(structureType.getPluginName()).thenReturn(pluginName);
+        Mockito.when(structureType.getSimpleName()).thenReturn(simpleName0);
+        Mockito.when(structureType.getVersion()).thenReturn(version);
+        Mockito.when(structureType.getLocalizationKey()).thenReturn("localization.key." + simpleName0);
+        Mockito.when(structureType.getFullName()).thenReturn(fullName);
+        Mockito.when(structureType.getFullNameWithVersion()).thenReturn(fullName + ":" + version);
+        Mockito.when(structureType.getValidOpenDirections()).thenReturn(Collections.emptySet());
+
+        Mockito.when(structureType.toString()).thenReturn(
+            "MockedStructureType[@" + Integer.toHexString(structureType.hashCode()) + "] " + fullName + ":" + version);
+
+        return structureType;
+    }
+}

--- a/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/core/storage/SQLiteJDBCDriverConnectionTest.java
+++ b/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/core/storage/SQLiteJDBCDriverConnectionTest.java
@@ -199,9 +199,9 @@ public class SQLiteJDBCDriverConnectionTest
 
     private void registerStructureTypes()
     {
-        structureTypeManager.registerStructureType(StructureTypeBigDoor.get());
-        structureTypeManager.registerStructureType(StructureTypePortcullis.get());
-        structureTypeManager.registerStructureType(StructureTypeDrawbridge.get());
+        structureTypeManager.register(StructureTypeBigDoor.get());
+        structureTypeManager.register(StructureTypePortcullis.get());
+        structureTypeManager.register(StructureTypeDrawbridge.get());
     }
 
     /**


### PR DESCRIPTION
- Use read/write locking on the entire registry for most accesses rather than having several synchronized collections. This ensures that the data in the registry is always consistent.
- Simplified the StructureTypeRegistry class a bi
- Get rid of the structureTypeFromName method/map. Any class that wants to use this functionality can do it themselves; there's no reason to burden the registry with this. The method to retrieve a type from its full name still exists because it makes more sense for the full names.
- There is (currently?) no way to actually get rid of existing structure instances, so the methods to unregister structure types have been removed.