### PR TITLE
Fix ProjectVersion + Improve docs & usability

### DIFF
--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/util/versioning/ProjectVersionTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/util/versioning/ProjectVersionTest.java
@@ -6,6 +6,17 @@ import org.junit.jupiter.api.Test;
 class ProjectVersionTest
 {
     @Test
+    void parse()
+    {
+        Assertions.assertEquals(new ProjectVersion("1", false), ProjectVersion.parse("1"));
+        Assertions.assertEquals(new ProjectVersion("1.0", false), ProjectVersion.parse("1.0"));
+        Assertions.assertEquals(new ProjectVersion("1.0.0", false), ProjectVersion.parse("1.0.0"));
+        Assertions.assertEquals(new ProjectVersion("1", true), ProjectVersion.parse("1-SNAPSHOT"));
+        Assertions.assertEquals(new ProjectVersion("1.0", true), ProjectVersion.parse("1.0-SNAPSHOT"));
+        Assertions.assertEquals(new ProjectVersion("1.0.0", true), ProjectVersion.parse("1.0.0-SNAPSHOT"));
+    }
+
+    @Test
     void testStringToInteger()
     {
         Assertions.assertEquals(1, ProjectVersion.versionSectionToInt("1", 1, true));
@@ -18,7 +29,7 @@ class ProjectVersionTest
     }
 
     @Test
-    void compareVersions()
+    void isNewer()
     {
         Assertions.assertTrue(ProjectVersion.isNewer("0", "1"));
         Assertions.assertTrue(ProjectVersion.isNewer("1.0", "1.1"));
@@ -29,10 +40,47 @@ class ProjectVersionTest
         Assertions.assertTrue(ProjectVersion.isNewer("0.01", "0.1"));
         Assertions.assertTrue(ProjectVersion.isNewer("0.0.2", "0.0.3"));
 
+        Assertions.assertFalse(ProjectVersion.isNewer("1", "1.0.00000.0"));
         Assertions.assertFalse(ProjectVersion.isNewer("0.1", "0.01"));
         Assertions.assertFalse(ProjectVersion.isNewer("0.11", "0.9"));
         Assertions.assertFalse(ProjectVersion.isNewer("1", "0"));
         Assertions.assertFalse(ProjectVersion.isNewer("1", "1"));
         Assertions.assertFalse(ProjectVersion.isNewer("0.0.0.0.01", "0.0.0.0.01"));
+    }
+
+    @Test
+    void isNewerThan()
+    {
+        Assertions.assertTrue(ProjectVersion.parse("1.0").isNewerThan("0"));
+        Assertions.assertTrue(ProjectVersion.parse("1").isNewerThan("0.1-SNAPSHOT"));
+        Assertions.assertFalse(ProjectVersion.parse("1.0").isNewerThan("1.0"));
+        Assertions.assertTrue(ProjectVersion.parse("1.0").isNewerThan("1.0-SNAPSHOT"));
+
+        Assertions.assertTrue(ProjectVersion.parse("1.0-SNAPSHOT").isNewerThan("0"));
+        Assertions.assertFalse(ProjectVersion.parse("1.0-SNAPSHOT").isNewerThan("1.0"));
+        Assertions.assertFalse(ProjectVersion.parse("1.0-SNAPSHOT").isNewerThan("1"));
+    }
+
+    @Test
+    void isAtLeast()
+    {
+        Assertions.assertTrue(ProjectVersion.parse("1.0").isAtLeast("0"));
+        Assertions.assertTrue(ProjectVersion.parse("1").isAtLeast("0.1-SNAPSHOT"));
+        Assertions.assertTrue(ProjectVersion.parse("1.0").isAtLeast("1.0"));
+        Assertions.assertTrue(ProjectVersion.parse("1.0").isAtLeast("1.0-SNAPSHOT"));
+
+        Assertions.assertTrue(ProjectVersion.parse("1.0-SNAPSHOT").isAtLeast("0"));
+        Assertions.assertFalse(ProjectVersion.parse("1.0-SNAPSHOT").isAtLeast("1.0"));
+        Assertions.assertFalse(ProjectVersion.parse("1.0-SNAPSHOT").isAtLeast("1"));
+    }
+
+    @Test
+    void trimInsignificantZeroes()
+    {
+        Assertions.assertEquals("1", ProjectVersion.trimInsignificantZeroes("1.0.0"));
+        Assertions.assertEquals("1000", ProjectVersion.trimInsignificantZeroes("1000"));
+        Assertions.assertEquals("1.0.0.1", ProjectVersion.trimInsignificantZeroes("1.0.0.1"));
+        Assertions.assertEquals("10", ProjectVersion.trimInsignificantZeroes("10.0.0"));
+        Assertions.assertEquals("0.0.0.00001", ProjectVersion.trimInsignificantZeroes("0.0.0.00001"));
     }
 }


### PR DESCRIPTION
- Fixed incorrect version comparison when using insignificant zeroes. Previously, version "1.0" would be considered greater than version "1", while they are actually the same version. This happened because when comparing two version Strings of varying parts length with the same version values in the relative indices (in this case `["1", "0"]` vs `["1"]`), the longer of the two is considered newer, as it was assumed that the remaining values added significance. However, in the case that all remaining values are zeroes, they have no significance and should be discarded. To solve this, we simply remove all insignificant zeroes from the version Strings before comparing them.
- Added a bunch of documentation to the ProjectVersion class.
- Added the `ProjectVersion#isAtLeast(ProjectVersion)` method, which is more intuitive to use for external plugins than the `ProjectVersion#isNewerThan(ProjectVersion)` method.