### PR TITLE
Update non-player Info command highlight logging

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Info.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/commands/Info.java
@@ -245,7 +245,7 @@ public class Info extends StructureTargetCommand
     {
         if (!(getCommandSender() instanceof IPlayer player))
         {
-            log.atSevere().withStackTrace(StackSize.FULL).log("Non-player command sender tried to highlight blocks!");
+            log.atFinest().withStackTrace(StackSize.FULL).log("Not highlighting blocks for non-player command sender.");
             return;
         }
         glowingBlockSpawner.spawnHighlightedBlocks(structure, player, Duration.ofSeconds(3));


### PR DESCRIPTION
- Previously, the logging made it seem like a non-player executing the Info command resulted in an error. It's actually not an error at all, though; just a matter of non-players being unable to see highlighted blocks and that step therefore being skipped.