### PR TITLE
Update Extension loading system

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfo.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfo.java
@@ -5,118 +5,225 @@ import lombok.ToString;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.animatedarchitecture.core.util.Util;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Contains information about a structure type.
+ * <p>
+ * These data are extracted from the manifest of the jar file that contains the structure type and can be used to
+ * instantiate the structure type.
+ */
 @Flogger
-@ToString//
+@ToString
 final class StructureTypeInfo
 {
-    private static final Pattern NAME_MATCH = Pattern.compile("^[a-zA-Z]*");
-    private static final Pattern MIN_VERSION_MATCH = Pattern.compile("[0-9]*;");
-    private static final Pattern MAX_VERSION_MATCH = Pattern.compile(";[0-9]*");
+    /**
+     * Matches the name of a dependency in the format "{@code string(int;int)}".
+     * <p>
+     * The name is expected to be a sequence of lower case characters followed by the version range in parentheses at
+     * the end of the string.
+     */
+    private static final Pattern NAME_MATCH = Pattern.compile("^[a-z0-9_-]+(?=\\([0-9]+;[0-9]+\\)$)");
 
+    /**
+     * Matches the version range of a dependency in the format "{@code string(int;int)}".
+     * <p>
+     * The version range is expected to be 2 integers separated by a semicolon and enclosed in parentheses without any
+     * characters in the String after the closing parenthesis.
+     */
+    private static final Pattern VERSION_MATCH = Pattern.compile("(?<=\\()[0-9]+;[0-9]+(?=\\)$)");
+
+    /**
+     * The name of the structure type.
+     */
     @Getter
     private final String typeName;
+
+    /**
+     * The version of the structure type.
+     */
     @Getter
     private final int version;
+
+    /**
+     * The path to the main class of the structure type.
+     * <p>
+     * E.g. {@code com.example.Main}.
+     */
     @Getter
     private final String mainClass;
+
+    /**
+     * The path to the jar file being described by this {@link StructureTypeInfo}.
+     */
     @Getter
     private final Path jarFile;
+
+    /**
+     * A String that contains the supported API version(s) of the structure type.
+     */
+    @Getter
+    private final String supportedApiVersions;
+
+    /**
+     * The dependencies of the structure type.
+     * <p>
+     * Each dependency is defined by a name, a minimum version, and a maximum version. The version of a structure type
+     * must be between the minimum and maximum version of the dependency for the dependency to be satisfied.
+     */
     @Getter
     private final List<Dependency> dependencies;
 
+    /**
+     * Creates a new instance of {@link StructureTypeInfo}.
+     *
+     * @param typeName
+     *     The name of the structure type.
+     * @param version
+     *     The version of the structure type.
+     * @param mainClass
+     *     The main class of the structure type.
+     * @param jarFile
+     *     The jar file that contains the structure type.
+     * @param dependencies
+     *     The dependencies of the structure type. This is a string that contains a space-separated list of dependencies
+     *     in the format "{@code <typeName>(minVersion;maxVersion)}". For example: "{@code portcullis(1;5) door(1;1)}".
+     *     <p>
+     *     Both the minimum and the maximum versions of the dependency are inclusive.
+     */
     public StructureTypeInfo(
         String typeName,
         int version,
         String mainClass,
         Path jarFile,
+        String supportedApiVersions,
         @Nullable String dependencies)
     {
         this.typeName = typeName.toLowerCase(Locale.ENGLISH);
         this.version = version;
         this.mainClass = mainClass;
         this.jarFile = jarFile;
-        this.dependencies = Collections.unmodifiableList(parseDependencies(dependencies));
+        this.supportedApiVersions = supportedApiVersions;
+        this.dependencies = parseDependencies(dependencies, typeName);
     }
 
-    private List<Dependency> parseDependencies(@Nullable String dependencies)
+    /**
+     * Parses a String containing dependencies into a list of {@link Dependency} objects.
+     * <p>
+     * The dependencies are expected to be a space-separated list of dependencies in the format
+     * "{@code <typeName>(minVersion;maxVersion)}". For example: "{@code portcullis(1;5) door(1;1)}".
+     *
+     * @param dependencies
+     *     The String
+     * @param typeName
+     *     The name of the structure type. This is used for logging purposes.
+     * @return The list of dependencies parsed from the provided string.
+     */
+    @VisibleForTesting
+    static List<Dependency> parseDependencies(@Nullable String dependencies, String typeName)
     {
-        if (dependencies == null || dependencies.isEmpty())
+        if (dependencies == null || dependencies.isEmpty() || "null".equals(dependencies))
             return Collections.emptyList();
 
-        final String[] split = dependencies.split(" ");
+        final String[] split = dependencies.toLowerCase(Locale.ENGLISH).split(" ");
         final List<Dependency> ret = new ArrayList<>(split.length);
 
         for (int idx = 0; idx < split.length; ++idx)
         {
-            final int arrPos = idx;
-            parseDependency(split[idx]).ifPresentOrElse(
-                dep -> ret.add(arrPos, dep),
-                () -> log.atSevere().log("Failed to parse dependency '%s' for type: %s", split[arrPos], typeName));
+            final String depStr = split[idx];
+
+            try
+            {
+                ret.add(idx, parseDependency(depStr));
+            }
+            catch (Exception exception)
+            {
+                throw new IllegalArgumentException(
+                    "Failed to parse dependency '" + depStr +
+                        "' at index " + idx +
+                        " from dependency string '" + dependencies +
+                        "' for structure type '" + typeName + "'.",
+                    exception
+                );
+            }
         }
-        return ret;
+        return Collections.unmodifiableList(ret);
     }
 
-    private Optional<Dependency> parseDependency(String dependency)
+    @VisibleForTesting
+    static Dependency parseDependency(@Nullable String dependency)
     {
+        if (dependency == null || dependency.isBlank())
+            throw new IllegalArgumentException("Dependency must not be null or blank.");
+
+        // Get all the alphanumeric characters at the start of the string.
         final Matcher nameMatcher = NAME_MATCH.matcher(dependency);
         if (!nameMatcher.find())
-        {
-            log.atFine().log("Failed to find the dependency name in: %s", dependency);
-            return Optional.empty();
-        }
+            throw new IllegalArgumentException("Failed to find the dependency name in: '" + dependency + "'");
+
         final String dependencyName = nameMatcher.group();
 
-        final Matcher minVersionMatcher = MIN_VERSION_MATCH.matcher(dependency);
-        if (!minVersionMatcher.find())
-        {
-            log.atFine().log("Failed to find the min version in: %s", dependency);
-            return Optional.empty();
-        }
-        String minVersionStr = minVersionMatcher.group();
-        minVersionStr = minVersionStr.substring(0, minVersionStr.length() - 1);
-        final OptionalInt minVersionOpt = Util.parseInt(minVersionStr);
+        final Matcher versionMatcher = VERSION_MATCH.matcher(dependency);
+        if (!versionMatcher.find())
+            throw new IllegalArgumentException("Failed to find the version in: '" + dependency + "'");
+
+        final String[] versionSplit = versionMatcher.group().split(";");
+        if (versionSplit.length != 2)
+            throw new IllegalArgumentException("Failed to split the version in: '" + dependency + "'");
+
+        final OptionalInt minVersionOpt = Util.parseInt(versionSplit[0]);
         if (minVersionOpt.isEmpty())
-        {
-            log.atFine().log("Failed to parse min version from: %s", minVersionStr);
-            return Optional.empty();
-        }
+            throw new IllegalArgumentException("Failed to parse min version from '" + versionSplit[0] + "'");
 
-        final Matcher maxVersionMatcher = MAX_VERSION_MATCH.matcher(dependency);
-        if (!maxVersionMatcher.find())
-        {
-            log.atFine().log("Failed to find the max version in: %s", dependency);
-            return Optional.empty();
-        }
-
-        String maxVersionStr = maxVersionMatcher.group();
-        maxVersionStr = maxVersionStr.substring(1);
-        final OptionalInt maxVersionOpt = Util.parseInt(maxVersionStr);
+        final OptionalInt maxVersionOpt = Util.parseInt(versionSplit[1]);
         if (maxVersionOpt.isEmpty())
-        {
-            log.atFine().log("Failed to parse max version from: %s", maxVersionStr);
-            return Optional.empty();
-        }
+            throw new IllegalArgumentException("Failed to parse max version from '" + versionSplit[1] + "'");
 
-        return Optional.of(new Dependency(dependencyName, minVersionOpt.getAsInt(), maxVersionOpt.getAsInt()));
+        return new Dependency(dependencyName, minVersionOpt.getAsInt(), maxVersionOpt.getAsInt());
     }
 
-    public record Dependency(String dependencyName, int minVersion, int maxVersion)
+    /**
+     * Represents a dependency of a structure type.
+     * <p>
+     * A dependency is defined by a name, a minimum version, and a maximum version. The version of a structure type must
+     * be between the minimum and maximum version of the dependency for the dependency to be satisfied.
+     *
+     * @param dependencyName
+     *     The name of the dependency. This is the name of the structure type that this dependency represents.
+     * @param minVersion
+     *     The minimum version of the dependency. Inclusive.
+     *     <p>
+     *     Must be smaller than {@code maxVersion}.
+     * @param maxVersion
+     *     The maximum version of the dependency. Inclusive.
+     *     <p>
+     *     Must be larger than {@code minVersion}.
+     */
+    record Dependency(String dependencyName, int minVersion, int maxVersion)
     {
+        // Ensure that the minVersion is smaller than the maxVersion.
+        Dependency
+        {
+            if (minVersion > maxVersion)
+                throw new IllegalArgumentException("minVersion must be smaller than maxVersion.");
+
+            if (dependencyName.isBlank())
+                throw new IllegalArgumentException("dependencyName must not be blank.");
+        }
+
         @Override
         public String toString()
         {
-            return dependencyName + "(" + minVersion + "," + maxVersion + ")";
+            return dependencyName + "(" + minVersion + ";" + maxVersion + ")";
         }
 
         /**
@@ -127,7 +234,7 @@ final class StructureTypeInfo
          *     The structure type info to compare against.
          * @return True if this dependency is satisfied by the provided {@link StructureTypeInfo}.
          */
-        public boolean satisfiedBy(StructureTypeInfo structureTypeInfo)
+        boolean satisfiedBy(StructureTypeInfo structureTypeInfo)
         {
             return structureTypeInfo.getTypeName().equals(dependencyName) &&
                 Util.between(structureTypeInfo.getVersion(), minVersion, maxVersion);

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInitializer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInitializer.java
@@ -202,7 +202,7 @@ final class StructureTypeInitializer
         }
         catch (NoSuchMethodException e)
         {
-            log.atSevere().log("Failed to load invalid extension: %s", structureTypeInfo);
+            log.atSevere().withCause(e).log("Failed to load invalid extension: %s", structureTypeInfo);
             return null;
         }
         catch (Exception | Error e)

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/storage/SQLStatement.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/storage/SQLStatement.java
@@ -275,22 +275,6 @@ public enum SQLStatement
         """
     ),
 
-    LEGACY_ALTER_TABLE_ON(
-        "PRAGMA legacy_alter_table = ON;"
-    ),
-
-    LEGACY_ALTER_TABLE_OFF(
-        "PRAGMA legacy_alter_table = OFF;"
-    ),
-
-    FOREIGN_KEYS_ON(
-        "PRAGMA foreign_keys = ON;"
-    ),
-
-    FOREIGN_KEYS_OFF(
-        "PRAGMA foreign_keys = OFF;"
-    ),
-
     ;
 
     private final String statement;

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/storage/sqlite/SQLiteJDBCDriverConnection.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/storage/sqlite/SQLiteJDBCDriverConnection.java
@@ -223,37 +223,6 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
         return getConnection(DatabaseState.OK);
     }
 
-    /**
-     * Because SQLite is a PoS and decided to remove the admittedly odd behavior that just disabling foreign keys
-     * suddenly ignored all the triggers etc. attached to it without actually providing a proper alternative (perhaps
-     * implement ALTER TABLE properly??), this method needs to be called now in order to safely modify stuff without
-     * having the foreign keys getting fucked up.
-     *
-     * @param conn
-     *     The connection.
-     */
-    @SuppressWarnings("unused")
-    private void disableForeignKeys(Connection conn)
-        throws Exception
-    {
-        SQLStatement.FOREIGN_KEYS_OFF.constructDelayedPreparedStatement().construct(conn).execute();
-        SQLStatement.LEGACY_ALTER_TABLE_ON.constructDelayedPreparedStatement().construct(conn).execute();
-    }
-
-    /**
-     * The anti method of {@link #disableForeignKeys(Connection)}. Only needs to be called if that was called first.
-     *
-     * @param conn
-     *     The connection.
-     */
-    @SuppressWarnings("unused")
-    private void reEnableForeignKeys(Connection conn)
-        throws Exception
-    {
-        SQLStatement.FOREIGN_KEYS_ON.constructDelayedPreparedStatement().construct(conn).execute();
-        SQLStatement.LEGACY_ALTER_TABLE_OFF.constructDelayedPreparedStatement().construct(conn).execute();
-    }
-
     private Optional<AbstractStructure> constructStructure(ResultSet structureBaseRS)
         throws Exception
     {

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfoTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfoTest.java
@@ -1,0 +1,200 @@
+package nl.pim16aap2.animatedarchitecture.core.extensions;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static nl.pim16aap2.animatedarchitecture.core.extensions.StructureTypeInfo.Dependency;
+import static nl.pim16aap2.animatedarchitecture.core.extensions.StructureTypeInfo.parseDependency;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StructureTypeInfoTest
+{
+    @Test
+    void testConstructor()
+    {
+        final String typeName = "typeName";
+        final int version = 1;
+        final String mainClass = "com.example.Main";
+        final Path jarFile = Path.of("/does/not/exist.jar");
+
+        Assertions.assertDoesNotThrow(() ->
+            new StructureTypeInfo(typeName, version, mainClass, jarFile, "1.0.0", ""));
+
+        Assertions.assertDoesNotThrow(() ->
+            new StructureTypeInfo(typeName, version, mainClass, jarFile, "1.0.0", null));
+
+        Assertions.assertDoesNotThrow(() ->
+            new StructureTypeInfo(typeName, version, mainClass, jarFile, "1.0.0", "null"));
+
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new StructureTypeInfo(typeName, version, mainClass, jarFile, "1.0.0", "garbage"));
+
+        // The name of the structure type should be lower-case.
+        Assertions.assertEquals(
+            "typename",
+            new StructureTypeInfo(typeName, version, mainClass, jarFile, "1.0.0", "").getTypeName()
+        );
+    }
+
+    @Test
+    void testParseValidDependencies()
+    {
+        final List<Dependency> dependencies =
+            parseDependencies("portcullis(1;5) Door(2;3) my-super_special-Dependency(1;1)");
+
+        assertEquals(3, dependencies.size());
+
+        var dep = dependencies.getFirst();
+        assertEquals("portcullis", dep.dependencyName());
+        assertEquals(1, dep.minVersion());
+        assertEquals(5, dep.maxVersion());
+
+        dep = dependencies.get(1);
+        assertEquals("door", dep.dependencyName());
+        assertEquals(2, dep.minVersion());
+        assertEquals(3, dep.maxVersion());
+
+        dep = dependencies.get(2);
+        assertEquals("my-super_special-dependency", dep.dependencyName());
+        assertEquals(1, dep.minVersion());
+        assertEquals(1, dep.maxVersion());
+    }
+
+    @Test
+    void testParseInvalidDependencies()
+    {
+        Assertions.assertTrue(parseDependencies("").isEmpty());
+        Assertions.assertTrue(parseDependencies(" ").isEmpty());
+        Assertions.assertTrue(parseDependencies(null).isEmpty());
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependencies("garbage"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependencies("portcullis(1;5)door(1;1)"));
+    }
+
+    @Test
+    void testParseValidDependency()
+    {
+        var dependency = parseDependency("portcullis(1;5)");
+
+        assertEquals("portcullis", dependency.dependencyName());
+        assertEquals(1, dependency.minVersion());
+        assertEquals(5, dependency.maxVersion());
+    }
+
+    @Test
+    void testParseEmptyDependency()
+    {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency(""));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency(" "));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency(null));
+    }
+
+    @Test
+    void testParseInvalidDependency()
+    {
+        // The name of the dependency should be lower-case.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency("Portcullis(1;5)"));
+
+        // Missing closing parenthesis.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency("portcullis(1;5"));
+
+        // 3 version numbers instead of 2.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency("portcullis(1;5;6)"));
+
+        // 1 version number instead of 2.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency("portcullis(1)"));
+
+        // Additional characters after the closing parenthesis.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency("portcullis(1;5)garbage"));
+
+        // Invalid (leading) characters in the name.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency(" portcullis(1;5)"));
+
+        // Invalid (trailing) characters in the name.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency("portcullis (1;5)"));
+
+        // Invalid characters in the middle of the name.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency("port cullis(1;5)"));
+
+        // Version numbers separated by a colon instead of a semicolon.
+        Assertions.assertThrows(IllegalArgumentException.class, () -> parseDependency("portcullis(1:5)"));
+    }
+
+    @Test
+    void testValidDependencyConstructor()
+    {
+        final String dependencyName = "dep";
+
+        Assertions.assertDoesNotThrow(() -> new Dependency(dependencyName, 1, 1));
+        Assertions.assertDoesNotThrow(() -> new Dependency(dependencyName, 1, 2));
+    }
+
+    @Test
+    void testInvalidNameDependencyConstructor()
+    {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Dependency("", 1, 1));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Dependency(" ", 1, 1));
+    }
+
+    @Test
+    void testInvalidVersionsDependencyConstructor()
+    {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Dependency("dep", 1, 0));
+    }
+
+    @Test
+    void testDependencySatisfiedBy()
+    {
+        final String dependencyName = "structure-type";
+        final Dependency dependency = new Dependency(dependencyName, 1, 2);
+
+        Assertions.assertTrue(dependency.satisfiedBy(structureTypeInfo(1, dependencyName)));
+        Assertions.assertTrue(dependency.satisfiedBy(structureTypeInfo(2, dependencyName)));
+
+        Assertions.assertFalse(dependency.satisfiedBy(structureTypeInfo(0, dependencyName)));
+        Assertions.assertFalse(dependency.satisfiedBy(structureTypeInfo(3, dependencyName)));
+
+        Assertions.assertFalse(dependency.satisfiedBy(structureTypeInfo(2, "another-" + dependencyName)));
+    }
+
+    /**
+     * Shortcut method for {@link StructureTypeInfo#parseDependencies(String, String)}. The name of the structure type
+     * is set to "TestType" (which is only used for logging).
+     *
+     * @param dependencies
+     *     The dependencies to parse.
+     * @return The parsed dependencies.
+     */
+    private List<Dependency> parseDependencies(@Nullable String dependencies)
+    {
+        return StructureTypeInfo.parseDependencies(dependencies, "TestType");
+    }
+
+    /**
+     * Creates a {@link StructureTypeInfo} with the given version and name.
+     * <p>
+     * All other fields are set to placeholder values.
+     *
+     * @param version
+     *     The version of the structure type.
+     * @param name
+     *     The name of the structure type.
+     * @return The created {@link StructureTypeInfo}.
+     */
+    private StructureTypeInfo structureTypeInfo(int version, String name)
+    {
+        return new StructureTypeInfo(
+            name,
+            version,
+            "com.example.Main",
+            Path.of("/does/not/exist.jar"),
+            "1.0.0",
+            null
+        );
+    }
+}

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoaderTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoaderTest.java
@@ -1,0 +1,149 @@
+package nl.pim16aap2.animatedarchitecture.core.extensions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.semver4j.Semver;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+class StructureTypeLoaderTest
+{
+    // This test kind of tests the library code, and only a subset of its functionality.
+    // However, the test is still here to make sure that at least the functionality that
+    // is officially supported by our extension API is working as expected, even if/when
+    // we make changes to how we use the library.
+    @Test
+    void testIsSupported()
+    {
+        final var apiVersion = Semver.of(1, 2, 3);
+
+        for (final String allowed : new String[]{
+            "=1.2.3",
+            ">=1.2.3",
+            "1.0.0 - 1.2.3",
+            "1.2.3 - 1.2.4",
+            "1.x",
+            "1.2.x",
+        })
+        {
+            Assertions.assertTrue(
+                StructureTypeLoader.isSupported(apiVersion, allowed),
+                "Version range '" + allowed + "' should be supported."
+            );
+        }
+
+        //noinspection DataFlowIssue
+        for (final String disallowed : new String[]{
+            "",
+            null,
+            "1.2.4",
+            "1.2.2",
+            "1.3.0",
+            "2.x",
+            "2.0.0",
+            ">=2.0.0",
+        })
+        {
+            Assertions.assertFalse(
+                StructureTypeLoader.isSupported(apiVersion, disallowed),
+                "Version range '" + disallowed + "' should not be supported."
+            );
+        }
+    }
+
+    @Test
+    void testPerformPreloadCheck()
+    {
+        final Path jarFile = Paths.get("/does/not/exist.jar");
+
+        final String alreadyLoadedTypeName = "already-loaded-type";
+        final String unloadedTypeName = "not-loaded-type";
+
+        final Semver apiVersion = Semver.of(1, 0, 0);
+
+        final var alreadyLoadedTypes = new HashSet<String>();
+        alreadyLoadedTypes.add(alreadyLoadedTypeName);
+
+        final var typeInfo = new StructureTypeInfo(
+            alreadyLoadedTypeName,
+            1,
+            "com.example.MainClass",
+            jarFile,
+            "1.2.3",
+            null
+        );
+
+        Assertions.assertEquals(
+            StructureTypeLoader.PreloadCheckResult.ALREADY_LOADED,
+            StructureTypeLoader.performPreloadCheck(apiVersion, alreadyLoadedTypes, typeInfo)
+        );
+
+        final var typeInfo2 = new StructureTypeInfo(
+            unloadedTypeName,
+            1,
+            "com.example.MainClass",
+            jarFile,
+            "2.0.0",
+            null
+        );
+
+        Assertions.assertEquals(
+            StructureTypeLoader.PreloadCheckResult.API_VERSION_NOT_SUPPORTED,
+            StructureTypeLoader.performPreloadCheck(apiVersion, alreadyLoadedTypes, typeInfo2)
+        );
+
+        final var typeInfo3 = new StructureTypeInfo(
+            unloadedTypeName,
+            1,
+            "com.example.MainClass",
+            jarFile,
+            "1.*",
+            null
+        );
+
+        Assertions.assertEquals(
+            StructureTypeLoader.PreloadCheckResult.PASS,
+            StructureTypeLoader.performPreloadCheck(apiVersion, alreadyLoadedTypes, typeInfo3)
+        );
+    }
+
+    @Test
+    void testGetStructureTypeInfo()
+    {
+        final var manifest = new Manifest();
+        final var attributes = new Attributes();
+        attributes.putValue("TypeName", "TypeName");
+        attributes.putValue("Version", "1");
+        attributes.putValue("SupportedApiVersions", "1.2.3");
+        attributes.putValue("TypeDependencies", "door(1;2)");
+        manifest.getEntries().put("EntryTitle", attributes);
+        manifest.getMainAttributes().putValue(Attributes.Name.MAIN_CLASS.toString(), "MainClass");
+
+        final var file = Paths.get("/does/not/exist.jar");
+        final var structureTypeInfoOpt = StructureTypeLoader.getStructureTypeInfo("EntryTitle", file, manifest);
+
+        Assertions.assertTrue(structureTypeInfoOpt.isPresent());
+
+        final var structureTypeInfo = structureTypeInfoOpt.get();
+
+        Assertions.assertEquals("typename", structureTypeInfo.getTypeName());
+        Assertions.assertEquals(1, structureTypeInfo.getVersion());
+        Assertions.assertEquals("MainClass", structureTypeInfo.getMainClass());
+        Assertions.assertEquals(file, structureTypeInfo.getJarFile());
+        Assertions.assertEquals("1.2.3", structureTypeInfo.getSupportedApiVersions());
+        Assertions.assertEquals(
+            List.of(new StructureTypeInfo.Dependency("door", 1, 2)),
+            structureTypeInfo.getDependencies()
+        );
+
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> StructureTypeLoader.getStructureTypeInfo("EntryTitle", file, new Manifest())
+        );
+    }
+}

--- a/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/extensions/StructureTypeLoaderIntegrationTest.java
+++ b/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/extensions/StructureTypeLoaderIntegrationTest.java
@@ -4,19 +4,23 @@ import nl.pim16aap2.animatedarchitecture.core.api.IConfig;
 import nl.pim16aap2.animatedarchitecture.core.api.restartable.RestartableHolder;
 import nl.pim16aap2.animatedarchitecture.core.extensions.StructureTypeLoader;
 import nl.pim16aap2.animatedarchitecture.core.managers.StructureTypeManager;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 
-class StructureTypeLoaderTest
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+// This class lives in the integration test module because it requires all the structure types to have been built.
+class StructureTypeLoaderIntegrationTest
 {
     @Mock
     private RestartableHolder restartableHolder;
@@ -27,50 +31,34 @@ class StructureTypeLoaderTest
     @Mock
     private IConfig config;
 
-    private AutoCloseable mocks;
-
     @BeforeEach
     public void init()
     {
-        mocks = MockitoAnnotations.openMocks(this);
         Mockito.when(config.debug()).thenReturn(true);
-    }
-
-    @AfterEach
-    void cleanup()
-        throws Exception
-    {
-        mocks.close();
     }
 
     @Test
     void test()
     {
-        final Path basePath = Path.of("");
-        final String extensionsPath =
-            basePath
-                .toAbsolutePath()
-                .getParent()
-                .getParent()
-                .resolve("structures")
-                .resolve("StructuresOutput")
-                .toAbsolutePath()
-                .toString();
+        final Path extensionsPath = Path.of("../../structures/StructuresOutput").toAbsolutePath();
 
-        final int inputCount = Objects.requireNonNull(new File(extensionsPath).list()).length;
+        final int jarCount =
+            Objects.requireNonNull(extensionsPath.toFile().list((dir, name) -> name.endsWith(".jar"))).length;
+
+        Assertions.assertEquals(9, jarCount);
 
         final var structureTypeLoader = new StructureTypeLoader(
             restartableHolder,
             structureTypeManager,
             config,
-            basePath
+            extensionsPath
         );
 
         structureTypeLoader.initialize();
 
         Assertions.assertEquals(
-            inputCount,
-            structureTypeLoader.loadStructureTypesFromDirectory(Path.of(extensionsPath)).size()
+            jarCount,
+            structureTypeLoader.loadStructureTypesFromDirectory(extensionsPath).size()
         );
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,6 @@
                         </rulesets>
                         <linkXRef>true</linkXRef>
                         <failOnViolation>true</failOnViolation>
-                        <showPmdLog>true</showPmdLog>
                         <detail>true</detail>
                         <printFailingErrors>true</printFailingErrors>
                         <excludeRoots>

--- a/structures/pom.xml
+++ b/structures/pom.xml
@@ -49,9 +49,51 @@
 
     <properties>
         <project.root-dir>${project.basedir}/..</project.root-dir>
+
+        <!--
+        The path to the main class, e.g. com.example.project.Main
+        The main class is supposed to be the class that extends StructureType
+        -->
         <mainClass>UNDEFINED</mainClass>
+
+        <!--
+        The name of the type, e.g. BigDoor
+        This is used for the name of the jar file
+
+        The name can contain letters, numbers, dashes, and underscores.
+        -->
         <typeName>UNDEFINED</typeName>
+
+        <!--
+        The (non-negative) version of the type, e.g. 1
+        -->
         <version>UNDEFINED</version>
+
+        <!--
+        The supported API version(s) of the structure type.
+
+        This refers to the API version of the extension system that the structure type is compatible with.
+
+        A structure can specify this in 2 ways:
+        1) A single version:
+           - `1.0.0`
+           - `>=1.0.0`
+           - `1.x` / `1.*`
+        2) A range of versions: `1.0.0 - 1.1.0`
+
+        If the structure type is incompatible with the API version at runtime, the structure type will not be loaded.
+        -->
+        <supportedApiVersions>UNDEFINED</supportedApiVersions>
+
+        <!--
+        The dependencies of the structure type.
+        This is a string that contains a space-separated list of dependencies in the format
+        `<typeName>(minVersion;maxVersion)`. For example: `portcullis(1;5) door(1;1)`. (Without the backticks.)
+
+        Both the minimum and the maximum versions of the dependency are inclusive.
+
+        Any dependencies listed here will be required at runtime for this structure type to be loaded.
+        -->
         <TypeDependencies/>
     </properties>
 
@@ -71,20 +113,11 @@
                             </manifest>
                             <manifestSections>
                                 <manifestSection>
-                                    <name>TypeName</name>
+                                    <name>StructureTypeMetadata</name>
                                     <manifestEntries>
                                         <TypeName>${typeName}</TypeName>
-                                    </manifestEntries>
-                                </manifestSection>
-                                <manifestSection>
-                                    <name>Version</name>
-                                    <manifestEntries>
                                         <Version>${version}</Version>
-                                    </manifestEntries>
-                                </manifestSection>
-                                <manifestSection>
-                                    <name>TypeDependencies</name>
-                                    <manifestEntries>
+                                        <SupportedApiVersions>${supportedApiVersions}</SupportedApiVersions>
                                         <TypeDependencies>${TypeDependencies}</TypeDependencies>
                                     </manifestEntries>
                                 </manifestSection>
@@ -97,8 +130,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <configuration>
-                        <!-- We do not want to shade anything into the resulting jars
-                        This is explicitly required here because we're exporting to separate jars -->
+                        <!--
+                        We do not want to shade anything into the resulting jars
+                        This is explicitly required here because we're exporting to separate jars
+                        -->
                         <artifactSet>
                             <includes>
                                 <include>nl.pim16aap2.animatedarchitecture.structures:*</include>

--- a/structures/structure-bigdoor/pom.xml
+++ b/structures/structure-bigdoor/pom.xml
@@ -16,6 +16,7 @@
         <mainClass>nl.pim16aap2.animatedarchitecture.structures.bigdoor.StructureTypeBigDoor</mainClass>
         <typeName>BigDoor</typeName>
         <version>1</version>
+        <supportedApiVersions>1.*</supportedApiVersions>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
     </properties>
 

--- a/structures/structure-clock/pom.xml
+++ b/structures/structure-clock/pom.xml
@@ -16,6 +16,7 @@
         <mainClass>nl.pim16aap2.animatedarchitecture.structures.clock.StructureTypeClock</mainClass>
         <typeName>Clock</typeName>
         <version>1</version>
+        <supportedApiVersions>1.*</supportedApiVersions>
         <TypeDependencies>windmill(1;1)</TypeDependencies>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
     </properties>

--- a/structures/structure-drawbridge/pom.xml
+++ b/structures/structure-drawbridge/pom.xml
@@ -16,6 +16,7 @@
         <mainClass>nl.pim16aap2.animatedarchitecture.structures.drawbridge.StructureTypeDrawbridge</mainClass>
         <typeName>Drawbridge</typeName>
         <version>1</version>
+        <supportedApiVersions>1.*</supportedApiVersions>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
     </properties>
 

--- a/structures/structure-flag/pom.xml
+++ b/structures/structure-flag/pom.xml
@@ -10,6 +10,7 @@
         <mainClass>nl.pim16aap2.animatedarchitecture.structures.flag.StructureTypeFlag</mainClass>
         <typeName>Flag</typeName>
         <version>1</version>
+        <supportedApiVersions>1.*</supportedApiVersions>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
     </properties>
 

--- a/structures/structure-garagedoor/pom.xml
+++ b/structures/structure-garagedoor/pom.xml
@@ -16,6 +16,7 @@
         <mainClass>nl.pim16aap2.animatedarchitecture.structures.garagedoor.StructureTypeGarageDoor</mainClass>
         <typeName>GarageDoor</typeName>
         <version>1</version>
+        <supportedApiVersions>1.*</supportedApiVersions>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
     </properties>
 

--- a/structures/structure-portcullis/pom.xml
+++ b/structures/structure-portcullis/pom.xml
@@ -16,6 +16,7 @@
         <mainClass>nl.pim16aap2.animatedarchitecture.structures.portcullis.StructureTypePortcullis</mainClass>
         <typeName>Portcullis</typeName>
         <version>1</version>
+        <supportedApiVersions>1.*</supportedApiVersions>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
     </properties>
 

--- a/structures/structure-revolvingdoor/pom.xml
+++ b/structures/structure-revolvingdoor/pom.xml
@@ -16,6 +16,7 @@
         <mainClass>nl.pim16aap2.animatedarchitecture.structures.revolvingdoor.StructureTypeRevolvingDoor</mainClass>
         <typeName>RevolvingDoor</typeName>
         <version>1</version>
+        <supportedApiVersions>1.*</supportedApiVersions>
         <TypeDependencies>bigdoor(1;1)</TypeDependencies>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
     </properties>

--- a/structures/structure-slidingdoor/pom.xml
+++ b/structures/structure-slidingdoor/pom.xml
@@ -16,6 +16,7 @@
         <mainClass>nl.pim16aap2.animatedarchitecture.structures.slidingdoor.StructureTypeSlidingDoor</mainClass>
         <typeName>SlidingDoor</typeName>
         <version>1</version>
+        <supportedApiVersions>1.*</supportedApiVersions>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
     </properties>
 

--- a/structures/structure-windmill/pom.xml
+++ b/structures/structure-windmill/pom.xml
@@ -16,6 +16,7 @@
         <mainClass>nl.pim16aap2.animatedarchitecture.structures.windmill.StructureTypeWindmill</mainClass>
         <typeName>Windmill</typeName>
         <version>1</version>
+        <supportedApiVersions>1.*</supportedApiVersions>
         <TypeDependencies>drawbridge(1;1)</TypeDependencies>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
     </properties>


### PR DESCRIPTION
- Introduced versioning for the Extensions API for structures. It is currently set to version (2.0.0).
- Each structure now specifies the API version(s) it was made for. If the version being loaded is not supported, there will now be an error message explaining it instead of an esoteric stacktrace about classes/methods/whatever not being found.
- Updated the format of the structure type manifest. All our metadata (other than the main class) is now written under a single header. This is a bit cleaner and simpler.
- Made the extension naming scheme a little more forgiving by allowing dashes, underscore, and numbers.
- Added some tests + docs.