### PR TITLE
Improve local rotation calculation

### DIFF
--- a/structures/structure-clock/src/main/java/nl/pim16aap2/animatedarchitecture/structures/clock/ClockAnimationComponent.java
+++ b/structures/structure-clock/src/main/java/nl/pim16aap2/animatedarchitecture/structures/clock/ClockAnimationComponent.java
@@ -100,7 +100,7 @@ public final class ClockAnimationComponent extends DrawbridgeAnimationComponent
         for (final IAnimatedBlock animatedBlock : animatedBlocks)
         {
             final double timeAngle = isHourArm.test(animatedBlock) ? hourAngle : minuteAngle;
-            animator.applyMovement(animatedBlock, getGoalPos(timeAngle, animatedBlock));
+            animator.applyMovement(animatedBlock, getGoalPos(null, timeAngle, animatedBlock));
         }
     }
 

--- a/structures/structure-clock/src/main/java/nl/pim16aap2/animatedarchitecture/structures/clock/ClockAnimationComponent.java
+++ b/structures/structure-clock/src/main/java/nl/pim16aap2/animatedarchitecture/structures/clock/ClockAnimationComponent.java
@@ -11,6 +11,7 @@ import nl.pim16aap2.animatedarchitecture.core.util.MathUtil;
 import nl.pim16aap2.animatedarchitecture.core.util.MovementDirection;
 import nl.pim16aap2.animatedarchitecture.core.util.Util;
 import nl.pim16aap2.animatedarchitecture.core.util.WorldTime;
+import nl.pim16aap2.animatedarchitecture.core.util.vector.Vector3Dd;
 import nl.pim16aap2.animatedarchitecture.structures.drawbridge.DrawbridgeAnimationComponent;
 import org.jetbrains.annotations.Nullable;
 
@@ -96,11 +97,24 @@ public final class ClockAnimationComponent extends DrawbridgeAnimationComponent
         final WorldTime worldTime = snapshot.getWorld().getTime();
         final double hourAngle = angleDirectionMultiplier * hoursToAngle(worldTime.getHours(), worldTime.getMinutes());
         final double minuteAngle = angleDirectionMultiplier * minutesToAngle(worldTime.getMinutes());
+        final Vector3Dd hourRotation = getGoalRotation(hourAngle);
+        final Vector3Dd minuteRotation = getGoalRotation(minuteAngle);
 
         for (final IAnimatedBlock animatedBlock : animatedBlocks)
         {
-            final double timeAngle = isHourArm.test(animatedBlock) ? hourAngle : minuteAngle;
-            animator.applyMovement(animatedBlock, getGoalPos(null, timeAngle, animatedBlock));
+            final double angle;
+            final Vector3Dd localRotation;
+            if (isHourArm.test(animatedBlock))
+            {
+                angle = hourAngle;
+                localRotation = hourRotation;
+            }
+            else
+            {
+                angle = minuteAngle;
+                localRotation = minuteRotation;
+            }
+            animator.applyMovement(animatedBlock, getGoalPos(localRotation, angle, animatedBlock));
         }
     }
 


### PR DESCRIPTION
## Changes
- Fixed missing local rotation at radius == 0.
- Optimized local rotation calculation.
- Calculate local rotation once per animation step (or twice for Clocks; once per arm) instead of once per animated block.


## Affected structure types:
- Big Door
- Revolving Door
- Windmill
- Drawbridge
- Clock

## Related Issues
Closes #451 