### PR TITLE
Update block placement/removal handling

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedBlockContainer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedBlockContainer.java
@@ -142,20 +142,20 @@ public class AnimatedBlockContainer implements IAnimatedBlockContainer
         {
             try
             {
-                animatedBlock.kill();
-            }
-            catch (Exception e)
-            {
-                log.atSevere().withCause(e).log("Failed to kill animated block: %s", animatedBlock);
-            }
-            try
-            {
                 final IVector3D goalPos = mapper.apply(animatedBlock).toInteger();
                 animatedBlock.getAnimatedBlockData().putBlock(goalPos);
             }
             catch (Exception e)
             {
                 log.atSevere().withCause(e).log("Failed to place block: %s", animatedBlock);
+            }
+            try
+            {
+                animatedBlock.kill();
+            }
+            catch (Exception e)
+            {
+                log.atSevere().withCause(e).log("Failed to kill animated block: %s", animatedBlock);
             }
         }
         privateAnimatedBlocks.clear();

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedBlockContainer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedBlockContainer.java
@@ -178,27 +178,34 @@ public class AnimatedBlockContainer implements IAnimatedBlockContainer
     private void putBlocks(Function<IAnimatedBlock, IVector3D> mapper)
     {
         executor.assertMainThread("Blocks cannot be placed asynchronously!");
-        for (final IAnimatedBlock animatedBlock : getAnimatedBlocks())
-        {
-            try
-            {
-                final IVector3D goalPos = mapper.apply(animatedBlock).toInteger();
-                animatedBlock.getAnimatedBlockData().putBlock(goalPos);
-            }
-            catch (Exception e)
-            {
-                log.atSevere().withCause(e).log("Failed to place block: %s", animatedBlock);
-            }
-            try
-            {
-                animatedBlock.kill();
-            }
-            catch (Exception e)
-            {
-                log.atSevere().withCause(e).log("Failed to kill animated block: %s", animatedBlock);
-            }
-        }
+
+        // The blocks are created from top to bottom, so the list is reversed to place
+        // the blocks from bottom to top (to prevent blocks from falling down).
+        getAnimatedBlocks()
+            .reversed()
+            .forEach(animatedBlock -> putBlock(mapper, animatedBlock));
         privateAnimatedBlocks.clear();
+    }
+
+    private void putBlock(Function<IAnimatedBlock, IVector3D> mapper, IAnimatedBlock animatedBlock)
+    {
+        try
+        {
+            final IVector3D goalPos = mapper.apply(animatedBlock).toInteger();
+            animatedBlock.getAnimatedBlockData().putBlock(goalPos);
+        }
+        catch (Exception e)
+        {
+            log.atSevere().withCause(e).log("Failed to place block: %s", animatedBlock);
+        }
+        try
+        {
+            animatedBlock.kill();
+        }
+        catch (Exception e)
+        {
+            log.atSevere().withCause(e).log("Failed to kill animated block: %s", animatedBlock);
+        }
     }
 
     @Override

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedPreviewBlockContainer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedPreviewBlockContainer.java
@@ -41,7 +41,8 @@ public class AnimatedPreviewBlockContainer implements IAnimatedBlockContainer
      * The (unmodifiable) list of animated blocks.
      */
     @Getter
-    @ToString.Include @EqualsAndHashCode.Include
+    @ToString.Include
+    @EqualsAndHashCode.Include
     private final List<IAnimatedBlock> animatedBlocks;
 
     @Getter
@@ -122,6 +123,18 @@ public class AnimatedPreviewBlockContainer implements IAnimatedBlockContainer
         if (position.equals(cuboid.getMax()))
             return Color.GREEN;
         return Color.BLUE;
+    }
+
+    @Override
+    public void removeOriginalBlocks()
+    {
+        // Not needed for this implementation.
+    }
+
+    @Override
+    public void spawnAnimatedBlocks()
+    {
+        privateAnimatedBlocks.forEach(IAnimatedBlock::spawn);
     }
 
     @Override

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/IAnimatedBlockContainer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/IAnimatedBlockContainer.java
@@ -38,7 +38,30 @@ public interface IAnimatedBlockContainer
      *
      * @return The animation region.
      */
