### PR TITLE
Implement per-type permissions

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/IPermissionsManager.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/IPermissionsManager.java
@@ -1,6 +1,8 @@
 package nl.pim16aap2.animatedarchitecture.core.api;
 
+import nl.pim16aap2.animatedarchitecture.core.commands.ICommandSender;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
 
 import java.util.OptionalInt;
 
@@ -53,4 +55,15 @@ public interface IPermissionsManager
      * @return True if the player is a server operator on this server.
      */
     boolean isOp(IPlayer player);
+
+    /**
+     * Checks if the given command sender has permission to create a structure of the given type.
+     *
+     * @param sender
+     *     The command sender to check.
+     * @param type
+     *     The type of structure to check.
+     * @return True if the sender has permission to create a structure of the given type.
+     */
+    boolean hasPermissionToCreateStructure(ICommandSender sender, StructureType type);
 }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/CommandDefinition.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/CommandDefinition.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.animatedarchitecture.core.commands;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import nl.pim16aap2.animatedarchitecture.core.util.Constants;
 import nl.pim16aap2.animatedarchitecture.core.util.Util;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,134 +18,120 @@ import java.util.Optional;
 @EqualsAndHashCode
 public final class CommandDefinition
 {
-    /**
-     * The prefix of all permissions that a regular user should have access to for normal usage.
-     * <p>
-     * This will include stuff like creating new structures and managing structures that you own.
-     */
-    public static final String PREFIX_USER = "animatedarchitecture.user.";
-
-    /**
-     * The prefix of all permissions for admin-related actions.
-     * <p>
-     * This should include stuff like affecting server settings and managing structures owned by other players.
-     */
-    public static final String PREFIX_ADMIN = "animatedarchitecture.admin.";
-
     public static final CommandDefinition ADD_OWNER =
         new CommandDefinition("ADD_OWNER",
-                              PREFIX_USER + "addowner",
-                              PREFIX_ADMIN + "bypass.addowner");
+                              Constants.PERMISSION_PREFIX_USER + "addowner",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.addowner");
 
     public static final CommandDefinition MENU =
         new CommandDefinition("MENU",
-                              PREFIX_USER + "base",
-                              PREFIX_ADMIN + "bypass.menu");
+                              Constants.PERMISSION_PREFIX_USER + "base",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.menu");
 
     public static final CommandDefinition CANCEL =
         new CommandDefinition("CANCEL",
-                              PREFIX_USER + "base",
+                              Constants.PERMISSION_PREFIX_USER + "base",
                               null);
 
     public static final CommandDefinition CONFIRM =
         new CommandDefinition("CONFIRM",
-                              PREFIX_USER + "base",
+                              Constants.PERMISSION_PREFIX_USER + "base",
                               null);
 
     public static final CommandDefinition DEBUG =
         new CommandDefinition("DEBUG",
                               null,
-                              PREFIX_ADMIN + "debug");
+                              Constants.PERMISSION_PREFIX_ADMIN + "debug");
 
     public static final CommandDefinition DELETE =
         new CommandDefinition("DELETE",
-                              PREFIX_USER + "delete",
-                              PREFIX_ADMIN + "bypass.delete");
+                              Constants.PERMISSION_PREFIX_USER + "delete",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.delete");
 
     public static final CommandDefinition INFO =
         new CommandDefinition("INFO",
-                              PREFIX_USER + "info",
-                              PREFIX_ADMIN + "bypass.info");
+                              Constants.PERMISSION_PREFIX_USER + "info",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.info");
 
     public static final CommandDefinition INSPECT_POWER_BLOCK =
         new CommandDefinition("INSPECT_POWER_BLOCK",
-                              PREFIX_USER + "inspect",
-                              PREFIX_ADMIN + "bypass.inspect");
+                              Constants.PERMISSION_PREFIX_USER + "inspect",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.inspect");
 
     public static final CommandDefinition LIST_STRUCTURES =
         new CommandDefinition("LIST_STRUCTURES",
-                              PREFIX_USER + "liststructures",
-                              PREFIX_ADMIN + "bypass.liststructures");
+                              Constants.PERMISSION_PREFIX_USER + "liststructures",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.liststructures");
 
     public static final CommandDefinition LOCK =
         new CommandDefinition("LOCK",
-                              PREFIX_USER + "lock",
-                              PREFIX_ADMIN + "bypass.lock");
+                              Constants.PERMISSION_PREFIX_USER + "lock",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.lock");
 
     public static final CommandDefinition MOVE_POWER_BLOCK =
         new CommandDefinition("MOVE_POWER_BLOCK",
-                              PREFIX_USER + "movepowerblock",
-                              PREFIX_ADMIN + "bypass.movepowerblock");
+                              Constants.PERMISSION_PREFIX_USER + "movepowerblock",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.movepowerblock");
 
     public static final CommandDefinition NEW_STRUCTURE =
         new CommandDefinition("NEW_STRUCTURE",
-                              PREFIX_USER + "newstructure",
+                              Constants.PERMISSION_PREFIX_USER + "base",
                               null);
 
     public static final CommandDefinition REMOVE_OWNER =
         new CommandDefinition("REMOVE_OWNER",
-                              PREFIX_USER + "removeowner",
-                              PREFIX_ADMIN + "bypass.removeowner");
+                              Constants.PERMISSION_PREFIX_USER + "removeowner",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.removeowner");
 
     public static final CommandDefinition RESTART =
         new CommandDefinition("RESTART",
                               null,
-                              PREFIX_ADMIN + "restart");
+                              Constants.PERMISSION_PREFIX_ADMIN + "restart");
 
     public static final CommandDefinition SET_BLOCKS_TO_MOVE =
         new CommandDefinition("SET_BLOCKS_TO_MOVE",
-                              PREFIX_USER + "base",
-                              PREFIX_ADMIN + "bypass.setblockstomove");
+                              Constants.PERMISSION_PREFIX_USER + "base",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.setblockstomove");
 
     public static final CommandDefinition SET_NAME =
         new CommandDefinition("SET_NAME",
-                              PREFIX_USER + "setname",
+                              Constants.PERMISSION_PREFIX_USER + "setname",
                               null);
 
     public static final CommandDefinition SET_OPEN_STATUS =
         new CommandDefinition("SET_OPEN_STATUS",
-                              PREFIX_USER + "base",
-                              PREFIX_ADMIN + "bypass.setopenstatus");
+                              Constants.PERMISSION_PREFIX_USER + "base",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.setopenstatus");
 
     public static final CommandDefinition SET_OPEN_DIRECTION =
         new CommandDefinition("SET_OPEN_DIRECTION",
-                              PREFIX_USER + "base",
-                              PREFIX_ADMIN + "bypass.setrotation");
+                              Constants.PERMISSION_PREFIX_USER + "base",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.setrotation");
 
     public static final CommandDefinition SPECIFY =
         new CommandDefinition("SPECIFY",
-                              PREFIX_USER + "base",
+                              Constants.PERMISSION_PREFIX_USER + "base",
                               null);
 
     public static final CommandDefinition UPDATE_CREATOR =
         new CommandDefinition("UPDATE_CREATOR",
-                              PREFIX_USER + "base",
+                              Constants.PERMISSION_PREFIX_USER + "base",
                               null);
 
     public static final CommandDefinition STOP_STRUCTURES =
         new CommandDefinition("STOP_STRUCTURES",
                               null,
-                              PREFIX_ADMIN + "stopstructures");
+                              Constants.PERMISSION_PREFIX_ADMIN + "stopstructures");
 
     public static final CommandDefinition VERSION =
         new CommandDefinition("VERSION",
                               null,
-                              PREFIX_ADMIN + "version");
+                              Constants.PERMISSION_PREFIX_ADMIN + "version");
 
     public static final CommandDefinition TOGGLE =
         new CommandDefinition("TOGGLE",
-                              PREFIX_USER + "toggle",
-                              PREFIX_ADMIN + "bypass.toggle");
+                              Constants.PERMISSION_PREFIX_USER + "toggle",
+                              Constants.PERMISSION_PREFIX_ADMIN + "bypass.toggle");
 
     @Getter
     private final String name;

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureType.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureType.java
@@ -6,6 +6,7 @@ import nl.pim16aap2.animatedarchitecture.core.audio.AudioSet;
 import nl.pim16aap2.animatedarchitecture.core.managers.StructureTypeManager;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.ToolUser;
 import nl.pim16aap2.animatedarchitecture.core.tooluser.creator.Creator;
