### PR TITLE
Improve failure safety

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedBlockContainer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimatedBlockContainer.java
@@ -196,7 +196,7 @@ public class AnimatedBlockContainer implements IAnimatedBlockContainer
         }
         catch (Exception e)
         {
-            log.atSevere().withCause(e).log("Failed to place block: %s", animatedBlock);
+            throw new RuntimeException("Failed to place block: " + animatedBlock, e);
         }
         try
         {

--- a/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/listeners/ChunkListener.java
+++ b/animatedarchitecture-spigot/spigot-core/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/core/listeners/ChunkListener.java
@@ -132,7 +132,7 @@ public class ChunkListener extends AbstractListener
                 .filter(mover -> mover.getSnapshot().getWorld().equals(world))
                 .filter(mover -> chunkInsideAnimationRange(chunkCoords, mover.getSnapshot().getAnimationRange()))
                 .toList() // Create new list to avoid ConcurrentModificationException.
-                .forEach(Animator::abort);
+                .forEach(Animator::blockingAbort);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
- Allow blocking the thread while aborting an active animation. This is used when, for example, a chunk is unloaded. This ensures the structure is fully aborted before going on to unload the chunk.
- We now throw an exception if we cannot place an animated block, rather than logging the problem and removing the animated block anyway. This ensures that we can at least use the recovery system if something goes wrong.