### PR TITLE
Fix incorrect block placement when crossing from negative to positive x or z values

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedBlockContainer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedBlockContainer.java
@@ -143,7 +143,7 @@ public class AnimatedBlockContainer implements IAnimatedBlockContainer
             }
             try
             {
-                final IVector3D goalPos = mapper.apply(animatedBlock).floor().toInteger();
+                final IVector3D goalPos = mapper.apply(animatedBlock).round().toInteger();
                 animatedBlock.getAnimatedBlockData().putBlock(goalPos);
             }
             catch (Exception e)

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/vector/IVector3D.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/vector/IVector3D.java
@@ -93,6 +93,16 @@ public sealed interface IVector3D permits Vector3Dd, Vector3Di
     IVector3D floor();
 
     /**
+     * @return A new vector with {@link Math#round(double)} applied to the current values.
+     */
+    IVector3D round();
+
+    /**
+     * @return A new vector with {@link Math#ceil(double)} applied to the current values.
+     */
+    IVector3D ceil();
+
+    /**
      * Converts all the values in this 3d vector to tadians.
      * <p>
      * See {@link Math#toRadians(double)}.

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/vector/Vector3Dd.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/vector/Vector3Dd.java
@@ -347,6 +347,18 @@ public record Vector3Dd(double x, double y, double z) implements IVector3D
         return new Vector3Dd(Math.floor(x), Math.floor(y), Math.floor(z));
     }
 
+    @Override
+    public Vector3Dd round()
+    {
+        return new Vector3Dd(Math.round(x), Math.round(y), Math.round(z));
+    }
+
+    @Override
+    public Vector3Dd ceil()
+    {
+        return new Vector3Dd(Math.ceil(x), Math.ceil(y), Math.ceil(z));
+    }
+
     /**
      * Clamps the vector using a cuboid to provide the upper and lower limits.
      *

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/vector/Vector3Di.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/vector/Vector3Di.java
@@ -553,4 +553,16 @@ public record Vector3Di(int x, int y, int z) implements IVector3D
     {
         return this;
     }
+
+    @Override
+    public Vector3Di round()
+    {
+        return this;
+    }
+
+    @Override
+    public Vector3Di ceil()
+    {
+        return this;
+    }
 }


### PR DESCRIPTION
When a BigDoor is animated, any blocks that cross from negative X or Z coordinates to positive ones, will be placed in an incorrect location. This was caused by using the floor of the final coordinates and solved by rounding it instead.

For example, a block at [-3, _, 45], when animated in a clockwise direction around [3, _, 45], would have a final location of [2.9999999999999996, _, 39.0]. The expected location is [3, _, 39], but using the floor it is placed at [2, _, 39], which is not part of the structure. Using `round` instead, we do get the correct value of x = 3.

Vertical movement (e.g. drawbridges) did not suffer from this problem.

To make sure this fix worked, I tested bigdoors moving around x==0, around z==0, with x>0, and with x<0. Additionally, all existing structures in my dev environment were tested to ensure there were no regressions there.