### PR TITLE
Improve Info command output

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/SetOpenDirection.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/SetOpenDirection.java
@@ -29,10 +29,16 @@ public class SetOpenDirection extends StructureTargetCommand
 
     @AssistedInject //
     SetOpenDirection(
-        @Assisted ICommandSender commandSender, ILocalizer localizer, ITextFactory textFactory,
-        @Assisted StructureRetriever structureRetriever, @Assisted MovementDirection movementDirection)
+        @Assisted ICommandSender commandSender,
+        @Assisted StructureRetriever structureRetriever,
+        @Assisted MovementDirection movementDirection,
+        @Assisted boolean sendUpdatedInfo,
+        ILocalizer localizer,
+        ITextFactory textFactory,
+        CommandFactory commandFactory)
     {
-        super(commandSender, localizer, textFactory, structureRetriever, StructureAttribute.OPEN_DIRECTION);
+        super(commandSender, localizer, textFactory, structureRetriever, StructureAttribute.OPEN_DIRECTION,
+              sendUpdatedInfo, commandFactory);
         this.movementDirection = movementDirection;
     }
 
@@ -66,7 +72,9 @@ public class SetOpenDirection extends StructureTargetCommand
         }
 
         structure.setOpenDir(movementDirection);
-        return structure.syncData().thenAccept(this::handleDatabaseActionResult);
+        return structure.syncData()
+                        .thenAccept(this::handleDatabaseActionResult)
+                        .thenRunAsync(() -> sendUpdatedInfo(structure));
     }
 
     @AssistedFactory
@@ -82,9 +90,34 @@ public class SetOpenDirection extends StructureTargetCommand
          *     direction will be modified.
          * @param movementDirection
          *     The new movement direction.
+         * @param sendUpdatedInfo
+         *     True to send the updated info text to the user after the command has been executed.
          * @return See {@link BaseCommand#run()}.
          */
         SetOpenDirection newSetOpenDirection(
-            ICommandSender commandSender, StructureRetriever structureRetriever, MovementDirection movementDirection);
+            ICommandSender commandSender,
+            StructureRetriever structureRetriever,
+            MovementDirection movementDirection,
+            boolean sendUpdatedInfo);
+
+        /**
+         * Creates (but does not execute!) a new {@link SetOpenDirection} command.
+         *
+         * @param commandSender
+         *     The {@link ICommandSender} responsible for changing open direction of the structure.
+         * @param structureRetriever
+         *     A {@link StructureRetrieverFactory} representing the {@link AbstractStructure} for which the open
+         *     direction will be modified.
+         * @param movementDirection
+         *     The new movement direction.
+         * @return See {@link BaseCommand#run()}.
+         */
+        default SetOpenDirection newSetOpenDirection(
+            ICommandSender commandSender,
+            StructureRetriever structureRetriever,
+            MovementDirection movementDirection)
+        {
+            return newSetOpenDirection(commandSender, structureRetriever, movementDirection, false);
+        }
     }
 }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/ILocalizer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/ILocalizer.java
@@ -1,6 +1,6 @@
 package nl.pim16aap2.animatedarchitecture.core.localization;
 
-import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
+import nl.pim16aap2.animatedarchitecture.core.structures.IStructureConst;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
 
 import java.util.List;
@@ -56,7 +56,7 @@ public interface ILocalizer
     /**
      * See {@link #getStructureType(StructureType)}
      */
-    default String getStructureType(AbstractStructure structure)
+    default String getStructureType(IStructureConst structure)
     {
         return getStructureType(structure.getType());
     }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/AbstractStructure.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/AbstractStructure.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -268,28 +267,6 @@ public abstract class AbstractStructure implements IStructureConst
      * @return The direction the structure would go if it were to be toggled.
      */
     public abstract MovementDirection getCurrentToggleDir();
