### PR TITLE
Fix locale issues

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationUtil.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationUtil.java
@@ -559,10 +559,13 @@ public final class LocalizationUtil
     {
         try (FileSystem fs = createNewFileSystem(zipFile))
         {
-            return LocalizationUtil.getLocaleFilesInDirectory(fs.getPath("."), baseName).stream()
-                                   .map(localeFile -> getLocale(localeFile.locale())).toList();
+            return LocalizationUtil
+                .getLocaleFilesInDirectory(fs.getPath("."), baseName)
+                .stream()
+                .map(localeFile -> getLocale(localeFile.locale()))
+                .toList();
         }
-        catch (IOException | URISyntaxException | ProviderNotFoundException e)
+        catch (Exception e)
         {
             log.atSevere().withCause(e).log("Failed to find locales in file: %s", zipFile);
             return Collections.emptyList();

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationUtil.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationUtil.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
@@ -39,6 +40,13 @@ import java.util.zip.ZipOutputStream;
 @Flogger
 public final class LocalizationUtil
 {
+    /**
+     * The list of all installed locales.
+     *
+     * @see Locale#getAvailableLocales()
+     */
+    private static final List<Locale> AVAILABLE_LOCALES = List.of(Locale.getAvailableLocales());
+
     private LocalizationUtil()
     {
         // utility class
@@ -562,7 +570,8 @@ public final class LocalizationUtil
             return LocalizationUtil
                 .getLocaleFilesInDirectory(fs.getPath("."), baseName)
                 .stream()
-                .map(localeFile -> getLocale(localeFile.locale()))
+                .map(localeFile -> parseLocale(localeFile.locale()))
+                .filter(Objects::nonNull)
                 .toList();
         }
         catch (Exception e)
@@ -573,27 +582,26 @@ public final class LocalizationUtil
     }
 
     /**
-     * Gets a {@link Locale} from a String representing a locale. E.g. "en_US".
+     * Parses a {@link Locale} from a String representing a locale. E.g. "en_US".
      * <p>
-     * If the locale string is empty, the root locale is returned. See {@link Locale#ROOT}.
+     * When the provided locale is null or blank, {@link Locale#ROOT} is returned.
      *
-     * @param localeStr
+     * @param locale
      *     A String representing a locale.
-     * @return The decoded Locale.
+     * @return The parse Locale.
      */
-    public static Locale getLocale(String localeStr)
+    public static @Nullable Locale parseLocale(@Nullable String locale)
     {
-        final String[] parts = localeStr.split("_", 3);
-        if (parts[0].isBlank())
+        if (locale == null || locale.isBlank())
             return Locale.ROOT;
 
-        final Locale.Builder builder = new Locale.Builder().setLanguage(parts[0]);
-        if (parts.length >= 2)
-            builder.setRegion(parts[1]);
-        if (parts.length >= 3)
-            builder.setVariant(parts[2]);
-        return builder.build();
+        final var languages = Locale.LanguageRange.parse(locale.replace('_', '-'));
+        final Locale parsed = Locale.lookup(languages, AVAILABLE_LOCALES);
+
+        if (parsed == null)
+            log.atSevere().log("Failed to parse locale: '%s'", locale);
+
+        log.atFine().log("Parsed locale: '%s' -> '%s'", locale, parsed);
+        return parsed;
     }
-
-
 }

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationUtilTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationUtilTest.java
@@ -1,11 +1,13 @@
 package nl.pim16aap2.animatedarchitecture.core.localization;
 
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import static nl.pim16aap2.animatedarchitecture.core.localization.LocalizationUtil.*;
@@ -140,5 +142,19 @@ class LocalizationUtilTest
         Assertions.assertEquals("", parseLocaleFile("Translation.properties"));
         Assertions.assertEquals("", parseLocaleFile("Translated.properties"));
         Assertions.assertNull(parseLocaleFile("Translation.txt"));
+    }
+
+    @Test
+    void getLocale()
+    {
+        Assertions.assertEquals(Locale.US, parseLocale("en_US"));
+        Assertions.assertEquals(Locale.US, parseLocale("en-US"));
+        Assertions.assertEquals(Locale.ROOT, parseLocale(""));
+        Assertions.assertNull(parseLocale("not-a-language"));
+
+        final @Nullable Locale traditionalChinese = parseLocale("zh_Hant");
+        Assertions.assertNotNull(traditionalChinese);
+        Assertions.assertEquals("Chinese (Traditional)", traditionalChinese.getDisplayName());
+        Assertions.assertEquals("Hant", traditionalChinese.getScript());
     }
 }

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/config/ConfigSpigot.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/config/ConfigSpigot.java
@@ -41,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.logging.Level;
@@ -392,7 +393,7 @@ public final class ConfigSpigot implements IConfig, IDebuggable
         // So we map it to an empty String to ensure we get Locale#ROOT instead.
         if ("root".equalsIgnoreCase(localeStr))
             localeStr = "";
-        locale = LocalizationUtil.getLocale(localeStr);
+        locale = Objects.requireNonNullElse(LocalizationUtil.parseLocale(localeStr), Locale.ROOT);
 
         resourcePackEnabled = addNewConfigEntry(config, "resourcePackEnabled", false, resourcePackComment);
 

--- a/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationUtilIntegrationTest.java
+++ b/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationUtilIntegrationTest.java
@@ -40,16 +40,13 @@ class LocalizationUtilIntegrationTest
         LocalizationTestingUtilities.addFilesToZip(zipFile,
                                                    base + ".properties",
                                                    base + "_en_us.properties",
-                                                   base + "_en_us_random.properties",
                                                    base + "_nl.properties",
                                                    base + "_nl_NL.properties");
 
         final List<Locale> locales = LocalizationUtil.getLocalesInZip(zipFile, base);
-        Assertions.assertEquals(5, locales.size());
+        Assertions.assertEquals(4, locales.size());
         Assertions.assertTrue(locales.contains(Locale.ROOT));
         Assertions.assertTrue(locales.contains(Locale.US));
-        Assertions.assertTrue(locales.contains(
-            new Locale.Builder().setLanguage("en").setRegion("US").setVariant("random").build()));
         Assertions.assertTrue(locales.contains(new Locale.Builder().setLanguage("nl").build()));
         Assertions.assertTrue(locales.contains(new Locale.Builder().setLanguage("nl").setRegion("NL").build()));
     }


### PR DESCRIPTION
- Improved locale parsing so we can properly parse "zh_Hant" (and similar locales).
  The new system no longer allows parsing random suffixes, but that's not a priority.
- Catch all exceptions when reading locales from a zip file so we can better log any issues.