### PR TITLE
Fix compilation issue with PlotSquared 6

### DIFF
--- a/animatedarchitecture-spigot/protection-hooks/hook-plotsquared-6/pom.xml
+++ b/animatedarchitecture-spigot/protection-hooks/hook-plotsquared-6/pom.xml
@@ -29,9 +29,27 @@
     <dependencies>
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-core</artifactId>
+            <version>${dependency.worldedit.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
             <version>${dependency.worldedit.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -39,6 +57,12 @@
             <artifactId>paperlib</artifactId>
             <version>${dependency.paperlib.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -46,12 +70,24 @@
             <artifactId>PlotSquared-Core</artifactId>
             <version>${dependency.plotsquared.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.plotsquared</groupId>
             <artifactId>PlotSquared-Bukkit</artifactId>
             <version>${dependency.plotsquared.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
- PS6 pulled in an older build of minimessage that's no longer hosted in the expected place. Excluding it allows us to compile it normally.