-
-    /**
-     * Cycle the {@link MovementDirection} direction this {@link AbstractStructure} will open in. By default, it will
-     * loop over all valid directions. See {@link StructureType#getValidOpenDirectionsList()}. However, subclasses may
-     * override this behavior.
-     * <p>
-     * Note that this does not actually change the open direction; it merely tells you which direction comes next!
-     *
-     * @return The new {@link MovementDirection} direction this {@link AbstractStructure} will open in.
-     */
-    @Locked.Read
-    public MovementDirection getCycledOpenDirection()
-    {
-        final List<MovementDirection> validOpenDirections = getType().getValidOpenDirectionsList();
-        final MovementDirection currentDir = getOpenDir();
-
-        if (validOpenDirections.size() <= 1)
-            return currentDir;
-
-        final int index = Math.max(0, validOpenDirections.indexOf(currentDir));
-        return validOpenDirections.get((index + 1) % validOpenDirections.size());
-    }
 
     /**
      * @param data

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/IStructureConst.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/IStructureConst.java
@@ -9,6 +9,7 @@ import nl.pim16aap2.animatedarchitecture.core.util.Util;
 import nl.pim16aap2.animatedarchitecture.core.util.vector.Vector3Di;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -297,6 +298,27 @@ public interface IStructureConst
     default long getChunkId()
     {
         return Util.getChunkId(getPowerBlock());
+    }
+
+    /**
+     * Cycle the {@link MovementDirection} direction this {@link AbstractStructure} will open in. By default, it will
+     * loop over all valid directions. See {@link StructureType#getValidOpenDirectionsList()}. However, subclasses may
+     * override this behavior.
+     * <p>
+     * Note that this does not actually change the open direction; it merely tells you which direction comes next!
+     *
+     * @return The new {@link MovementDirection} direction this {@link AbstractStructure} will open in.
+     */
+    default MovementDirection getCycledOpenDirection()
+    {
+        final List<MovementDirection> validOpenDirections = getType().getValidOpenDirectionsList();
+        final MovementDirection currentDir = getOpenDir();
+
+        if (validOpenDirections.size() <= 1)
+            return currentDir;
+
+        final int index = Math.max(0, validOpenDirections.indexOf(currentDir));
+        return validOpenDirections.get((index + 1) % validOpenDirections.size());
     }
 
     @Override

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureSerializer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureSerializer.java
@@ -239,13 +239,18 @@ public final class StructureSerializer<T extends AbstractStructure>
     }
 
     /**
-     * Serializes the type-specific data of a structure.
+     * Gets a map of all the values of the fields annotated with {@link PersistentVariable} in the given structure.
+     * <p>
+     * The map is keyed by the field name and the value is the value of the field in the given structure.
      *
      * @param structure
      *     The structure.
-     * @return The serialized type-specific data represented as a json string.
+     * @return The map of field values.
+     *
+     * @throws Exception
+     *     If an error occurs while getting the value of a field.
      */
-    public String serialize(AbstractStructure structure)
+    public Map<String, Object> getPropertyMap(AbstractStructure structure)
         throws Exception
     {
         final HashMap<String, Object> values = new HashMap<>(MathUtil.ceil(1.25 * fields.size()));
@@ -259,6 +264,20 @@ public final class StructureSerializer<T extends AbstractStructure>
                 throw new Exception(String.format("Failed to get value of field %s (type %s) for structure type %s!",
                                                   field.name(), field.typeName(), getStructureTypeName()), e);
             }
