### PR TITLE
Separate second block removal pass

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedBlockContainer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedBlockContainer.java
@@ -88,8 +88,7 @@ public class AnimatedBlockContainer implements IAnimatedBlockContainer
                             .ifPresent(animatedBlocksTmp::add);
                     }
 
-            tryRemoveOriginalBlocks(animatedBlocksTmp, false);
-            tryRemoveOriginalBlocks(animatedBlocksTmp, true);
+            tryRemoveOriginalBlocks(animatedBlocksTmp);
         }
         catch (Exception e)
         {
@@ -111,21 +110,14 @@ public class AnimatedBlockContainer implements IAnimatedBlockContainer
      *
      * @param animatedBlocks
      *     The animated blocks to process.
-     * @param edgePass
-     *     True to do a pass over the edges specifically.
      * @return True if the original blocks could be spawned. If something went wrong and the process had to be aborted,
      * false is returned instead.
      */
-    private void tryRemoveOriginalBlocks(List<IAnimatedBlock> animatedBlocks, boolean edgePass)
+    private void tryRemoveOriginalBlocks(List<IAnimatedBlock> animatedBlocks)
     {
         executor.assertMainThread("Blocks must be removed on the main thread!");
-
-        for (final IAnimatedBlock animatedBlock : animatedBlocks)
-        {
-            if (edgePass && !animatedBlock.isOnEdge())
-                continue;
-            animatedBlock.getAnimatedBlockData().deleteOriginalBlock(edgePass);
-        }
+        animatedBlocks.forEach(block -> block.getAnimatedBlockData().deleteOriginalBlock());
+        animatedBlocks.forEach(block -> block.getAnimatedBlockData().postProcessStructureRemoval());
     }
 
     private void putBlocks(Function<IAnimatedBlock, IVector3D> mapper)

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimationRegion.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimationRegion.java
@@ -198,12 +198,6 @@ public final class AnimationRegion
         }
 
         @Override
-        public boolean isOnEdge()
-        {
-            return false;
-        }
-
-        @Override
         public int getTicksLived()
         {
             return 0;

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/AnimatedHighlightedBlock.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/AnimatedHighlightedBlock.java
@@ -34,8 +34,13 @@ public class AnimatedHighlightedBlock implements IAnimatedBlock
     private volatile RotatedPosition currentTarget;
 
     public AnimatedHighlightedBlock(
-        ILocationFactory locationFactory, HighlightedBlockSpawner highlightedBlockSpawner, IWorld world, IPlayer player,
-        RotatedPosition position, float startRadius, Color color)
+        ILocationFactory locationFactory,
+        HighlightedBlockSpawner highlightedBlockSpawner,
+        IWorld world,
+        IPlayer player,
+        RotatedPosition position,
+        float startRadius,
+        Color color)
     {
         this.locationFactory = locationFactory;
         this.highlightedBlockSpawner = highlightedBlockSpawner;
@@ -163,12 +168,6 @@ public class AnimatedHighlightedBlock implements IAnimatedBlock
         return startRadius;
     }
 
-    @Override
-    public boolean isOnEdge()
-    {
-        return false;
-    }
-
     private static final class PreviewAnimatedBlockData implements IAnimatedBlockData
     {
         @Override
@@ -189,7 +188,7 @@ public class AnimatedHighlightedBlock implements IAnimatedBlock
         }
 
         @Override
-        public void deleteOriginalBlock(boolean applyPhysics)
+        public void deleteOriginalBlock()
         {
         }
     }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/IAnimatedBlock.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/IAnimatedBlock.java
@@ -7,8 +7,6 @@ import nl.pim16aap2.animatedarchitecture.core.util.vector.Vector3Dd;
 
 /**
  * Represents a block that is being animated.
- *
- * @author Pim
  */
 @SuppressWarnings("unused")
 public interface IAnimatedBlock
@@ -130,11 +128,6 @@ public interface IAnimatedBlock
      * @return The radius this animated block had in relation to the engine when the animation first started.
      */
     float getRadius();
-
-    /**
-     * @return True if this animated block is on the edge of the cuboid being animated.
-     */
-    boolean isOnEdge();
 
     enum TeleportMode
     {

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/IAnimatedBlockData.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/IAnimatedBlockData.java
@@ -4,10 +4,11 @@ import nl.pim16aap2.animatedarchitecture.core.util.MovementDirection;
 import nl.pim16aap2.animatedarchitecture.core.util.vector.IVector3D;
 
 /**
- * Represents an NMS block.
- *
- * @author Pim
+ * Represents the internal data of an animated block.
+ * <p>
+ * These data represent a representation of the block in the structure as it is in the world.
  */
+@SuppressWarnings("unused")
 public interface IAnimatedBlockData
 {
     /**
@@ -48,10 +49,16 @@ public interface IAnimatedBlockData
 
     /**
      * Deletes the block at the original location.
-     *
-     * @param applyPhysics
-     *     True to apply physics when removing this block. When this is false, stuff like torches that are attached to
-     *     this block will not be broken upon removal of this block.
      */
-    void deleteOriginalBlock(boolean applyPhysics);
+    void deleteOriginalBlock();
+
+    /**
+     * Called after all blocks in a structure have been removed for any potential post-processing.
+     * <p>
+     * Subclasses can override this method if they need to do any post-processing, such as updating the physics around
+     * the edges of the empty space where the structure used to be.
+     */
+    default void postProcessStructureRemoval()
+    {
+    }
 }


### PR DESCRIPTION
Removing blocks happens in two passes: On the first pass, all blocks are removed without applying physics. On the second pass, all blocks along the edges of where the structure used to do a postprocessing step to trigger a physics update which should update any blocks that interacted with the structure before it was removed. This was all handled by the `IAnimatedBlockData#deleteOriginalBlock(applyPhysics)` method. There are two problems with this approach:
  1) It results in the pre/post block removal methods of the IAnimatedBlockHook class being called twice for edge blocks.
  2) It's a leaky abstraction.

To resolve the issues mentioned above, `IAnimatedBlockData#deleteOriginalBlock(applyPhysics)` was changed to `IAnimatedBlockData#deleteOriginalBlock()` that only did what it says: Remove the original block however it wants to. `IAnimatedBlockData#postProcessStructureRemoval()` was introduced as a separate post-processing step that is called after all blocks have been removed. The subclasses of IAnimatedBlockData may handle this however they see fit. This postprocessing method has no callbacks into the IAnimatedBlockHook class. The reasoning for this is that;
1) I cannot think of any reason why a hook would interact with the physics-updating step of the removal process that cannot be handled in either the regular removal or the spawning steps.
2) This will make it easier to make changes to the two-pass system in the future.