### PR TITLE
Fix limit permission names

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Limit.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Limit.java
@@ -18,12 +18,12 @@ public enum Limit
     /**
      * The maximum size a structure can have in number of blocks.
      */
-    STRUCTURE_SIZE("door_size", IConfig::maxStructureSize),
+    STRUCTURE_SIZE("structure_size", IConfig::maxStructureSize),
 
     /**
      * The maximum number of structures a player can own.
      */
-    STRUCTURE_COUNT("door_count", IConfig::maxStructureCount),
+    STRUCTURE_COUNT("structure_count", IConfig::maxStructureCount),
 
     /**
      * The maximum distance a power block can be from a structure.


### PR DESCRIPTION
- Whoops. The Limits still referred to 'door's instead of 'structure's.