### PR TITLE
Implement recovery system for orphaned animated blocks

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/AnimatedHighlightedBlock.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/AnimatedHighlightedBlock.java
@@ -14,6 +14,10 @@ import nl.pim16aap2.animatedarchitecture.core.util.vector.IVector3D;
 import nl.pim16aap2.animatedarchitecture.core.util.vector.Vector3Dd;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * An {@link IAnimatedBlock} that represents a highlighted block. This block can be used to highlight a block in the
+ * world for a player. Usage of this block will not result in any changes to the world.
+ */
 public class AnimatedHighlightedBlock implements IAnimatedBlock
 {
     private static final IAnimatedBlockData ANIMATED_BLOCK_DATA = new PreviewAnimatedBlockData();

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Constants.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Constants.java
@@ -38,9 +38,9 @@ public final class Constants
     public static final String PERMISSION_PREFIX_ADMIN_BYPASS_LIMIT = PERMISSION_PREFIX_ADMIN_BYPASS + "limit.";
 
     /**
-     * The key used to identify entities created by AnimatedArchitecture.
+     * The key used to store the recovery data of an animated block in the metadata of an animated block.
      */
-    public static final String ANIMATED_ARCHITECTURE_ENTITY_MARKER_KEY = "AnimatedArchitectureEntity";
+    public static final String ANIMATED_ARCHITECTURE_ENTITY_RECOVERY_KEY = "AnimatedArchitectureEntity";
 
     /**
      * The amount of time (in ms) a user gets to complete a command waiter.

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Constants.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Constants.java
@@ -38,9 +38,9 @@ public final class Constants
     public static final String PERMISSION_PREFIX_ADMIN_BYPASS_LIMIT = PERMISSION_PREFIX_ADMIN_BYPASS + "limit.";
 
     /**
-     * The name used by all entities created by AnimatedArchitecture.
+     * The key used to identify entities created by AnimatedArchitecture.
      */
-    public static final String ANIMATED_ARCHITECTURE_ENTITY_NAME = "AnimatedArchitectureEntity";
+    public static final String ANIMATED_ARCHITECTURE_ENTITY_MARKER_KEY = "AnimatedArchitectureEntity";
 
     /**
      * The amount of time (in ms) a user gets to complete a command waiter.

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockDisplay.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockDisplay.java
@@ -18,6 +18,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.BlockDisplay;
 import org.bukkit.entity.Entity;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -35,6 +36,7 @@ public final class AnimatedBlockDisplay implements IAnimatedBlockSpigot
     @Getter
     private final boolean onEdge;
     private final List<IAnimatedBlockHook> hooks;
+    private final JavaPlugin plugin;
     private final IExecutor executor;
     @Getter
     private final RotatedPosition startPosition;
@@ -51,10 +53,17 @@ public final class AnimatedBlockDisplay implements IAnimatedBlockSpigot
     private RotatedPosition currentTarget;
 
     public AnimatedBlockDisplay(
-        IExecutor executor, AnimatedBlockHookManager animatedBlockHookManager,
-        @Nullable Consumer<IAnimatedBlockData> blockDataRotator, RotatedPosition startPosition,
-        IWorld world, RotatedPosition finalPosition, boolean onEdge, float radius)
+        JavaPlugin plugin,
+        IExecutor executor,
+        AnimatedBlockHookManager animatedBlockHookManager,
+        @Nullable Consumer<IAnimatedBlockData> blockDataRotator,
+        RotatedPosition startPosition,
+        IWorld world,
+        RotatedPosition finalPosition,
+        boolean onEdge,
+        float radius)
     {
+        this.plugin = plugin;
         this.executor = executor;
         this.startPosition = startPosition;
         this.world = world;
@@ -74,7 +83,7 @@ public final class AnimatedBlockDisplay implements IAnimatedBlockSpigot
     @GuardedBy("this")
     private void spawn0()
     {
-        this.entity = BlockDisplayHelper.spawn(executor, bukkitWorld, currentTarget, blockData.getBlockData());
+        this.entity = BlockDisplayHelper.spawn(plugin, executor, bukkitWorld, currentTarget, blockData.getBlockData());
         this.entity.setViewRange(2.5F);
     }
 

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockDisplay.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockDisplay.java
@@ -80,7 +80,7 @@ public final class AnimatedBlockDisplay implements IAnimatedBlockSpigot
             this, executor, blockDataRotator, bukkitWorld, this.startPosition.position().floor().toInteger());
 
         this.recoveryData = new IAnimatedBlockRecoveryData.AnimatedBlockRecoveryData(
-            this.bukkitWorld,
+            bukkitWorld,
             this.startPosition.position().floor().toInteger(),
             this.blockData.getBlockData()
         );

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockDisplayFactory.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockDisplayFactory.java
@@ -12,6 +12,7 @@ import nl.pim16aap2.animatedarchitecture.core.util.vector.Vector3Di;
 import nl.pim16aap2.animatedarchitecture.spigot.util.SpigotAdapter;
 import nl.pim16aap2.animatedarchitecture.spigot.util.api.IBlockAnalyzerSpigot;
 import org.bukkit.Material;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
@@ -25,15 +26,18 @@ public class AnimatedBlockDisplayFactory implements IAnimatedBlockFactory
     private final IExecutor executor;
     private final AnimatedBlockHookManager animatedBlockHookManager;
     private final IBlockAnalyzerSpigot blockAnalyzer;
+    private final JavaPlugin plugin;
 
     @Inject AnimatedBlockDisplayFactory(
         IExecutor executor,
         AnimatedBlockHookManager animatedBlockHookManager,
-        IBlockAnalyzerSpigot blockAnalyzer)
+        IBlockAnalyzerSpigot blockAnalyzer,
+        JavaPlugin plugin)
     {
         this.executor = executor;
         this.animatedBlockHookManager = animatedBlockHookManager;
         this.blockAnalyzer = blockAnalyzer;
+        this.plugin = plugin;
     }
 
     @Override
@@ -49,6 +53,7 @@ public class AnimatedBlockDisplayFactory implements IAnimatedBlockFactory
             return Optional.empty();
 
         return Optional.of(new AnimatedBlockDisplay(
+            plugin,
             executor,
             animatedBlockHookManager,
             blockDataRotator,

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockDisplayFactory.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockDisplayFactory.java
@@ -12,7 +12,6 @@ import nl.pim16aap2.animatedarchitecture.core.util.vector.Vector3Di;
 import nl.pim16aap2.animatedarchitecture.spigot.util.SpigotAdapter;
 import nl.pim16aap2.animatedarchitecture.spigot.util.api.IBlockAnalyzerSpigot;
 import org.bukkit.Material;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
@@ -26,23 +25,27 @@ public class AnimatedBlockDisplayFactory implements IAnimatedBlockFactory
     private final IExecutor executor;
     private final AnimatedBlockHookManager animatedBlockHookManager;
     private final IBlockAnalyzerSpigot blockAnalyzer;
-    private final JavaPlugin plugin;
+    private final BlockDisplayHelper blockDisplayHelper;
 
     @Inject AnimatedBlockDisplayFactory(
         IExecutor executor,
         AnimatedBlockHookManager animatedBlockHookManager,
         IBlockAnalyzerSpigot blockAnalyzer,
-        JavaPlugin plugin)
+        BlockDisplayHelper blockDisplayHelper)
     {
         this.executor = executor;
         this.animatedBlockHookManager = animatedBlockHookManager;
         this.blockAnalyzer = blockAnalyzer;
-        this.plugin = plugin;
+        this.blockDisplayHelper = blockDisplayHelper;
     }
 
     @Override
     public Optional<IAnimatedBlock> create(
-        IWorld world, RotatedPosition startPosition, float radius, boolean onEdge, RotatedPosition finalPosition,
+        IWorld world,
+        RotatedPosition startPosition,
+        float radius,
+        boolean onEdge,
+        RotatedPosition finalPosition,
         @Nullable Consumer<IAnimatedBlockData> blockDataRotator)
     {
         final Vector3Di pos = startPosition.position().floor().toInteger();
@@ -53,7 +56,7 @@ public class AnimatedBlockDisplayFactory implements IAnimatedBlockFactory
             return Optional.empty();
 
         return Optional.of(new AnimatedBlockDisplay(
-            plugin,
+            blockDisplayHelper,
             executor,
             animatedBlockHookManager,
             blockDataRotator,

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockHelper.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockHelper.java
@@ -1,0 +1,99 @@
+package nl.pim16aap2.animatedarchitecture.spigot.core.animation;
+
+import com.google.common.flogger.LazyArgs;
+import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.animatedarchitecture.core.util.Constants;
+import nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery.AnimatedBlockRecoveryDataType;
+import nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery.IAnimatedBlockRecoveryData;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.BlockDisplay;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Nullable;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Objects;
+
+/**
+ * Helper class for animated blocks.
+ */
+@Flogger
+@Singleton
+public final class AnimatedBlockHelper
+{
+    /**
+     * The key used to store the recovery data in the entity's persistent data container.
+     */
+    private final NamespacedKey RECOVERY_KEY;
+
+    @Inject AnimatedBlockHelper(JavaPlugin plugin)
+    {
+        RECOVERY_KEY = new NamespacedKey(plugin, Constants.ANIMATED_ARCHITECTURE_ENTITY_RECOVERY_KEY);
+    }
+
+    /**
+     * Attempts to recover an animated block from an entity.
+     * <p>
+     * If the entity is not an animated block (or null), this method does nothing.
+     * <p>
+     * If the entity is an animated block, this method will attempt to perform a recovery action by calling
+     * {@link IAnimatedBlockRecoveryData#recover()}. If the recovery action is successful, the entity will be removed.
+     *
+     * @param entity
+     *     The entity for which to attempt recovery.
+     */
+    public void recoverAnimatedBlock(@Nullable Entity entity)
+    {
+        if (entity == null)
+            return;
+
+        final IAnimatedBlockRecoveryData recoveryData = entity.getPersistentDataContainer().get(
+            RECOVERY_KEY,
+            AnimatedBlockRecoveryDataType.INSTANCE);
+
+        if (recoveryData == null)
+            return;
+
+        log.atFinest().log(
+            "Attempting to recover animated block with recovery data '%s'",
+            LazyArgs.lazy(
+                () -> entity.getPersistentDataContainer().get(RECOVERY_KEY, AnimatedBlockRecoveryDataType.STRING))
+        );
+
+        try
+        {
+            if (recoveryData.recover())
+                log.atWarning().log(
+                    "Recovered animated block with recovery data '%s'! " +
+                        "This is not intended behavior, please contact the author(s) of this plugin!",
+                    recoveryData);
+            else
+                log.atFine().log("No recovery action required for data '%s'", recoveryData);
+
+            entity.remove();
+        }
+        catch (Exception e)
+        {
+            log.atSevere().withCause(e).log(
+                "Failed to recover animated block '%s' from recovery: '%s'",
+                entity, recoveryData);
+        }
+    }
+
+    /**
+     * Sets the recovery data for an animated block entity.
+     *
+     * @param entity
+     *     The entity to set the recovery data for.
+     * @param recoveryData
+     *     The recovery data to set for the entity.
+     */
+    public void setRecoveryData(BlockDisplay entity, @Nullable IAnimatedBlockRecoveryData recoveryData)
+    {
+        entity.getPersistentDataContainer().set(
+            RECOVERY_KEY,
+            AnimatedBlockRecoveryDataType.INSTANCE,
+            Objects.requireNonNullElse(recoveryData, IAnimatedBlockRecoveryData.EMPTY));
+    }
+}

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/BlockDisplayHelper.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/BlockDisplayHelper.java
@@ -1,15 +1,20 @@
 package nl.pim16aap2.animatedarchitecture.spigot.core.animation;
 
+import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.animatedarchitecture.core.animation.RotatedPosition;
 import nl.pim16aap2.animatedarchitecture.core.api.IExecutor;
 import nl.pim16aap2.animatedarchitecture.core.util.Constants;
 import nl.pim16aap2.animatedarchitecture.core.util.vector.IVector3D;
 import nl.pim16aap2.animatedarchitecture.core.util.vector.Vector3Dd;
+import nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery.AnimatedBlockRecoveryDataType;
+import nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery.IAnimatedBlockRecoveryData;
+import nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery.RecoveryFailureException;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.BlockDisplay;
-import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.entity.Entity;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.util.Transformation;
 import org.jetbrains.annotations.Nullable;
@@ -17,24 +22,69 @@ import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 /**
  * Helper class for BlockDisplay entities.
  */
+@Flogger
+@Singleton
 public final class BlockDisplayHelper
 {
-    private static final Vector3f ONE_VECTOR = new Vector3f(1F, 1F, 1F);
-    private static final Vector3f HALF_VECTOR_POSITIVE = new Vector3f(0.5F, 0.5F, 0.5F);
-    private static final Vector3f HALF_VECTOR_NEGATIVE = new Vector3f(-0.5F, -0.5F, -0.5F);
+    private final Vector3f ONE_VECTOR = new Vector3f(1F, 1F, 1F);
+    private final Vector3f HALF_VECTOR_POSITIVE = new Vector3f(0.5F, 0.5F, 0.5F);
+    private final Vector3f HALF_VECTOR_NEGATIVE = new Vector3f(-0.5F, -0.5F, -0.5F);
 
-    private BlockDisplayHelper()
+    private final NamespacedKey RECOVERY_KEY;
+
+    @Inject BlockDisplayHelper(JavaPlugin plugin)
     {
+        RECOVERY_KEY = new NamespacedKey(plugin, Constants.ANIMATED_ARCHITECTURE_ENTITY_RECOVERY_KEY);
+    }
+
+    /**
+     * Attempts to recover an animated block from an entity.
+     * <p>
+     * If the entity is not an animated block (or null), this method does nothing.
+     * <p>
+     * If the entity is an animated block, this method will attempt to perform a recovery action by calling
+     * {@link IAnimatedBlockRecoveryData#recover()}. If the recovery action is successful, the entity will be removed.
+     *
+     * @param entity
+     */
+    public void recoverAnimatedBlock(@Nullable Entity entity)
+    {
+        if (entity == null)
+            return;
+
+        final IAnimatedBlockRecoveryData recoveryData = entity.getPersistentDataContainer().get(
+            RECOVERY_KEY,
+            AnimatedBlockRecoveryDataType.INSTANCE);
+
+        if (recoveryData == null)
+            return;
+
+        try
+        {
+            if (recoveryData.recover())
+                log.atWarning().log(
+                    "Recovered animated block with recovery data '%s'! " +
+                        "This is not intended behavior, please contact the author(s) of this plugin!",
+                    recoveryData);
+            entity.remove();
+        }
+        catch (RecoveryFailureException e)
+        {
+            log.atSevere().withCause(e).log(
+                "Failed to recover animated block '%s' from recovery: '%s'",
+                entity, recoveryData);
+        }
     }
 
     /**
      * Spawns a new BlockDisplay entity.
      *
-     * @param plugin
-     *     The plugin that is spawning the entity. Used for metadata.
      * @param executor
      *     The executor to assert that this method is called on the main thread.
      * @param bukkitWorld
@@ -45,20 +95,26 @@ public final class BlockDisplayHelper
      *     The block data of the entity to spawn.
      * @return The spawned entity.
      */
-    static BlockDisplay spawn(
-        JavaPlugin plugin,
+    BlockDisplay spawn(
+        IAnimatedBlockRecoveryData recoveryData,
         IExecutor executor,
         World bukkitWorld,
         RotatedPosition spawnPose,
         BlockData blockData)
     {
         executor.assertMainThread("Animated blocks must be spawned on the main thread!");
+
         final Vector3Dd pos = spawnPose.position().floor();
         final Location loc = new Location(bukkitWorld, pos.x(), pos.y(), pos.z());
 
         final BlockDisplay newEntity = bukkitWorld.spawn(loc, BlockDisplay.class);
         newEntity.setBlock(blockData);
-        newEntity.setMetadata(Constants.ANIMATED_ARCHITECTURE_ENTITY_MARKER_KEY, new FixedMetadataValue(plugin, true));
+
+        newEntity.getPersistentDataContainer().set(
+            RECOVERY_KEY,
+            AnimatedBlockRecoveryDataType.INSTANCE,
+            recoveryData);
+
         newEntity.setInterpolationDuration(1);
         return newEntity;
     }
@@ -75,7 +131,7 @@ public final class BlockDisplayHelper
      * @param target
      *     The target position of the entity.
      */
-    public static void moveToTarget(
+    public void moveToTarget(
         @Nullable BlockDisplay entity, RotatedPosition startPosition, RotatedPosition target)
     {
         if (entity == null)
@@ -83,13 +139,13 @@ public final class BlockDisplayHelper
         updateTransformation(entity, startPosition, target);
     }
 
-    private static void updateTransformation(BlockDisplay entity, RotatedPosition startPosition, RotatedPosition target)
+    private void updateTransformation(BlockDisplay entity, RotatedPosition startPosition, RotatedPosition target)
     {
         final Vector3Dd delta = target.position().subtract(startPosition.position());
         entity.setTransformation(getTransformation(startPosition, target.rotation(), delta));
     }
 
-    private static Transformation getTransformation(RotatedPosition startPosition, Vector3Dd rotation, Vector3Dd delta)
+    private Transformation getTransformation(RotatedPosition startPosition, Vector3Dd rotation, Vector3Dd delta)
     {
         final Vector3Dd rads = rotation.subtract(startPosition.rotation()).toRadians();
         final float roll = (float) rads.x();
@@ -107,7 +163,7 @@ public final class BlockDisplayHelper
         return new Transformation(translation, leftRotation, ONE_VECTOR, new Quaternionf());
     }
 
-    private static Vector3f to3f(IVector3D vec)
+    private Vector3f to3f(IVector3D vec)
     {
         return new Vector3f((float) vec.xD(), (float) vec.yD(), (float) vec.zD());
     }
@@ -123,7 +179,7 @@ public final class BlockDisplayHelper
      *     The yaw. Rotation around the y-axis measured in radians.
      * @return The quaternion representing the rotation.
      */
-    public static Quaternionf fromRollPitchYaw(float roll, float pitch, float yaw)
+    public Quaternionf fromRollPitchYaw(float roll, float pitch, float yaw)
     {
         return new Quaternionf().rotateY(yaw).rotateX(pitch).rotateZ(roll);
     }

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/BlockDisplayHelper.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/BlockDisplayHelper.java
@@ -9,13 +9,18 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.BlockDisplay;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.util.Transformation;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
-final class BlockDisplayHelper
+/**
+ * Helper class for BlockDisplay entities.
+ */
+public final class BlockDisplayHelper
 {
     private static final Vector3f ONE_VECTOR = new Vector3f(1F, 1F, 1F);
     private static final Vector3f HALF_VECTOR_POSITIVE = new Vector3f(0.5F, 0.5F, 0.5F);
@@ -25,7 +30,27 @@ final class BlockDisplayHelper
     {
     }
 
-    static BlockDisplay spawn(IExecutor executor, World bukkitWorld, RotatedPosition spawnPose, BlockData blockData)
+    /**
+     * Spawns a new BlockDisplay entity.
+     *
+     * @param plugin
+     *     The plugin that is spawning the entity. Used for metadata.
+     * @param executor
+     *     The executor to assert that this method is called on the main thread.
+     * @param bukkitWorld
+     *     The world to spawn the entity in.
+     * @param spawnPose
+     *     The pose to use for the entity.
+     * @param blockData
+     *     The block data of the entity to spawn.
+     * @return The spawned entity.
+     */
+    static BlockDisplay spawn(
+        JavaPlugin plugin,
+        IExecutor executor,
+        World bukkitWorld,
+        RotatedPosition spawnPose,
+        BlockData blockData)
     {
         executor.assertMainThread("Animated blocks must be spawned on the main thread!");
         final Vector3Dd pos = spawnPose.position().floor();
@@ -33,12 +58,23 @@ final class BlockDisplayHelper
 
         final BlockDisplay newEntity = bukkitWorld.spawn(loc, BlockDisplay.class);
         newEntity.setBlock(blockData);
-        newEntity.setCustomName(Constants.ANIMATED_ARCHITECTURE_ENTITY_NAME);
-        newEntity.setCustomNameVisible(false);
+        newEntity.setMetadata(Constants.ANIMATED_ARCHITECTURE_ENTITY_MARKER_KEY, new FixedMetadataValue(plugin, true));
         newEntity.setInterpolationDuration(1);
         return newEntity;
     }
 
+    /**
+     * Moves an entity from the start position to the target position.
+     * <p>
+     * This method updates the transformation of the entity to move it from the start position to the target position.
+     *
+     * @param entity
+     *     The entity to move. If null, this method does nothing.
+     * @param startPosition
+     *     The start position of the entity. This is original position the entity was created at.
+     * @param target
+     *     The target position of the entity.
+     */
     public static void moveToTarget(
         @Nullable BlockDisplay entity, RotatedPosition startPosition, RotatedPosition target)
     {
@@ -76,6 +112,17 @@ final class BlockDisplayHelper
         return new Vector3f((float) vec.xD(), (float) vec.yD(), (float) vec.zD());
     }
 
+    /**
+     * Creates a quaternion from roll, pitch and yaw.
+     *
+     * @param roll
+     *     The roll. Rotation around the z-axis measured in radians.
+     * @param pitch
+     *     The pitch. Rotation around the x-axis measured in radians.
+     * @param yaw
+     *     The yaw. Rotation around the y-axis measured in radians.
+     * @return The quaternion representing the rotation.
+     */
     public static Quaternionf fromRollPitchYaw(float roll, float pitch, float yaw)
     {
         return new Quaternionf().rotateY(yaw).rotateX(pitch).rotateZ(roll);

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/HighlightedBlockDisplay.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/HighlightedBlockDisplay.java
@@ -7,6 +7,7 @@ import nl.pim16aap2.animatedarchitecture.core.api.IExecutor;
 import nl.pim16aap2.animatedarchitecture.core.api.IHighlightedBlock;
 import nl.pim16aap2.animatedarchitecture.core.api.IWorld;
 import nl.pim16aap2.animatedarchitecture.core.util.Util;
+import nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery.IAnimatedBlockRecoveryData;
 import nl.pim16aap2.animatedarchitecture.spigot.util.SpigotAdapter;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -14,13 +15,12 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.BlockDisplay;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.Entity;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
 @Flogger
 public final class HighlightedBlockDisplay implements IHighlightedBlock
 {
-    private final JavaPlugin plugin;
+    private final BlockDisplayHelper blockDisplayHelper;
     private final IExecutor executor;
     private final RotatedPosition startPosition;
     private final World bukkitWorld;
@@ -29,13 +29,13 @@ public final class HighlightedBlockDisplay implements IHighlightedBlock
     private @Nullable BlockDisplay entity;
 
     public HighlightedBlockDisplay(
-        JavaPlugin plugin,
+        BlockDisplayHelper blockDisplayHelper,
         IExecutor executor,
         RotatedPosition startPosition,
         IWorld world,
         Color color)
     {
-        this.plugin = plugin;
+        this.blockDisplayHelper = blockDisplayHelper;
         this.executor = executor;
         this.startPosition = startPosition;
         this.bukkitWorld = Util.requireNonNull(SpigotAdapter.getBukkitWorld(world), "Bukkit World");
@@ -70,7 +70,8 @@ public final class HighlightedBlockDisplay implements IHighlightedBlock
         executor.assertMainThread("Highlighted blocks must be spawned on the main thread!");
         if (this.entity != null)
             kill();
-        this.entity = BlockDisplayHelper.spawn(plugin, executor, bukkitWorld, startPosition, blockData);
+        this.entity = blockDisplayHelper.spawn(
+            IAnimatedBlockRecoveryData.EMPTY, executor, bukkitWorld, startPosition, blockData);
         this.entity.setViewRange(1F);
         this.entity.setGlowing(true);
         this.entity.setBrightness(new Display.Brightness(15, 15));
@@ -91,7 +92,7 @@ public final class HighlightedBlockDisplay implements IHighlightedBlock
     @Override
     public synchronized void moveToTarget(RotatedPosition target)
     {
-        BlockDisplayHelper.moveToTarget(entity, startPosition, target);
+        blockDisplayHelper.moveToTarget(entity, startPosition, target);
     }
 
     public synchronized @Nullable Entity getEntity()

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/HighlightedBlockDisplay.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/HighlightedBlockDisplay.java
@@ -14,11 +14,13 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.BlockDisplay;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.Entity;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
 @Flogger
 public final class HighlightedBlockDisplay implements IHighlightedBlock
 {
+    private final JavaPlugin plugin;
     private final IExecutor executor;
     private final RotatedPosition startPosition;
     private final World bukkitWorld;
@@ -26,8 +28,14 @@ public final class HighlightedBlockDisplay implements IHighlightedBlock
 
     private @Nullable BlockDisplay entity;
 
-    public HighlightedBlockDisplay(IExecutor executor, RotatedPosition startPosition, IWorld world, Color color)
+    public HighlightedBlockDisplay(
+        JavaPlugin plugin,
+        IExecutor executor,
+        RotatedPosition startPosition,
+        IWorld world,
+        Color color)
     {
+        this.plugin = plugin;
         this.executor = executor;
         this.startPosition = startPosition;
         this.bukkitWorld = Util.requireNonNull(SpigotAdapter.getBukkitWorld(world), "Bukkit World");
@@ -62,11 +70,11 @@ public final class HighlightedBlockDisplay implements IHighlightedBlock
         executor.assertMainThread("Highlighted blocks must be spawned on the main thread!");
         if (this.entity != null)
             kill();
-        this.entity = BlockDisplayHelper.spawn(executor, bukkitWorld, startPosition, blockData);
+        this.entity = BlockDisplayHelper.spawn(plugin, executor, bukkitWorld, startPosition, blockData);
         this.entity.setViewRange(1F);
         this.entity.setGlowing(true);
         this.entity.setBrightness(new Display.Brightness(15, 15));
-        //noinspection deprecation
+        //noinspection UnstableApiUsage
         this.entity.setVisibleByDefault(false);
     }
 

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/package-info.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Implementations of animation-related objects for the Spigot platform that do not rely on NMS.
+ * Implementations of animation-related objects for the Spigot platform that do not use version-specific code.
  */
 @NonNullByDefault
 package nl.pim16aap2.animatedarchitecture.spigot.core.animation;

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/recovery/AnimatedBlockRecoveryDataType.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/recovery/AnimatedBlockRecoveryDataType.java
@@ -1,0 +1,101 @@
+package nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.persistence.PersistentDataAdapterContext;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.lang.reflect.Type;
+
+/**
+ * Represents the data type for the recovery data of an animated block.
+ * <p>
+ * This class is used to store the recovery data of an animated block. These data are used to recover the state of an
+ * animated block that has been 'orphaned' (e.g. during a server crash).
+ * <p>
+ * This class can be used through {@link #INSTANCE}.
+ */
+public final class AnimatedBlockRecoveryDataType implements PersistentDataType<String, IAnimatedBlockRecoveryData>
+{
+    /**
+     * The instance of this class.
+     */
+    public static final AnimatedBlockRecoveryDataType INSTANCE = new AnimatedBlockRecoveryDataType();
+
+    private final Gson gson = new GsonBuilder()
+        .registerTypeAdapter(BlockData.class, new BlockDataSerializer())
+        .registerTypeAdapter(BlockData.class, new BlockDataDeserializer())
+        .create();
+
+    private AnimatedBlockRecoveryDataType()
+    {
+    }
+
+    @Override
+    public Class<String> getPrimitiveType()
+    {
+        return String.class;
+    }
+
+    @Override
+    public Class<IAnimatedBlockRecoveryData> getComplexType()
+    {
+        return IAnimatedBlockRecoveryData.class;
+    }
+
+    @Override
+    public String toPrimitive(IAnimatedBlockRecoveryData complex, PersistentDataAdapterContext context)
+    {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("type", complex.getClass().getName());
+        jsonObject.add("data", gson.toJsonTree(complex));
+        return gson.toJson(jsonObject);
+    }
+
+    @Override
+    public IAnimatedBlockRecoveryData fromPrimitive(String primitive, PersistentDataAdapterContext context)
+    {
+        final JsonObject jsonObject = gson.fromJson(primitive, JsonObject.class);
+        final String type = jsonObject.get("type").getAsString();
+        final JsonElement element = jsonObject.get("data");
+
+        try
+        {
+            Class<?> clazz = Class.forName(type);
+            return (IAnimatedBlockRecoveryData) gson.fromJson(element, clazz);
+        }
+        catch (ClassNotFoundException e)
+        {
+            throw new IllegalArgumentException("Unknown RecoveryData subclass: " + type);
+        }
+    }
+
+    private static class BlockDataSerializer implements JsonSerializer<BlockData>
+    {
+        @Override
+        public JsonElement serialize(BlockData src, Type typeOfSrc, JsonSerializationContext context)
+        {
+            return new JsonPrimitive(src.getAsString());
+        }
+    }
+
+    private static class BlockDataDeserializer implements JsonDeserializer<BlockData>
+    {
+        @Override
+        public BlockData deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException
+        {
+            return Bukkit.createBlockData(json.getAsString());
+        }
+    }
+}

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/recovery/IAnimatedBlockRecoveryData.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/recovery/IAnimatedBlockRecoveryData.java
@@ -1,0 +1,77 @@
+package nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery;
+
+import nl.pim16aap2.animatedarchitecture.core.util.vector.Vector3Di;
+import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
+
+import javax.annotation.CheckReturnValue;
+
+/**
+ * Represents an object that stores recovery data for an animated block.
+ */
+public sealed interface IAnimatedBlockRecoveryData
+{
+    /**
+     * An empty recovery data object.
+     *
+     * @see EmptyRecoveryData
+     */
+    IAnimatedBlockRecoveryData EMPTY = new EmptyRecoveryData();
+
+    /**
+     * Attempts recovery of the animated block display.
+     * <p>
+     * This method gives the animated block the opportunity to recover from a crash or other unexpected event.
+     * <p>
+     * No guarantees are made about the exact behavior of this method, but as long as any kind of recovery action is
+     * performed, this method should return true. Only when this method is a no-op should it return false.
+     *
+     * @return True if a recovery action was performed, false otherwise.
+     *
+     * @throws RecoveryFailureException
+     *     If something prevented the recovery action from being successful.
+     */
+    @CheckReturnValue
+    boolean recover()
+        throws RecoveryFailureException;
+
+    /**
+     * Represents an object that stores recovery data for an animated block.
+     * <p>
+     * The recovery data consists of the world, position, and block data of the block that needs to be recovered.
+     * <p>
+     * The recovery action is performed by placing the block data at the specified position in the specified world.
+     */
+    record AnimatedBlockRecoveryData(
+        World world,
+        Vector3Di position,
+        BlockData data
+    ) implements IAnimatedBlockRecoveryData
+    {
+        @Override
+        public boolean recover()
+        {
+            world.setBlockData(position.x(), position.y(), position.z(), data);
+            return true;
+        }
+    }
+
+    /**
+     * Represents an empty recovery data object.
+     * <p>
+     * This object does nothing when {@link #recover()} is called.
+     * <p>
+     * This is useful in situations where no recovery action is needed (e.g. when the block is a preview block and does
+     * not alter the world).
+     *
+     * @see #EMPTY
+     */
+    record EmptyRecoveryData() implements IAnimatedBlockRecoveryData
+    {
+        @Override
+        public boolean recover()
+        {
+            return false;
+        }
+    }
+}

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/recovery/IAnimatedBlockRecoveryData.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/recovery/IAnimatedBlockRecoveryData.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery;
 
 import nl.pim16aap2.animatedarchitecture.core.util.vector.Vector3Di;
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.block.data.BlockData;
 
@@ -41,6 +42,13 @@ public sealed interface IAnimatedBlockRecoveryData
      * The recovery data consists of the world, position, and block data of the block that needs to be recovered.
      * <p>
      * The recovery action is performed by placing the block data at the specified position in the specified world.
+     *
+     * @param world
+     *     The world the block exists in.
+     * @param position
+     *     The position of the block.
+     * @param data
+     *     The recovery data.
      */
     record AnimatedBlockRecoveryData(
         World world,
@@ -48,6 +56,13 @@ public sealed interface IAnimatedBlockRecoveryData
         BlockData data
     ) implements IAnimatedBlockRecoveryData
     {
+        public AnimatedBlockRecoveryData
+        {
+            // We need to make a deep copy of BlockData because it is mutable and
+            // may be altered after this object is created.
+            Bukkit.createBlockData(data.getAsString());
+        }
+
         @Override
         public boolean recover()
         {

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/recovery/RecoveryFailureException.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/recovery/RecoveryFailureException.java
@@ -1,0 +1,25 @@
+package nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery;
+
+/**
+ * Represents an exception that is thrown when a recovery action fails.
+ */
+public class RecoveryFailureException extends Exception
+{
+    @SuppressWarnings("unused")
+    public RecoveryFailureException(String message)
+    {
+        super(message);
+    }
+
+    @SuppressWarnings("unused")
+    public RecoveryFailureException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    @SuppressWarnings("unused")
+    public RecoveryFailureException(Throwable cause)
+    {
+        super(cause);
+    }
+}

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/recovery/package-info.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/recovery/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Contains classes that are used to recover data from animated blocks in case they end up in a state4 where this plugin
+ * has lost track of them.
+ */
+@NonNullByDefault
+package nl.pim16aap2.animatedarchitecture.spigot.core.animation.recovery;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/implementations/HighlightedBlockSpawnerSpigot.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/implementations/HighlightedBlockSpawnerSpigot.java
@@ -116,7 +116,7 @@ public class HighlightedBlockSpawnerSpigot extends HighlightedBlockSpawner imple
             log.atSevere().log("Failed to create glowing entity!");
             return Optional.empty();
         }
-        //noinspection deprecation
+        //noinspection UnstableApiUsage
         spigotPlayer.showEntity(plugin, entity);
 
         onBlockSpawn(block, time);
@@ -126,7 +126,7 @@ public class HighlightedBlockSpawnerSpigot extends HighlightedBlockSpawner imple
     private HighlightedBlockDisplay newPreviewBlock(IWorld world, RotatedPosition rotatedPosition, Color color)
     {
         final HighlightedBlockDisplay ret =
-            new HighlightedBlockDisplay(executor, rotatedPosition, world, color);
+            new HighlightedBlockDisplay(plugin, executor, rotatedPosition, world, color);
         ret.spawn();
         return ret;
     }

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/implementations/HighlightedBlockSpawnerSpigot.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/implementations/HighlightedBlockSpawnerSpigot.java
@@ -15,6 +15,7 @@ import nl.pim16aap2.animatedarchitecture.core.api.restartable.IRestartable;
 import nl.pim16aap2.animatedarchitecture.core.api.restartable.RestartableHolder;
 import nl.pim16aap2.animatedarchitecture.core.util.Util;
 import nl.pim16aap2.animatedarchitecture.spigot.core.AnimatedArchitecturePlugin;
+import nl.pim16aap2.animatedarchitecture.spigot.core.animation.BlockDisplayHelper;
 import nl.pim16aap2.animatedarchitecture.spigot.core.animation.HighlightedBlockDisplay;
 import nl.pim16aap2.animatedarchitecture.spigot.util.SpigotAdapter;
 import nl.pim16aap2.animatedarchitecture.spigot.util.SpigotUtil;
@@ -63,11 +64,17 @@ public class HighlightedBlockSpawnerSpigot extends HighlightedBlockSpawner imple
     @Getter(AccessLevel.PROTECTED)
     private final IExecutor executor;
 
+    private final BlockDisplayHelper blockDisplayHelper;
+
     @Inject HighlightedBlockSpawnerSpigot(
-        RestartableHolder holder, AnimatedArchitecturePlugin plugin, IExecutor executor)
+        RestartableHolder holder,
+        AnimatedArchitecturePlugin plugin,
+        BlockDisplayHelper blockDisplayHelper,
+        IExecutor executor)
     {
         this.plugin = plugin;
         this.executor = executor;
+        this.blockDisplayHelper = blockDisplayHelper;
         holder.registerRestartable(this);
     }
 
@@ -126,7 +133,7 @@ public class HighlightedBlockSpawnerSpigot extends HighlightedBlockSpawner imple
     private HighlightedBlockDisplay newPreviewBlock(IWorld world, RotatedPosition rotatedPosition, Color color)
     {
         final HighlightedBlockDisplay ret =
-            new HighlightedBlockDisplay(plugin, executor, rotatedPosition, world, color);
+            new HighlightedBlockDisplay(blockDisplayHelper, executor, rotatedPosition, world, color);
         ret.spawn();
         return ret;
     }


### PR DESCRIPTION
Closes #593

- Each animated block now stores `IAnimatedBlockRecoveryData` in its PersistentDataContainer. These data contain either the original world+location+blockdata of the blocks or nothing at all.
- Add a listener for chunk load events to check if any animated blocks exist in the chunk. If so, it will attempt to recover these blocks by putting them back where they came from and cleaning up the leftover entities.