### PR TITLE
Drop support for MC < 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following structure types are currently supported:
 ### Requirements:
 
 * Java 21+
-* A Spigot server (or a fork of Spigot) for Minecraft 1.19.4+
+* A Spigot server (or a fork of Spigot) for Minecraft 1.20+
 * Vault
 
 ### Installation:

--- a/animatedarchitecture-spigot/pom.xml
+++ b/animatedarchitecture-spigot/pom.xml
@@ -16,11 +16,11 @@
         <project.root-dir>${project.basedir}/..</project.root-dir>
 
         <dependency.paperlib.version>1.0.8</dependency.paperlib.version>
-        <dependency.spigot-base.version>1.19.4-R0.1-SNAPSHOT</dependency.spigot-base.version>
+        <dependency.spigot-base.version>1.20-R0.1-SNAPSHOT</dependency.spigot-base.version>
     </properties>
 
     <modules>
-        <module>spigot-v1_19_R3</module>
+        <module>spigot-v1_20</module>
         <module>spigot-v1_21</module>
         <module>spigot-core</module>
         <module>spigot-util</module>
@@ -35,6 +35,13 @@
     </repositories>
 
     <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${dependency.spigot-base.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>nl.pim16aap2.animatedarchitecture</groupId>
             <artifactId>animatedarchitecture-core</artifactId>

--- a/animatedarchitecture-spigot/protection-hooks/pom.xml
+++ b/animatedarchitecture-spigot/protection-hooks/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
 
-        <dependency.spigot.version>1.19.4-R0.1-SNAPSHOT</dependency.spigot.version>
         <dependency.worldedit.version>7.3.3</dependency.worldedit.version>
     </properties>
 
@@ -47,13 +46,6 @@
     </modules>
 
     <dependencies>
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>${dependency.spigot.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>nl.pim16aap2.animatedarchitecture</groupId>
             <artifactId>spigot-util</artifactId>

--- a/animatedarchitecture-spigot/spigot-core/pom.xml
+++ b/animatedarchitecture-spigot/spigot-core/pom.xml
@@ -33,7 +33,7 @@
     <dependencies>
         <dependency>
             <groupId>nl.pim16aap2.animatedarchitecture</groupId>
-            <artifactId>spigot-v1_19_R3</artifactId>
+            <artifactId>spigot-v1_20</artifactId>
             <version>0.6.0-SNAPSHOT</version>
         </dependency>
         <dependency>
@@ -64,13 +64,6 @@
             <artifactId>inventorygui</artifactId>
             <version>${dependency.inventory-gui.version}</version>
             <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>${dependency.spigot-base.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/animatedarchitecture-spigot/spigot-core/src/main/resources/plugin.yml
+++ b/animatedarchitecture-spigot/spigot-core/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: AnimatedArchitecture
 main: nl.pim16aap2.animatedarchitecture.spigot.core.AnimatedArchitecturePlugin
 version: ${project.version}
 author: pim16aap2
-api-version: 1.19
+api-version: 1.20
 depend:
   - Vault
 libraries:

--- a/animatedarchitecture-spigot/spigot-util/pom.xml
+++ b/animatedarchitecture-spigot/spigot-util/pom.xml
@@ -16,15 +16,6 @@
         <project.root-dir>${project.basedir}/../..</project.root-dir>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>${dependency.spigot-base.version}</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/animatedarchitecture-spigot/spigot-v1_19_R3/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/v1_19_R3/package-info.java
+++ b/animatedarchitecture-spigot/spigot-v1_19_R3/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/v1_19_R3/package-info.java
@@ -1,7 +1,0 @@
-/**
- * Contains all version-specific code for the Spigot v1_19_R3 platform.
- */
-@NonNullByDefault
-package nl.pim16aap2.animatedarchitecture.spigot.v1_19_R3;
-
-import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/animatedarchitecture-spigot/spigot-v1_20/pom.xml
+++ b/animatedarchitecture-spigot/spigot-v1_20/pom.xml
@@ -2,9 +2,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>spigot-v1_19_R3</artifactId>
+    <artifactId>spigot-v1_20</artifactId>
     <packaging>jar</packaging>
-    <description>AnimatedArchitecture implementation for Spigot 1.19.4</description>
+    <description>AnimatedArchitecture implementation for Spigot 1.20</description>
 
     <parent>
         <artifactId>animatedarchitecture-spigot</artifactId>
@@ -14,8 +14,6 @@
 
     <properties>
         <project.root-dir>${project.basedir}/../..</project.root-dir>
-
-        <dependency.spigot.version>1.19.4-R0.1-SNAPSHOT</dependency.spigot.version>
     </properties>
 
     <dependencies>
@@ -23,13 +21,6 @@
             <groupId>nl.pim16aap2.animatedarchitecture</groupId>
             <artifactId>spigot-util</artifactId>
             <version>0.6.0-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>${dependency.spigot.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/animatedarchitecture-spigot/spigot-v1_20/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/v1_20/BlockAnalyzer_V1_20.java
+++ b/animatedarchitecture-spigot/spigot-v1_20/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/v1_20/BlockAnalyzer_V1_20.java
@@ -1,4 +1,4 @@
-package nl.pim16aap2.animatedarchitecture.spigot.v1_19_R3;
+package nl.pim16aap2.animatedarchitecture.spigot.v1_20;
 
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.animatedarchitecture.core.api.restartable.RestartableHolder;
@@ -15,13 +15,13 @@ import javax.inject.Singleton;
 import java.util.List;
 
 /**
- * Represents a class that can perform analysis on blocks on the Spigot 1.19 platform.
+ * Represents a class that can perform analysis on blocks on the Spigot 1.20 platform.
  * <p>
  * See {@link BlockAnalyzerSpigot} for more information.
  */
 @Flogger
 @Singleton
-final class BlockAnalyzer_V1_19 extends BlockAnalyzerSpigot
+final class BlockAnalyzer_V1_20 extends BlockAnalyzerSpigot
 {
     private static final List<Tag<Material>> BLOCKED_TAGS = List.of(
         Tag.ALL_SIGNS,
@@ -32,7 +32,7 @@ final class BlockAnalyzer_V1_19 extends BlockAnalyzerSpigot
     );
 
     @Inject
-    BlockAnalyzer_V1_19(
+    BlockAnalyzer_V1_20(
         IBlockAnalyzerConfig config,
         RestartableHolder restartableHolder)
     {

--- a/animatedarchitecture-spigot/spigot-v1_20/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/v1_20/SubPlatform_V1_20.java
+++ b/animatedarchitecture-spigot/spigot-v1_20/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/v1_20/SubPlatform_V1_20.java
@@ -1,4 +1,4 @@
-package nl.pim16aap2.animatedarchitecture.spigot.v1_19_R3;
+package nl.pim16aap2.animatedarchitecture.spigot.v1_20;
 
 import nl.pim16aap2.animatedarchitecture.spigot.util.api.BlockAnalyzerSpigot;
 import nl.pim16aap2.animatedarchitecture.spigot.util.api.ISpigotSubPlatform;
@@ -7,15 +7,15 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * Represents a sub-platform for Spigot 1.19.
+ * Represents a sub-platform for Spigot 1.20.
  */
 @Singleton
-public final class SubPlatform_V1_19 implements ISpigotSubPlatform
+public final class SubPlatform_V1_20 implements ISpigotSubPlatform
 {
-    private final BlockAnalyzer_V1_19 blockAnalyzer;
+    private final BlockAnalyzer_V1_20 blockAnalyzer;
 
     @Inject
-    SubPlatform_V1_19(BlockAnalyzer_V1_19 blockAnalyzer)
+    SubPlatform_V1_20(BlockAnalyzer_V1_20 blockAnalyzer)
     {
         this.blockAnalyzer = blockAnalyzer;
     }

--- a/animatedarchitecture-spigot/spigot-v1_20/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/v1_20/package-info.java
+++ b/animatedarchitecture-spigot/spigot-v1_20/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/v1_20/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Contains all version-specific code for the Spigot v1_20 platform.
+ */
+@NonNullByDefault
+package nl.pim16aap2.animatedarchitecture.spigot.v1_20;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;


### PR DESCRIPTION
- Dropped all support for versions of Minecraft prior to 1.20. It is currently too annoying to get this plugin to run on 1.19 anyway, so this should not have much of an effect. Additionally, bstats shows almost all servers run 1.20 or higher already.