### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,6 +33,8 @@
     "nl.pim16aap2.animatedarchitecture:structure-revolvingdoor",
     "nl.pim16aap2.animatedarchitecture:structure-slidingdoor",
     "nl.pim16aap2.animatedarchitecture:structure-windmill",
-    "nl.pim16aap2.animatedarchitecture:structures"
+    "nl.pim16aap2.animatedarchitecture:structures",
+    "com.plotsquared:PlotSquared-Bukkit",
+    "com.plotsquared:PlotSquared-Core"
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "ignoreDeps": [
     "nl.pim16aap2:test-util",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,33 @@
   "extends": [
     "config:recommended"
   ],
+  "packageRules": [
+    {
+      "depTypeList": [
+        "build"
+      ],
+      "packageNames": [
+        "com.google.dagger:dagger",
+        "org.junit.jupiter:junit-jupiter-api",
+        "org.mockito:mockito-core",
+        "com.google.jimfs:jimfs",
+        "org.projectlombok:lombok",
+        "com.alibaba:fastjson",
+        "com.puppycrawl.tools:checkstyle"
+      ],
+      "packagePatterns": [
+        "^org\\.apache\\.maven\\.plugins:.*",
+        "^org\\.slf4j:.*",
+        "^ch\\.qos\\.logback:.*",
+        "^log4j:.*"
+      ],
+      "automerge": true,
+      "automergeType": "branch",
+      "requiredStatusChecks": [
+        "build"
+      ]
+    }
+  ],
   "ignoreDeps": [
     "nl.pim16aap2:test-util",
     "nl.pim16aap2:util",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,19 @@
       "requiredStatusChecks": [
         "build"
       ]
+    },
+    {
+      "matchFileNames": [
+        "animatedarchitecture-spigot/protection-hooks/**/pom.xml"
+      ],
+      "schedule": [
+        "on the first day of the month"
+      ],
+      "automerge": true,
+      "automergeType": "branch",
+      "requiredStatusChecks": [
+        "build"
+      ]
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
- Use recommended settings as a starting point instead of the base settings.
- Automatically merge dependency PRs for certain 'safe' dependencies that are either required to work for successful compilation (e.g. maven-compiler-plugin) or are tested properly.
- Skip PlotSquared 6 updates, as its latest update is broken and there are no planned future updates for it.