### PR TITLE
Replace `synchronized` with lock for StructureFinder

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Util.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Util.java
@@ -891,6 +891,25 @@ public final class Util
     }
 
     /**
+     * Concatenates two lists into a single list.
+     *
+     * @param list0
+     *     The first list.
+     * @param list1
+     *     The second list.
+     * @param <T>
+     *     The type of data in the lists.
+     * @return A single list containing all elements from both input lists.
+     */
+    public static <T> List<T> concat(List<T> list0, List<T> list1)
+    {
+        final List<T> ret = new ArrayList<>(list0.size() + list1.size());
+        ret.addAll(list0);
+        ret.addAll(list1);
+        return ret;
+    }
+
+    /**
      * See {@link #getAllCompletableFutureResults(CompletableFuture[])}.
      */
     public static <T> CompletableFuture<List<T>> getAllCompletableFutureResults(

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/comands/CommandExecutor.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/comands/CommandExecutor.java
@@ -126,7 +126,7 @@ class CommandExecutor
                 query,
                 StructureRetrieverFactory.StructureFinderMode.NEW_INSTANCE,
                 PermissionLevel.USER)
-            .asRetriever(false);
+            .asRetriever();
         commandFactory.newListStructures(context.getSender(), retriever).run().exceptionally(Util::exceptionally);
     }
 


### PR DESCRIPTION
- To avoid thread pinning, synchronization was replaced with a ReentrantReadWriteLock where applicable in the StructureFinder class.