-    @Nullable AnimationRegion getAnimationRegion();
+    @Nullable
+    AnimationRegion getAnimationRegion();
+
+    /**
+     * Tries to replace the original blocks with the animated blocks in the world.
+     * <p>
+     * This method also handles the removal of the original blocks.
+     *
+     * @throws Exception
+     *     If something went wrong and the process had to be aborted.
+     */
+    void spawnAnimatedBlocks()
+        throws Exception;
+
+    /**
+     * Removes the original blocks from the world.
+     * <p>
+     * This method does not have to be called when spawning the animated blocks using {@link #spawnAnimatedBlocks()}.
+     *
+     * @throws Exception
+     *     If something went wrong while removing the original blocks.
+     */
+    void removeOriginalBlocks()
+        throws Exception;
 
     /**
      * Restores all spawned animated blocks to their original positions.

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/AnimatedHighlightedBlock.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/animatedblock/AnimatedHighlightedBlock.java
@@ -118,8 +118,10 @@ public class AnimatedHighlightedBlock implements IAnimatedBlock
     }
 
     @Override
-    public void spawn()
+    public synchronized void spawn()
     {
+        kill();
+
         this.highlightedBlock = highlightedBlockSpawner
             .builder()
             .forPlayer(player)
@@ -131,13 +133,13 @@ public class AnimatedHighlightedBlock implements IAnimatedBlock
     }
 
     @Override
-    public void kill()
+    public synchronized void kill()
     {
         final @Nullable IHighlightedBlock currentBlock = this.highlightedBlock;
         if (currentBlock != null)
         {
-            currentBlock.kill();
             highlightedBlock = null;
+            currentBlock.kill();
         }
     }
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureToggleResult.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureToggleResult.java
@@ -33,6 +33,17 @@ public enum StructureToggleResult
     ERROR("constants.structure_toggle_result.generic_toggle_failure"),
 
     /**
+     * The {@link StructureBase} could not be toggled because it could not find the target coordinates to move to.
+     */
+    CANNOT_FIND_COORDINATES(ERROR.localizationKey),
+
+    /**
+     * The {@link StructureBase} could not be toggled because it was requested to skip an animation that cannot be
+     * skipped.
+     */
+    CANNOT_SKIP_UNSKIPPABLE(ERROR.localizationKey),
+
+    /**
      * Called when trying to skip an animation for a type of structure that does not support skipping animations.
      */
     CANNOT_SKIP("constants.structure_toggle_result.cannot_skip"),

--- a/animatedarchitecture-core/src/main/resources/Core.properties
+++ b/animatedarchitecture-core/src/main/resources/Core.properties
@@ -34,6 +34,7 @@ constants.structure_toggle_result.obstructed={0} "{1}" is obstructed!
 constants.structure_toggle_result.no_direction=Could not find an open direction for {0} "{1}"!
 constants.structure_toggle_result.already_open={0} "{1}" is already open!
 constants.structure_toggle_result.already_closed={0} "{1}" is already closed!
+constants.structure_toggle_result.generic_toggle_failure=Failed to toggle {0} "{1}"!
 constants.structure_toggle_result.type_disabled=The structure type "{0}" is disabled!
 #
 #

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockDisplay.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/animation/AnimatedBlockDisplay.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.animatedarchitecture.spigot.core.animation;
 
+import com.google.common.flogger.StackSize;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import lombok.Getter;
 import lombok.extern.flogger.Flogger;
