### PR TITLE
Fix incorrect toggle speeds using GUI/commands

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Toggle.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Toggle.java
@@ -27,10 +27,11 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Represents a command that toggles a structure.
  *
- * @author Pim
+ * @deprecated Use {@link StructureAnimationRequestBuilder} instead.
  */
 @ToString
 @Flogger
+@Deprecated
 public class Toggle extends BaseCommand
 {
     public static final StructureActionType DEFAULT_STRUCTURE_ACTION_TYPE = StructureActionType.TOGGLE;
@@ -200,7 +201,10 @@ public class Toggle extends BaseCommand
          * @param structureRetrievers
          *     The structure(s) to toggle.
          * @return See {@link BaseCommand#run()}.
+         *
+         * @deprecated Use {@link StructureAnimationRequestBuilder} instead.
          */
+        @Deprecated
         Toggle newToggle(
             ICommandSender commandSender, StructureActionType actionType, AnimationType animationType,
             @Nullable Double speedMultiplier, boolean preventPerpetualMovement,
@@ -212,7 +216,10 @@ public class Toggle extends BaseCommand
          * StructureRetriever...)}.
          * <p>
          * Defaults to null for the speed multiplier and true for preventPerpetualMovement.
+         *
+         * @deprecated Use {@link StructureAnimationRequestBuilder} instead.
          */
+        @Deprecated
         default Toggle newToggle(
             ICommandSender commandSender, StructureActionType actionType, AnimationType animationType,
             StructureRetriever... structureRetrievers)
@@ -229,7 +236,10 @@ public class Toggle extends BaseCommand
          * Defaults to null for the speed multiplier, to {@link Toggle#DEFAULT_STRUCTURE_ACTION_TYPE} for the structure
          * action type, to {@link Toggle#DEFAULT_ANIMATION_TYPE} for the animation type, and to true for
          * preventPerpetualMovement.
+         *
+         * @deprecated Use {@link StructureAnimationRequestBuilder} instead.
          */
+        @Deprecated
         default Toggle newToggle(ICommandSender commandSender, StructureRetriever... structureRetrievers)
         {
             return newToggle(

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/gui/AttributeButtonFactory.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/gui/AttributeButtonFactory.java
@@ -4,13 +4,14 @@ import de.themoep.inventorygui.GuiElement;
 import de.themoep.inventorygui.GuiStateElement;
 import de.themoep.inventorygui.StaticGuiElement;
 import nl.pim16aap2.animatedarchitecture.core.animation.AnimationType;
-import nl.pim16aap2.animatedarchitecture.core.api.IConfig;
 import nl.pim16aap2.animatedarchitecture.core.api.IExecutor;
 import nl.pim16aap2.animatedarchitecture.core.api.factories.ITextFactory;
 import nl.pim16aap2.animatedarchitecture.core.commands.CommandFactory;
-import nl.pim16aap2.animatedarchitecture.core.commands.Toggle;
+import nl.pim16aap2.animatedarchitecture.core.events.StructureActionCause;
+import nl.pim16aap2.animatedarchitecture.core.events.StructureActionType;
 import nl.pim16aap2.animatedarchitecture.core.localization.ILocalizer;
 import nl.pim16aap2.animatedarchitecture.core.structures.AbstractStructure;
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureAnimationRequestBuilder;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureAttribute;
 import nl.pim16aap2.animatedarchitecture.core.structures.retriever.StructureRetrieverFactory;
 import nl.pim16aap2.animatedarchitecture.core.text.TextComponent;
@@ -30,21 +31,25 @@ class AttributeButtonFactory
     private final CommandFactory commandFactory;
     private final IExecutor executor;
     private final StructureRetrieverFactory structureRetrieverFactory;
+    private final StructureAnimationRequestBuilder structureAnimationRequestBuilder;
     private final DeleteGui.IFactory deleteGuiFactory;
-    private final IConfig config;
 
-    @Inject //
-    AttributeButtonFactory(
-        ILocalizer localizer, ITextFactory textFactory, CommandFactory commandFactory, IExecutor executor,
-        StructureRetrieverFactory structureRetrieverFactory, DeleteGui.IFactory deleteGuiFactory, IConfig config)
+    @Inject AttributeButtonFactory(
+        ILocalizer localizer,
+        ITextFactory textFactory,
+        CommandFactory commandFactory,
+        IExecutor executor,
+        StructureRetrieverFactory structureRetrieverFactory,
+        StructureAnimationRequestBuilder structureAnimationRequestBuilder,
+        DeleteGui.IFactory deleteGuiFactory)
     {
         this.localizer = localizer;
         this.textFactory = textFactory;
         this.commandFactory = commandFactory;
         this.executor = executor;
         this.structureRetrieverFactory = structureRetrieverFactory;
+        this.structureAnimationRequestBuilder = structureAnimationRequestBuilder;
         this.deleteGuiFactory = deleteGuiFactory;
-        this.config = config;
     }
 
     private void lockButtonExecute(
@@ -89,13 +94,15 @@ class AttributeButtonFactory
             new ItemStack(Material.LEVER),
             click ->
             {
-                commandFactory.newToggle(
-                    player,
-                    Toggle.DEFAULT_STRUCTURE_ACTION_TYPE,
-                    Toggle.DEFAULT_ANIMATION_TYPE,
-                    config.getAnimationTimeMultiplier(structure.getType()),
-                    true,
-                    structureRetrieverFactory.of(structure)).run().exceptionally(Util::exceptionally);
+                structureAnimationRequestBuilder
+                    .builder()
+                    .structure(structure)
+                    .structureActionCause(StructureActionCause.PLAYER)
+                    .structureActionType(StructureActionType.TOGGLE)
+                    .responsible(player)
+                    .build()
+                    .execute()
+                    .exceptionally(Util::exceptionally);
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.toggle",
@@ -110,13 +117,16 @@ class AttributeButtonFactory
             new ItemStack(Material.ENDER_EYE),
             click ->
             {
-                commandFactory.newToggle(
-                    player,
-                    Toggle.DEFAULT_STRUCTURE_ACTION_TYPE,
-                    AnimationType.PREVIEW,
-                    config.getAnimationTimeMultiplier(structure.getType()),
-                    true,
-                    structureRetrieverFactory.of(structure)).run().exceptionally(Util::exceptionally);
+                structureAnimationRequestBuilder
+                    .builder()
+                    .structure(structure)
+                    .structureActionCause(StructureActionCause.PLAYER)
+                    .structureActionType(StructureActionType.TOGGLE)
+                    .responsible(player)
+                    .animationType(AnimationType.PREVIEW)
+                    .build()
+                    .execute()
+                    .exceptionally(Util::exceptionally);
                 return true;
             },
             localizer.getMessage("gui.info_page.attribute.preview",


### PR DESCRIPTION
- The GUI and commands used the Toggle command for toggle requests. However, this class had an issue where the 'speedMultiplier' variable was actually used as the time variable, meaning that the default multiplier of 1.0 would result in the structure trying to toggle in 1 second. To solve this issue, I have deprecated the entire Toggle command class, as it's just a wrapper for the StructureAnimationRequestBuilder class anyway. The GUI and the command executor both use the request builder now.