+import nl.pim16aap2.animatedarchitecture.core.util.Constants;
 import nl.pim16aap2.animatedarchitecture.core.util.LazyValue;
 import nl.pim16aap2.animatedarchitecture.core.util.MovementDirection;
 import org.jetbrains.annotations.Nullable;
@@ -31,7 +32,10 @@ public abstract class StructureType
     protected final String pluginName;
 
     /**
-     * Gets the name of this {@link StructureType}. Note that this is always in lower case!
+     * Gets the simple name of this {@link StructureType}. Note that this is always in lower case!
+     * <p>
+     * The simple name is the name of the {@link StructureType} without the plugin name. For example, "windmill",
+     * "bigdoor", "flag", etc.
      *
      * @return The name of this {@link StructureType}.
      */
@@ -201,5 +205,15 @@ public abstract class StructureType
     {
         // There may only ever exist 1 instance of each StructureType.
         return super.equals(obj);
+    }
+
+    /**
+     * Gets the permission that is required to create a structure of this type.
+     *
+     * @return The permission that is required to create a structure of this type.
+     */
+    public String getCreationPermission()
+    {
+        return Constants.PERMISSION_PREFIX_USER + "create." + getSimpleName();
     }
 }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Constants.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Constants.java
@@ -11,6 +11,20 @@ import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
 public final class Constants
 {
     /**
+     * The prefix of all permissions that a regular user should have access to for normal usage.
+     * <p>
+     * This will include stuff like creating new structures and managing structures that you own.
+     */
+    public static final String PERMISSION_PREFIX_USER = "animatedarchitecture.user.";
+
+    /**
+     * The prefix of all permissions for admin-related actions.
+     * <p>
+     * This should include stuff like affecting server settings and managing structures owned by other players.
+     */
+    public static final String PERMISSION_PREFIX_ADMIN = "animatedarchitecture.admin.";
+
+    /**
      * The name used by all entities created by AnimatedArchitecture.
      */
     public static final String ANIMATED_ARCHITECTURE_ENTITY_NAME = "AnimatedArchitectureEntity";

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/comands/StructureTypeParser.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/comands/StructureTypeParser.java
@@ -59,7 +59,12 @@ public class StructureTypeParser implements ArgumentParser<ICommandSender, Struc
     @Override
     public List<String> suggestions(CommandContext<ICommandSender> commandContext, String input)
     {
-        return suggestions.keySet().stream().filter(val -> startsWith(input, val)).toList();
+        return suggestions
+            .entrySet().stream()
+            .filter(entry -> startsWith(input, entry.getKey()))
+            .filter(entry -> commandContext.hasPermission(entry.getValue().getCreationPermission()))
+            .map(Map.Entry::getKey)
+            .toList();
     }
 
     /**

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/managers/VaultManager.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/managers/VaultManager.java
@@ -11,6 +11,7 @@ import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
 import nl.pim16aap2.animatedarchitecture.core.api.IWorld;
 import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.api.restartable.IRestartable;
+import nl.pim16aap2.animatedarchitecture.core.commands.ICommandSender;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.managers.StructureTypeManager;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
@@ -410,6 +411,15 @@ public final class VaultManager implements IRestartable, IEconomyManager, IPermi
     public boolean isOp(IPlayer player)
     {
         return isOp(getBukkitPlayer(player));
+    }
+
+    @Override
+    public boolean hasPermissionToCreateStructure(ICommandSender sender, StructureType type)
+    {
+        return sender
+            .getPlayer()
+            .map(player -> hasPermission(player, type.getCreationPermission()))
+            .orElse(true);
     }
 
     private @Nullable Player getBukkitPlayer(IPlayer player)


### PR DESCRIPTION
- To be able to create a structure of a type, the user now needs the `PERMISSION_PREFIX_USER + "create." + type.getSimpleName()` permission node. For example: `animatedarchitecture.user.create.bigdoor`. In addition, they also need the base permission node (`animatedarchitecture.user.base`), as this is required to complete the process.