@@ -99,6 +100,12 @@ public final class AnimatedBlockDisplay implements IAnimatedBlockSpigot
     @GuardedBy("this")
     private void spawn0()
     {
+        if (entity != null)
+        {
+            log.atFine().withStackTrace(StackSize.FULL).log("Entity is already spawned, killing it first!");
+            kill0();
+        }
+
         this.entity = blockDisplayHelper.spawn(
             recoveryData,
             executor,

--- a/structures/structure-drawbridge/src/main/java/nl/pim16aap2/animatedarchitecture/structures/drawbridge/Drawbridge.java
+++ b/structures/structure-drawbridge/src/main/java/nl/pim16aap2/animatedarchitecture/structures/drawbridge/Drawbridge.java
@@ -31,7 +31,8 @@ import java.util.stream.Stream;
 @Flogger
 public class Drawbridge extends AbstractStructure implements IHorizontalAxisAligned
 {
-    @EqualsAndHashCode.Exclude @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
@@ -57,6 +58,12 @@ public class Drawbridge extends AbstractStructure implements IHorizontalAxisAlig
     public Drawbridge(BaseHolder base)
     {
         this(base, 1);
+    }
+
+    @Override
+    public boolean canSkipAnimation()
+    {
+        return true;
     }
 
     @Override

--- a/structures/structure-flag/src/main/java/nl/pim16aap2/animatedarchitecture/structures/flag/Flag.java
+++ b/structures/structure-flag/src/main/java/nl/pim16aap2/animatedarchitecture/structures/flag/Flag.java
@@ -27,7 +27,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @EqualsAndHashCode(callSuper = true)
 public class Flag extends AbstractStructure implements IHorizontalAxisAligned, IPerpetualMover
 {
-    @EqualsAndHashCode.Exclude @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
@@ -92,12 +93,6 @@ public class Flag extends AbstractStructure implements IHorizontalAxisAligned, I
     protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return new FlagAnimationComponent(data, isNorthSouthAnimated());
-    }
-
-    @Override
-    public boolean canSkipAnimation()
-    {
-        return false;
     }
 
     @Override

--- a/structures/structure-garagedoor/src/main/java/nl/pim16aap2/animatedarchitecture/structures/garagedoor/GarageDoor.java
+++ b/structures/structure-garagedoor/src/main/java/nl/pim16aap2/animatedarchitecture/structures/garagedoor/GarageDoor.java
@@ -30,7 +30,8 @@ public class GarageDoor extends AbstractStructure implements IHorizontalAxisAlig
 {
     private static final boolean USE_COUNTER_WEIGHT = true;
 
-    @EqualsAndHashCode.Exclude @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
@@ -44,6 +45,12 @@ public class GarageDoor extends AbstractStructure implements IHorizontalAxisAlig
         super(base, StructureTypeGarageDoor.get());
         this.lock = getLock();
         this.northSouthAnimated = northSouthAnimated;
+    }
+
+    @Override
+    public boolean canSkipAnimation()
+    {
+        return true;
     }
 
     /**
@@ -135,7 +142,7 @@ public class GarageDoor extends AbstractStructure implements IHorizontalAxisAlig
     protected IAnimationComponent constructAnimationComponent(AnimationRequestData data)
     {
         return USE_COUNTER_WEIGHT ?
-               new CounterWeightGarageDoorAnimationComponent(data, getCurrentToggleDir()) :
-               new SectionalGarageDoorAnimationComponent(data, getCurrentToggleDir());
+            new CounterWeightGarageDoorAnimationComponent(data, getCurrentToggleDir()) :
+            new SectionalGarageDoorAnimationComponent(data, getCurrentToggleDir());
     }
 }

--- a/structures/structure-portcullis/src/main/java/nl/pim16aap2/animatedarchitecture/structures/portcullis/Portcullis.java
+++ b/structures/structure-portcullis/src/main/java/nl/pim16aap2/animatedarchitecture/structures/portcullis/Portcullis.java
@@ -27,7 +27,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @EqualsAndHashCode(callSuper = true)
 public class Portcullis extends AbstractStructure implements IDiscreteMovement
 {
-    @EqualsAndHashCode.Exclude @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
@@ -50,6 +51,12 @@ public class Portcullis extends AbstractStructure implements IDiscreteMovement
     public Portcullis(BaseHolder base, @PersistentVariable(value = "blocksToMove") int blocksToMove)
     {
         this(base, StructureTypePortcullis.get(), blocksToMove);
+    }
+
+    @Override
+    public boolean canSkipAnimation()
+    {
+        return true;
     }
 
     @Override

--- a/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/animatedarchitecture/structures/slidingdoor/SlidingDoor.java
+++ b/structures/structure-slidingdoor/src/main/java/nl/pim16aap2/animatedarchitecture/structures/slidingdoor/SlidingDoor.java
@@ -28,7 +28,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @EqualsAndHashCode(callSuper = true)
 public class SlidingDoor extends AbstractStructure implements IDiscreteMovement
 {
-    @EqualsAndHashCode.Exclude @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private final ReentrantReadWriteLock lock;
 
@@ -82,9 +83,9 @@ public class SlidingDoor extends AbstractStructure implements IDiscreteMovement
     {
         final MovementDirection openDirection = getOpenDir();
         return openDirection.equals(MovementDirection.NORTH) ? MovementDirection.EAST :
-               openDirection.equals(MovementDirection.EAST) ? MovementDirection.SOUTH :
-               openDirection.equals(MovementDirection.SOUTH) ? MovementDirection.WEST :
-               MovementDirection.NORTH;
+            openDirection.equals(MovementDirection.EAST) ? MovementDirection.SOUTH :
+                openDirection.equals(MovementDirection.SOUTH) ? MovementDirection.WEST :
+                    MovementDirection.NORTH;
     }
 
     @Override


### PR DESCRIPTION
- Place blocks from the bottom up. This ensures that blocks that require a (certain type of) block under them, such as flowers, are placed correctly.
- Execute block removal and animated block spawning in a single step to reduce the amount of time there's just air where the blocks used to be.
- Some random minor improvements to help with logging/debugging.