+        return values;
+    }
+
+    /**
+     * Serializes the type-specific data of a structure.
+     *
+     * @param structure
+     *     The structure.
+     * @return The serialized type-specific data represented as a json string.
+     */
+    public String serialize(AbstractStructure structure)
+        throws Exception
+    {
+        final Map<String, Object> values = getPropertyMap(structure);
         try
         {
             return JSON.toJSONString(values);

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureSnapshot.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureSnapshot.java
@@ -43,6 +43,9 @@ public final class StructureSnapshot implements IStructureConst
     private final Map<UUID, StructureOwner> owners;
     private final StructureType type;
 
+    @Getter(AccessLevel.NONE)
+    private final Map<String, Object> propertyMap;
+
     StructureSnapshot(AbstractStructure structure)
     {
         this(
@@ -58,7 +61,8 @@ public final class StructureSnapshot implements IStructureConst
             structure.isLocked(),
             structure.getPrimeOwner(),
             Map.copyOf(structure.getOwnersView()),
-            structure.getType()
+            structure.getType(),
+            getPropertyMap(structure)
         );
     }
 
@@ -91,5 +95,31 @@ public final class StructureSnapshot implements IStructureConst
     public StructureSnapshot getSnapshot()
     {
         return this;
+    }
+
+    /**
+     * Gets the value of a property of this structure.
+     * <p>
+     * This can be used to retrieve type-specific properties of a structure.
+     *
+     * @param key
+     *     The key of the property.
+     * @return The value of the property, or {@link Optional#empty()} if the property does not exist.
+     */
+    public Optional<Object> getProperty(String key)
+    {
+        return Optional.ofNullable(propertyMap.get(key));
+    }
+
+    private static Map<String, Object> getPropertyMap(AbstractStructure structure)
+    {
+        try
+        {
+            return structure.getType().getStructureSerializer().getPropertyMap(structure);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/animatedarchitecture-core/src/main/resources/Core.properties
+++ b/animatedarchitecture-core/src/main/resources/Core.properties
@@ -132,6 +132,13 @@ commands.delete.description=Deletes a structure.
 commands.delete.success={0} {1} has been deleted.
 #
 commands.info.description=Prints the information of a structure.
+commands.info.output.header=Information about {0} {1}:
+commands.info.output.location=Location: Min {0} Max {1}
+commands.info.output.open_status=Open status: {0}
+commands.info.output.open_direction=Open direction: {0}
+commands.info.output.locked_status=Locked Status: {0}
+commands.info.output.blocks_to_move=Blocks to Move: {0}
+commands.info.output.power_block_location=Power block: {0}
 #
 commands.inspect_power_block.description=Gives you a tool to inspect which structures are associated with a powerblock.
 #

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/commands/LockTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/commands/LockTest.java
@@ -65,11 +65,15 @@ class LockTest
 
         Mockito.when(factory.newLock(Mockito.any(ICommandSender.class),
                                      Mockito.any(StructureRetriever.class),
+                                     Mockito.anyBoolean(),
                                      Mockito.anyBoolean()))
-               .thenAnswer(invoc -> new Lock(invoc.getArgument(0, ICommandSender.class), localizer,
-                                             ITextFactory.getSimpleTextFactory(),
+               .thenAnswer(invoc -> new Lock(invoc.getArgument(0, ICommandSender.class),
                                              invoc.getArgument(1, StructureRetriever.class),
                                              invoc.getArgument(2, Boolean.class),
+                                             invoc.getArgument(3, Boolean.class),
+                                             localizer,
+                                             ITextFactory.getSimpleTextFactory(),
+                                             Mockito.mock(CommandFactory.class),
                                              Mockito.mock(IAnimatedArchitectureEventCaller.class),
                                              eventFactory));
     }

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/commands/SetOpenDirectionTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/commands/SetOpenDirectionTest.java
@@ -57,11 +57,15 @@ class SetOpenDirectionTest
 
         Mockito.when(factory.newSetOpenDirection(Mockito.any(ICommandSender.class),
                                                  Mockito.any(StructureRetriever.class),
-                                                 Mockito.any(MovementDirection.class)))
-               .thenAnswer(invoc -> new SetOpenDirection(invoc.getArgument(0, ICommandSender.class), localizer,
-                                                         ITextFactory.getSimpleTextFactory(),
+                                                 Mockito.any(MovementDirection.class),
+                                                 Mockito.anyBoolean()))
+               .thenAnswer(invoc -> new SetOpenDirection(invoc.getArgument(0, ICommandSender.class),
                                                          invoc.getArgument(1, StructureRetriever.class),
-                                                         invoc.getArgument(2, MovementDirection.class)));
+                                                         invoc.getArgument(2, MovementDirection.class),
+                                                         invoc.getArgument(3, Boolean.class),
+                                                         localizer,
+                                                         ITextFactory.getSimpleTextFactory(),
+                                                         Mockito.mock(CommandFactory.class)));
     }
 
     @Test

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/tooluser/PowerBlockRelocatorTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/tooluser/PowerBlockRelocatorTest.java
@@ -7,6 +7,7 @@ import nl.pim16aap2.animatedarchitecture.core.api.IProtectionHookManager;
 import nl.pim16aap2.animatedarchitecture.core.api.IWorld;
 import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
+import nl.pim16aap2.animatedarchitecture.core.managers.DatabaseManager;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
 import nl.pim16aap2.animatedarchitecture.core.text.Text;
@@ -22,6 +23,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 class PowerBlockRelocatorTest
 {
@@ -54,6 +56,8 @@ class PowerBlockRelocatorTest
 
         Mockito.when(structure.getWorld()).thenReturn(world);
         Mockito.when(structure.getPowerBlock()).thenReturn(currentPowerBlockLoc);
+        Mockito.when(structure.syncData())
+               .thenReturn(CompletableFuture.completedFuture(DatabaseManager.ActionResult.SUCCESS));
 
         final StructureType structureTypeType = Mockito.mock(StructureType.class);
         Mockito.when(structure.getType()).thenReturn(structureTypeType);

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/comands/CommandExecutor.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/comands/CommandExecutor.java
@@ -107,7 +107,8 @@ class CommandExecutor
     {
         final StructureRetriever structureRetriever = context.get("structureRetriever");
         final boolean lockStatus = context.get("lockStatus");
-        commandFactory.newLock(context.getSender(), structureRetriever, lockStatus).run()
+        final boolean sendUpdatedInfo = context.get("sendUpdatedInfo");
+        commandFactory.newLock(context.getSender(), structureRetriever, lockStatus, sendUpdatedInfo).run()
                       .exceptionally(Util::exceptionally);
     }
 
@@ -186,11 +187,12 @@ class CommandExecutor
     void setOpenStatus(CommandContext<ICommandSender> context)
     {
         final boolean isOpen = context.get("isOpen");
+        final boolean sendUpdatedInfo = context.get("sendUpdatedInfo");
         final ICommandSender commandSender = context.getSender();
         final @Nullable StructureRetriever structureRetriever = nullable(context, "structureRetriever");
 
         if (structureRetriever != null)
-            commandFactory.newSetOpenStatus(commandSender, structureRetriever, isOpen).run()
+            commandFactory.newSetOpenStatus(commandSender, structureRetriever, isOpen, sendUpdatedInfo).run()
                           .exceptionally(Util::exceptionally);
         else
             commandFactory.getSetOpenStatusDelayed().provideDelayedInput(commandSender, isOpen)
@@ -200,11 +202,12 @@ class CommandExecutor
     void setOpenDirection(CommandContext<ICommandSender> context)
     {
         final MovementDirection direction = context.get("direction");
+        final boolean sendUpdatedInfo = context.get("sendUpdatedInfo");
         final ICommandSender commandSender = context.getSender();
         final @Nullable StructureRetriever structureRetriever = nullable(context, "structureRetriever");
 
         if (structureRetriever != null)
-            commandFactory.newSetOpenDirection(commandSender, structureRetriever, direction).run()
+            commandFactory.newSetOpenDirection(commandSender, structureRetriever, direction, sendUpdatedInfo).run()
                           .exceptionally(Util::exceptionally);
         else
             commandFactory.getSetOpenDirectionDelayed().provideDelayedInput(commandSender, direction)

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/comands/CommandManager.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/comands/CommandManager.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.animatedarchitecture.spigot.core.comands;
 
 import cloud.commandframework.ArgumentDescription;
 import cloud.commandframework.Command;
+import cloud.commandframework.arguments.CommandArgument;
 import cloud.commandframework.arguments.standard.BooleanArgument;
 import cloud.commandframework.arguments.standard.IntegerArgument;
 import cloud.commandframework.arguments.standard.StringArgument;
@@ -37,6 +38,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -290,6 +292,7 @@ public final class CommandManager
             baseInit(builder, CommandDefinition.LOCK, "commands.lock.description")
                 .argument(BooleanArgument.<ICommandSender>builder("lockStatus").withLiberal(true).build())
                 .argument(defaultStructureArgument(true, StructureAttribute.INFO).build())
+                .argument(newHiddenSendInfoArgument().build())
                 .handler(commandExecutor::lock)
         );
     }
@@ -387,6 +390,7 @@ public final class CommandManager
             baseInit(builder, CommandDefinition.SET_OPEN_STATUS, "commands.set_open_status.description")
                 .argument(defaultOpenStatusArgument(true).build())
                 .argument(defaultStructureArgument(false, StructureAttribute.OPEN_STATUS).build())
+                .argument(newHiddenSendInfoArgument().build())
                 .handler(commandExecutor::setOpenStatus)
         );
     }
@@ -398,6 +402,7 @@ public final class CommandManager
             baseInit(builder, CommandDefinition.SET_OPEN_DIRECTION, "commands.set_open_direction.description")
                 .argument(defaultDirectionArgument(true).build())
                 .argument(defaultStructureArgument(false, StructureAttribute.OPEN_DIRECTION).build())
+                .argument(newHiddenSendInfoArgument().build())
                 .handler(commandExecutor::setOpenDirection)
         );
     }
@@ -490,6 +495,16 @@ public final class CommandManager
     private StructureTypeArgument.StructureTypeArgumentBuilder defaultStructureTypeArgument(boolean required)
     {
         return StructureTypeArgument.builder().required(required).name("structureType").parser(structureTypeParser);
+    }
+
+    private static CommandArgument.Builder<ICommandSender, Boolean> newHiddenSendInfoArgument()
+    {
+        return BooleanArgument
+            .<ICommandSender>builder("sendUpdatedInfo")
+            .withLiberal(true)
+            .asOptionalWithDefault("false")
+            .withSuggestionsProvider((iCommandSenderCommandContext, s) -> Collections.emptyList())
+            .withDefaultDescription(ArgumentDescription.empty());
     }
 
     private static void registerBrigadier(BukkitCommandManager<ICommandSender> manager)

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/gui/AttributeButtonFactory.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/gui/AttributeButtonFactory.java
@@ -131,7 +131,8 @@ class AttributeButtonFactory
             new ItemStack(Material.BOOKSHELF),
             click ->
             {
-                player.sendInfo(textFactory, structure.getBasicInfo());
+                commandFactory.newInfo(player, structureRetrieverFactory.of(structure))
+                              .run().exceptionally(Util::exceptionally);
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.info",


### PR DESCRIPTION
- The output of the Info command was improved so it is actually readable + localized.
- Several parameters of the Info command output (open status/direction, locked status) can now be updated using clickable text.
- Added a sendUpdatedInfo parameter to some StructureTargetCommands that will execute the Info command after executing their respective updates. This allows us to redraw the Info command output after using its clickable text to update any parameters.