### PR TITLE
Embed Structure Jars in Main Spigot Jar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,13 @@ jobs:
         run: mvn --batch-mode -P=docs -Dmaven.test.skip -DskipTests install antrun:run lombok:delombok javadoc:javadoc javadoc:aggregate
         if: github.event_name == 'push' && github.ref == 'refs/heads/release'
 
-      - name: Upload structure types
-        uses: actions/upload-artifact@v4
-        with:
-          name: Structures
-          path: structures/StructuresOutput/*.jar
-
       - name: Upload AnimatedArchitecture-Spigot
         uses: actions/upload-artifact@v4
         with:
           name: AnimatedArchitecture-Spigot
-          path: animatedarchitecture-spigot/spigot-core/target/AnimatedArchitecture-Spigot.jar
+          path: animatedarchitecture-spigot/spigot-packager/target/AnimatedArchitecture-Spigot.jar
+          if-no-files-found: error
+          compression-level: 0
 
       # Publish java doc page when a commit/PR is pushed/merged to master
       - name: Deploy Javadoc

--- a/README.md
+++ b/README.md
@@ -36,12 +36,11 @@ The following structure types are currently supported:
 ### Installation:
 
 * Grab the files of the latest [release](https://github.com/PimvanderLoos/AnimatedArchitecture/releases). You will need
-  both the `AnimatedArchitecture-Spigot.jar` file and the `Structures.zip` file.
+  to grab the `AnimatedArchitecture-Spigot.jar` file.
 * Place the `AnimatedArchitecture-Spigot.jar` in the plugins directory of your server.
-* Create the following folder (or start the server to generate it automatically): `plugins/AnimatedArchitecture/extensions`.
-* Move all the jars from the `Structures.zip` file to the new `extensions` directory.<br>
-  Don't forget to update these when installing new updates!
 * (Re)start your server.
+* Optionally, configure the plugin to your liking by editing the config files in the newly generated
+  `AnimatedArchitecture` folder.
 
 ### Importing BigDoors' Database
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfo.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfo.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.animatedarchitecture.core.extensions;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
 import nl.pim16aap2.animatedarchitecture.core.util.MathUtil;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -132,6 +133,37 @@ final class StructureTypeInfo
         this.jarFile = jarFile;
         this.supportedApiVersions = supportedApiVersions;
         this.dependencies = parseDependencies(dependencies, typeName);
+    }
+
+    /**
+     * Verifies that the loaded structure type is the same as the one described by this {@link StructureTypeInfo}.
+     *
+     * @param structureType
+     *     The loaded structure type.
+     * @throws IllegalArgumentException
+     *     If the loaded structure type does not match the structure type described by this {@link StructureTypeInfo}.
+     */
+    public void verifyLoadedType(StructureType structureType)
+    {
+        if (!structureType.getSimpleName().equals(typeName))
+            throw new IllegalArgumentException(
+                "Expected structure type to have name '" + typeName +
+                    "' but was '" + structureType.getSimpleName() + "'."
+            );
+
+        if (!structureType.getPluginName().equals(namespace))
+            throw new IllegalArgumentException(
+                "Expected structure type '" + typeName +
+                    "' to have namespace '" + namespace +
+                    "' but was '" + structureType.getPluginName() + "'."
+            );
+
+        if (structureType.getVersion() != version)
+            throw new IllegalArgumentException(
+                "Expected structure type '" + typeName +
+                    "' to have version '" + version +
+                    "' but was '" + structureType.getVersion() + "'."
+            );
     }
 
     /**

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfo.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfo.java
@@ -43,10 +43,24 @@ final class StructureTypeInfo
     private static final Pattern VERSION_MATCH = Pattern.compile("(?<=\\()[0-9]+;[0-9]+(?=\\)$)");
 
     /**
+     * The namespace of the structure type.
+     */
+    @Getter
+    private final String namespace;
+
+    /**
      * The name of the structure type.
      */
     @Getter
     private final String typeName;
+
+    /**
+     * The name of the structure type in the namespace.
+     * <p>
+     * This is a combination of {@link #namespace} and {@link #typeName}.
+     */
+    @Getter
+    private final String fullName;
 
     /**
      * The version of the structure type.
@@ -101,6 +115,7 @@ final class StructureTypeInfo
      *     Both the minimum and the maximum versions of the dependency are inclusive.
      */
     public StructureTypeInfo(
+        String namespace,
         String typeName,
         int version,
         String mainClass,
@@ -108,7 +123,10 @@ final class StructureTypeInfo
         String supportedApiVersions,
         @Nullable String dependencies)
     {
+        this.namespace = namespace.toLowerCase(Locale.ENGLISH);
         this.typeName = typeName.toLowerCase(Locale.ENGLISH);
+        this.fullName = this.namespace + ":" + this.typeName;
+
         this.version = version;
         this.mainClass = mainClass;
         this.jarFile = jarFile;

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInitializer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInitializer.java
@@ -199,6 +199,7 @@ final class StructureTypeInitializer
             structureType = structureTypeClassLoader.loadStructureTypeClass(structureTypeInfo.getMainClass());
             // Retrieve the serializer to ensure that it could be initialized successfully.
             structureType.getStructureSerializer();
+            structureTypeInfo.verifyLoadedType(structureType);
         }
         catch (NoSuchMethodException e)
         {

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoader.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoader.java
@@ -23,6 +23,7 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -269,6 +270,8 @@ public final class StructureTypeLoader extends Restartable
             preloadCheckListMap = files
                 .filter(Files::isRegularFile)
                 .filter(pathMatcher::matches)
+                // Sort inverted to get e.g. my-structure-v2 before my-structure-v1
+                .sorted(Comparator.reverseOrder())
                 .map(this::getStructureTypeInfo)
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoader.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoader.java
@@ -146,9 +146,9 @@ public final class StructureTypeLoader extends Restartable
     private Set<String> getAlreadyLoadedTypes()
     {
         return structureTypeManager
-            .getRegisteredStructureTypes().stream()
-            .map(StructureType::getClass)
-            .map(Class::getName)
+            .getRegisteredStructureTypes()
+            .stream()
+            .map(StructureType::getFullName)
             .collect(Collectors.toSet());
     }
 
@@ -182,7 +182,7 @@ public final class StructureTypeLoader extends Restartable
         Set<String> alreadyLoadedTypes,
         StructureTypeInfo typeInfo)
     {
-        if (alreadyLoadedTypes.contains(typeInfo.getTypeName()))
+        if (alreadyLoadedTypes.contains(typeInfo.getFullName()))
             return PreloadCheckResult.ALREADY_LOADED;
 
         if (!isSupported(currentApiVersion, typeInfo.getSupportedApiVersions()))
@@ -383,6 +383,7 @@ public final class StructureTypeLoader extends Restartable
             Util.requireNonNull(manifest.getMainAttributes().getValue(Attributes.Name.MAIN_CLASS), "Main-Class");
 
         return Optional.of(new StructureTypeInfo(
+            Util.requireNonNull(attributes.getValue("Namespace"), "Namespace"),
             Util.requireNonNull(attributes.getValue("TypeName"), "TypeName"),
             MathUtil.parseInt(attributes.getValue("Version"))
                 .orElseThrow(() -> new NoSuchElementException("Version not found")),

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationGenerator.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationGenerator.java
@@ -125,7 +125,16 @@ final class LocalizationGenerator implements ILocalizationGenerator
     public void addResourcesFromClass(List<Class<?>> classes)
     {
         for (final Class<?> clz : classes)
-            addResourcesFromClass(clz, null);
+        {
+            try
+            {
+                addResourcesFromClass(clz, null);
+            }
+            catch (Throwable t)
+            {
+                log.atSevere().withCause(t).log("Failed to load resources from class: %s", clz);
+            }
+        }
     }
 
     /**

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationGenerator.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationGenerator.java
@@ -2,8 +2,8 @@ package nl.pim16aap2.animatedarchitecture.core.localization;
 
 import lombok.Getter;
 import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.animatedarchitecture.core.util.FileUtil;
 import nl.pim16aap2.animatedarchitecture.core.util.MathUtil;
-import nl.pim16aap2.animatedarchitecture.core.util.Util;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -47,7 +47,7 @@ final class LocalizationGenerator implements ILocalizationGenerator
         this.outputBaseName = outputBaseName;
         this.rootKeys = new HashSet<>();
         outputFile = outputDirectory.resolve(this.outputBaseName + ".bundle");
-        LocalizationUtil.ensureZipFileExists(outputFile);
+        FileUtil.ensureZipFileExists(outputFile);
     }
 
     @Override
@@ -83,10 +83,10 @@ final class LocalizationGenerator implements ILocalizationGenerator
     void addResourcesFromZip(Path jarFile, @Nullable String baseName)
     {
         try (
-            FileSystem zipFileSystem = LocalizationUtil.createNewFileSystem(jarFile);
+            FileSystem zipFileSystem = FileUtil.createNewFileSystem(jarFile);
             FileSystem outputFileSystem = getOutputFileFileSystem())
         {
-            List<String> fileNames = Util.getLocaleFilesInJar(jarFile);
+            List<String> fileNames = LocalizationUtil.getLocaleFilesInJar(jarFile);
             if (baseName != null)
                 fileNames = fileNames.stream().filter(file -> file.startsWith(baseName)).toList();
 
@@ -111,7 +111,7 @@ final class LocalizationGenerator implements ILocalizationGenerator
     @Override
     public void addResourcesFromClass(Class<?> clz, @Nullable String baseName)
     {
-        addResourcesFromZip(Util.getJarFile(clz), baseName);
+        addResourcesFromZip(FileUtil.getJarFile(clz), baseName);
     }
 
     /**
@@ -142,7 +142,7 @@ final class LocalizationGenerator implements ILocalizationGenerator
         {
             final Path existingLocaleFile =
                 outputFileSystem.getPath(LocalizationUtil.getOutputLocaleFileName(outputBaseName, localeSuffix));
-            LocalizationUtil.ensureFileExists(existingLocaleFile);
+            FileUtil.ensureFileExists(existingLocaleFile);
 
             final StringBuilder sb = new StringBuilder();
             try (InputStream inputStream = Files.newInputStream(existingLocaleFile))
@@ -201,13 +201,13 @@ final class LocalizationGenerator implements ILocalizationGenerator
     /**
      * Creates a new {@link FileSystem} for {@link #outputFile}.
      * <p>
-     * See {@link LocalizationUtil#createNewFileSystem(Path)}.
+     * See {@link FileUtil#createNewFileSystem(Path)}.
      */
     private FileSystem getOutputFileFileSystem()
         throws IOException, URISyntaxException, ProviderNotFoundException
     {
-        LocalizationUtil.ensureZipFileExists(outputFile);
-        return LocalizationUtil.createNewFileSystem(outputFile);
+        FileUtil.ensureZipFileExists(outputFile);
+        return FileUtil.createNewFileSystem(outputFile);
     }
 
     /**
@@ -232,14 +232,14 @@ final class LocalizationGenerator implements ILocalizationGenerator
     {
         final Path existingLocaleFile =
             outputFileSystem.getPath(LocalizationUtil.getOutputLocaleFileName(outputBaseName, locale));
-        LocalizationUtil.ensureFileExists(existingLocaleFile);
-        LocalizationUtil.ensureFileExists(outputFile);
+        FileUtil.ensureFileExists(existingLocaleFile);
+        FileUtil.ensureFileExists(outputFile);
         final List<String> existing = LocalizationUtil.readFile(Files.newInputStream(existingLocaleFile));
         final List<String> newlines = LocalizationUtil.readFile(inputStream);
         final List<String> appendable = LocalizationUtil.getAppendable(existing, newlines);
         registerRootKeys(existing);
         registerRootKeys(appendable);
-        LocalizationUtil.appendToFile(existingLocaleFile, appendable);
+        FileUtil.appendToFile(existingLocaleFile, appendable);
     }
 
     private void registerRootKeys(List<String> lines)

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationPatcher.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationPatcher.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.animatedarchitecture.core.localization;
 
 import lombok.Getter;
 import lombok.extern.flogger.Flogger;
+import nl.pim16aap2.animatedarchitecture.core.util.FileUtil;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,7 +31,7 @@ final class LocalizationPatcher
         throws IOException
     {
         // Ensure the base patch file exists.
-        LocalizationUtil.ensureFileExists(directory.resolve(baseName + ".properties"));
+        FileUtil.ensureFileExists(directory.resolve(baseName + ".properties"));
         patchFiles = LocalizationUtil.getLocaleFilesInDirectory(directory, baseName);
     }
 

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationUtil.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationUtil.java
@@ -1,7 +1,6 @@
 package nl.pim16aap2.animatedarchitecture.core.localization;
 
 import lombok.extern.flogger.Flogger;
-import lombok.val;
 import nl.pim16aap2.animatedarchitecture.core.util.FileUtil;
 import nl.pim16aap2.animatedarchitecture.core.util.MathUtil;
 import org.jetbrains.annotations.Nullable;
@@ -27,8 +26,6 @@ import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 /**
  * Represents a utility class with methods that can be used for the localization system.
@@ -68,19 +65,7 @@ public final class LocalizationUtil
     public static List<String> getLocaleFilesInJar(Path jarFile)
         throws IOException
     {
-        final List<String> ret = new ArrayList<>();
-
-        try (val zipInputStream = new ZipInputStream(Files.newInputStream(jarFile)))
-        {
-            @Nullable ZipEntry entry;
-            while ((entry = zipInputStream.getNextEntry()) != null)
-            {
-                final var name = entry.getName();
-                if (LOCALE_FILE_PATTERN.matcher(name).matches())
-                    ret.add(name);
-            }
-        }
-        return ret;
+        return FileUtil.getFilesInJar(jarFile, LOCALE_FILE_PATTERN);
     }
 
     /**

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/Localizer.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/localization/Localizer.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.animatedarchitecture.core.localization;
 import lombok.Setter;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.animatedarchitecture.core.annotations.Initializer;
+import nl.pim16aap2.animatedarchitecture.core.util.FileUtil;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -58,7 +59,7 @@ final class Localizer implements ILocalizer
         this.defaultLocale = defaultLocale;
         bundleName = baseName + ".bundle";
         if (deleteBundleOnStart)
-            LocalizationUtil.deleteFile(directory.resolve(bundleName));
+            FileUtil.deleteFile(directory.resolve(bundleName));
         init();
     }
 
@@ -135,10 +136,10 @@ final class Localizer implements ILocalizer
         if (classLoader != null)
             throw new IllegalStateException("ClassLoader is already initialized!");
 
-        LocalizationUtil.ensureDirectoryExists(directory);
+        FileUtil.ensureDirectoryExists(directory);
 
         final Path bundlePath = directory.resolve(bundleName);
-        LocalizationUtil.ensureZipFileExists(bundlePath);
+        FileUtil.ensureZipFileExists(bundlePath);
         try
         {
             classLoader = getNewURLClassLoader(bundlePath, baseName);

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureType.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureType.java
@@ -58,7 +58,7 @@ public abstract class StructureType
     protected final String localizationKey;
 
     /**
-     * The fully-qualified name of this {@link StructureType} formatted as "pluginName_simpleName".
+     * The fully-qualified name of this {@link StructureType} formatted as "pluginName:simpleName".
      */
     @Getter
     private final String fullName;

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureType.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/StructureType.java
@@ -109,7 +109,7 @@ public abstract class StructureType
         List<MovementDirection> validMovementDirections,
         String localizationKey)
     {
-        this.pluginName = pluginName;
+        this.pluginName = pluginName.toLowerCase(Locale.ENGLISH);
         this.simpleName = simpleName.toLowerCase(Locale.ENGLISH);
         this.version = version;
         this.validMovementDirections =

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/FileUtil.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/FileUtil.java
@@ -1,0 +1,206 @@
+package nl.pim16aap2.animatedarchitecture.core.util;
+
+import lombok.extern.flogger.Flogger;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.ProviderNotFoundException;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Utility class for file operations.
+ */
+@Flogger
+public final class FileUtil
+{
+
+    private FileUtil()
+    {
+    }
+
+    /**
+     * Deletes a file if it exists.
+     * <p>
+     * If an exception occurs while deleting the file, it will be logged, but the method will not throw an exception.
+     * <p>
+     * If the file does not exist, nothing happens.
+     *
+     * @param file
+     *     The file to delete.
+     */
+    public static void deleteFile(Path file)
+    {
+        try
+        {
+            Files.deleteIfExists(file);
+        }
+        catch (IOException e)
+        {
+            log.atSevere().withCause(e).log("Failed to delete file: '%s'", file);
+        }
+    }
+
+    /**
+     * Ensures that a file exists.
+     * <p>
+     * If the file does not already exist, it will be created.
+     *
+     * @param file
+     *     The file whose existence to ensure.
+     * @return The path to the file.
+     *
+     * @throws IOException
+     *     When the file could not be created.
+     */
+    public static Path ensureFileExists(Path file)
+        throws IOException
+    {
+        if (Files.isRegularFile(file))
+            return file;
+
+        final Path parent = file.getParent();
+        if (parent != null && !Files.isDirectory(parent))
+            Files.createDirectories(parent);
+        return Files.createFile(file);
+    }
+
+    /**
+     * Appends a list of strings to a file.
+     * <p>
+     * Every entry in the list will be printed on its own line.
+     *
+     * @param path
+     *     The path of the file.
+     * @param append
+     *     The list of Strings (lines) to append to the file.
+     */
+    public static void appendToFile(Path path, List<String> append)
+    {
+        if (append.isEmpty())
+            return;
+
+        final StringBuilder sb = new StringBuilder();
+        append.forEach(line -> sb.append(line).append('\n'));
+        try
+        {
+            Files.writeString(path, sb.toString(), StandardOpenOption.APPEND);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Failed to write localization file: " + path, e);
+        }
+    }
+
+    /**
+     * Ensures a directory exists.
+     */
+    public static void ensureDirectoryExists(Path dir)
+    {
+        if (Files.exists(dir))
+            return;
+
+        try
+        {
+            Files.createDirectories(dir);
+        }
+        catch (IOException e)
+        {
+            log.atSevere().withCause(e).log("Failed to create directories: %s", dir);
+        }
+    }
+
+    /**
+     * Ensures a given zip file exists.
+     */
+    public static void ensureZipFileExists(Path zipFile)
+    {
+        if (Files.exists(zipFile))
+            return;
+
+        final Path parent = zipFile.getParent();
+        if (parent != null)
+        {
+            try
+            {
+                if (!Files.isDirectory(parent))
+                    Files.createDirectories(parent);
+            }
+            catch (IOException e)
+            {
+                log.atSevere().withCause(e).log("Failed to create directories: %s", parent);
+                return;
+            }
+        }
+
+        // Just opening the ZipOutputStream and then letting it close
+        // on its own is enough to create a new zip file.
+        //noinspection EmptyTryBlock
+        try (
+            OutputStream outputStream = Files.newOutputStream(zipFile);
+            ZipOutputStream ignored = new ZipOutputStream(outputStream))
+        {
+            // ignored
+        }
+        catch (IOException e)
+        {
+            log.atSevere().withCause(e).log("Failed to create file: %s", zipFile);
+        }
+    }
+
+    /**
+     * Gets the file of the jar that contained a specific class.
+     *
+     * @param clz
+     *     The class for which to find the jar file.
+     * @return The location of the jar file.
+     */
+    public static Path getJarFile(Class<?> clz)
+    {
+        try
+        {
+            return Path.of(clz.getProtectionDomain().getCodeSource().getLocation().toURI());
+        }
+        catch (IllegalArgumentException | URISyntaxException e)
+        {
+            throw new RuntimeException("Failed to find jar file for class: " + clz, e);
+        }
+    }
+
+    /**
+     * Creates a new {@link FileSystem} for a zip file.
+     * <p>
+     * Don't forget to close it when you're done!
+     *
+     * @param zipFile
+     *     The zip file for which to create a new FileSystem.
+     * @return The newly created FileSystem.
+     *
+     * @throws IOException
+     *     If an I/O error occurs creating the file system.
+     * @throws FileSystemAlreadyExistsException
+     *     When a FileSystem already exists for the provided file.
+     */
+    public static FileSystem createNewFileSystem(Path zipFile)
+        throws IOException, URISyntaxException, ProviderNotFoundException
+    {
+        final URI uri = new URI("jar:" + zipFile.toUri());
+        try
+        {
+            return FileSystems.newFileSystem(uri, Map.of());
+        }
+        catch (FileSystemAlreadyExistsException e)
+        {
+            throw new RuntimeException("Failed to create new filesystem: '" + uri + "'", e);
+        }
+    }
+}

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/StringUtil.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/StringUtil.java
@@ -1,6 +1,5 @@
 package nl.pim16aap2.animatedarchitecture.core.util;
 
-import lombok.experimental.UtilityClass;
 import lombok.extern.flogger.Flogger;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
@@ -15,7 +14,6 @@ import java.util.stream.Collector;
  * Utility class for strings.
  */
 @Flogger
-@UtilityClass
 public final class StringUtil
 {
     /**
@@ -35,6 +33,9 @@ public final class StringUtil
      */
     private static final Pattern VALID_STRUCTURE_NAME = Pattern.compile("^\\w*[a-zA-Z_-]+\\w*$");
 
+    private StringUtil()
+    {
+    }
 
     /**
      * Generate an (insecure) random alphanumeric string of a given length.

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Util.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/util/Util.java
@@ -1,8 +1,6 @@
 package nl.pim16aap2.animatedarchitecture.core.util;
 
-import lombok.experimental.UtilityClass;
 import lombok.extern.flogger.Flogger;
-import lombok.val;
 import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
 import nl.pim16aap2.animatedarchitecture.core.structures.IStructureConst;
 import nl.pim16aap2.animatedarchitecture.core.structures.PermissionLevel;
@@ -11,27 +9,17 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.logging.Level;
-import java.util.regex.Pattern;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 /**
  * Represents various small and platform-agnostic utility functions.
  */
-@UtilityClass
 @Flogger
 public final class Util
 {
@@ -40,11 +28,6 @@ public final class Util
 
     private static final Map<MovementDirection, BlockFace> TO_BLOCK_FACE =
         new EnumMap<>(MovementDirection.class);
-
-    /**
-     * Looks for top-level .properties files.
-     */
-    private static final Pattern LOCALE_FILE_PATTERN = Pattern.compile("^[\\w-]+\\.properties");
 
     static
     {
@@ -64,53 +47,8 @@ public final class Util
         }
     }
 
-    /**
-     * Gets the file of the jar that contained a specific class.
-     *
-     * @param clz
-     *     The class for which to find the jar file.
-     * @return The location of the jar file.
-     */
-    public Path getJarFile(Class<?> clz)
+    private Util()
     {
-        try
-        {
-            return Path.of(clz.getProtectionDomain().getCodeSource().getLocation().toURI());
-        }
-        catch (IllegalArgumentException | URISyntaxException e)
-        {
-            throw new RuntimeException("Failed to find jar file for class: " + clz, e);
-        }
-    }
-
-    /**
-     * Gets the names of all locale files in a jar.
-     * <p>
-     * The name of each locale file is the name of the file itself, with optional relative path.
-     *
-     * @param jarFile
-     *     The jar file to search in.
-     * @return The names of all locale files in the jar.
-     *
-     * @throws IOException
-     *     If an I/O error occurs.
-     */
-    public List<String> getLocaleFilesInJar(Path jarFile)
-        throws IOException
-    {
-        final List<String> ret = new ArrayList<>();
-
-        try (val zipInputStream = new ZipInputStream(Files.newInputStream(jarFile)))
-        {
-            @Nullable ZipEntry entry;
-            while ((entry = zipInputStream.getNextEntry()) != null)
-            {
-                final var name = entry.getName();
-                if (LOCALE_FILE_PATTERN.matcher(name).matches())
-                    ret.add(name);
-            }
-        }
-        return ret;
     }
 
     /**
@@ -133,7 +71,7 @@ public final class Util
      *     If the input object to check is null.
      */
     @Contract("null, _ -> fail")
-    public <T> T requireNonNull(@Nullable T obj, String name)
+    public static <T> T requireNonNull(@Nullable T obj, String name)
         throws NullPointerException
     {
         //noinspection ConstantConditions
@@ -151,7 +89,7 @@ public final class Util
      *     The type of the value.
      * @return The value if it is not null, otherwise the fallback.
      */
-    public <T> T valOrDefault(@Nullable T value, Supplier<T> fallback)
+    public static <T> T valOrDefault(@Nullable T value, Supplier<T> fallback)
     {
         return value == null ? fallback.get() : value;
     }

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoaderTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoaderTest.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.animatedarchitecture.core.extensions;
 
+import nl.pim16aap2.animatedarchitecture.core.util.Constants;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.semver4j.Semver;
@@ -59,6 +60,7 @@ class StructureTypeLoaderTest
     @Test
     void testPerformPreloadCheck()
     {
+        final String namespace = Constants.PLUGIN_NAME;
         final Path jarFile = Paths.get("/does/not/exist.jar");
 
         final String alreadyLoadedTypeName = "already-loaded-type";
@@ -67,9 +69,9 @@ class StructureTypeLoaderTest
         final Semver apiVersion = Semver.of(1, 0, 0);
 
         final var alreadyLoadedTypes = new HashSet<String>();
-        alreadyLoadedTypes.add(alreadyLoadedTypeName);
 
         final var typeInfo = new StructureTypeInfo(
+            namespace,
             alreadyLoadedTypeName,
             1,
             "com.example.MainClass",
@@ -78,12 +80,15 @@ class StructureTypeLoaderTest
             null
         );
 
+        alreadyLoadedTypes.add(typeInfo.getFullName());
+
         Assertions.assertEquals(
             StructureTypeLoader.PreloadCheckResult.ALREADY_LOADED,
             StructureTypeLoader.performPreloadCheck(apiVersion, alreadyLoadedTypes, typeInfo)
         );
 
         final var typeInfo2 = new StructureTypeInfo(
+            namespace,
             unloadedTypeName,
             1,
             "com.example.MainClass",
@@ -98,6 +103,7 @@ class StructureTypeLoaderTest
         );
 
         final var typeInfo3 = new StructureTypeInfo(
+            namespace,
             unloadedTypeName,
             1,
             "com.example.MainClass",
@@ -117,6 +123,7 @@ class StructureTypeLoaderTest
     {
         final var manifest = new Manifest();
         final var attributes = new Attributes();
+        attributes.putValue("Namespace", Constants.PLUGIN_NAME);
         attributes.putValue("TypeName", "TypeName");
         attributes.putValue("Version", "1");
         attributes.putValue("SupportedApiVersions", "1.2.3");

--- a/animatedarchitecture-spigot/pom.xml
+++ b/animatedarchitecture-spigot/pom.xml
@@ -25,6 +25,7 @@
         <module>spigot-core</module>
         <module>spigot-util</module>
         <module>protection-hooks</module>
+        <module>spigot-packager</module>
     </modules>
 
     <repositories>

--- a/animatedarchitecture-spigot/spigot-core/pom.xml
+++ b/animatedarchitecture-spigot/spigot-core/pom.xml
@@ -173,7 +173,6 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-        <finalName>AnimatedArchitecture-Spigot</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/animatedarchitecture-spigot/spigot-packager/pom.xml
+++ b/animatedarchitecture-spigot/spigot-packager/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spigot-packager</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+        <artifactId>animatedarchitecture-spigot</artifactId>
+        <version>0.7.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <project.root-dir>${project.basedir}/../..</project.root-dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>spigot-core</artifactId>
+            <version>0.7.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>structure-bigdoor</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>structure-clock</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>structure-drawbridge</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>structure-flag</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>structure-garagedoor</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>structure-portcullis</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>structure-revolvingdoor</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>structure-slidingdoor</artifactId>
+            <version>1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.pim16aap2.animatedarchitecture</groupId>
+            <artifactId>structure-windmill</artifactId>
+            <version>1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>AnimatedArchitecture-Spigot</finalName>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/assembly/packaging.xml</descriptor>
+                    </descriptors>
+                    <finalName>spigot-core-with-extensions</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/animatedarchitecture-spigot/spigot-packager/pom.xml
+++ b/animatedarchitecture-spigot/spigot-packager/pom.xml
@@ -80,8 +80,6 @@
     </dependencies>
 
     <build>
-        <finalName>AnimatedArchitecture-Spigot</finalName>
-
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -90,7 +88,7 @@
                     <descriptors>
                         <descriptor>src/assembly/packaging.xml</descriptor>
                     </descriptors>
-                    <finalName>spigot-core-with-extensions</finalName>
+                    <finalName>AnimatedArchitecture-Spigot</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
                 <executions>

--- a/animatedarchitecture-spigot/spigot-packager/src/assembly/packaging.xml
+++ b/animatedarchitecture-spigot/spigot-packager/src/assembly/packaging.xml
@@ -1,0 +1,26 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+    <id>packaging</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <unpack>true</unpack>
+            <includes>
+                <include>nl.pim16aap2.animatedarchitecture:spigot-core</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>extensions</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <includes>
+                <include>nl.pim16aap2.animatedarchitecture:structure-*</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationPatcherIntegrationTest.java
+++ b/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationPatcherIntegrationTest.java
@@ -2,6 +2,7 @@ package nl.pim16aap2.animatedarchitecture.core.localization;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import nl.pim16aap2.animatedarchitecture.core.util.FileUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,11 +39,11 @@ class LocalizationPatcherIntegrationTest
     void testUpdateRootKeys()
         throws IOException
     {
-        final Path file0 = LocalizationUtil.ensureFileExists(directoryOutput.resolve("patch.properties"));
-        LocalizationUtil.appendToFile(file0, List.of("key0=aaa", "key3=baa", "key1=aba", "key2=aab"));
+        final Path file0 = FileUtil.ensureFileExists(directoryOutput.resolve("patch.properties"));
+        FileUtil.appendToFile(file0, List.of("key0=aaa", "key3=baa", "key1=aba", "key2=aab"));
 
-        final Path file1 = LocalizationUtil.ensureFileExists(directoryOutput.resolve("patch_en_US.properties"));
-        LocalizationUtil.appendToFile(file1, List.of("key10=aaa", "key13=baa", "key12=aab", "key11=aba"));
+        final Path file1 = FileUtil.ensureFileExists(directoryOutput.resolve("patch_en_US.properties"));
+        FileUtil.appendToFile(file1, List.of("key10=aaa", "key13=baa", "key12=aab", "key11=aba"));
 
         final LocalizationPatcher patcher = new LocalizationPatcher(directoryOutput, "patch");
         patcher.updatePatchKeys(List.of("key1", "key5", "key4"));
@@ -62,8 +63,8 @@ class LocalizationPatcherIntegrationTest
     void testGetPatches()
         throws IOException
     {
-        final Path file = LocalizationUtil.ensureFileExists(directoryOutput.resolve("patch.properties"));
-        LocalizationUtil.appendToFile(file, List.of("key0=", "key1= ", "key2=aab", "key3=baa"));
+        final Path file = FileUtil.ensureFileExists(directoryOutput.resolve("patch.properties"));
+        FileUtil.appendToFile(file, List.of("key0=", "key1= ", "key2=aab", "key3=baa"));
 
         final LocalizationPatcher patcher = new LocalizationPatcher(directoryOutput, "patch");
         final Map<String, String> patches = patcher.getPatches(new LocaleFile(file, ""));

--- a/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationTestingUtilities.java
+++ b/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/core/localization/LocalizationTestingUtilities.java
@@ -1,5 +1,7 @@
 package nl.pim16aap2.animatedarchitecture.core.localization;
 
+import nl.pim16aap2.animatedarchitecture.core.util.FileUtil;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -72,8 +74,8 @@ class LocalizationTestingUtilities
     static void writeToFile(Path file, List<String> lines)
         throws IOException
     {
-        LocalizationUtil.ensureFileExists(file);
-        LocalizationUtil.appendToFile(file, lines);
+        FileUtil.ensureFileExists(file);
+        FileUtil.appendToFile(file, lines);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -462,6 +462,10 @@
                                 <pattern>javax.inject</pattern>
                                 <shadedPattern>nl.pim16aap2.animatedarchitecture.lib.javax.inject</shadedPattern>
                             </relocation>
+                            <relocation>
+                                <pattern>jakarta.inject</pattern>
+                                <shadedPattern>nl.pim16aap2.animatedarchitecture.lib.jakarta.inject</shadedPattern>
+                            </relocation>
                         </relocations>
                     </configuration>
                     <executions>

--- a/structures/pom.xml
+++ b/structures/pom.xml
@@ -57,6 +57,15 @@
         <mainClass>UNDEFINED</mainClass>
 
         <!--
+        The namespace of the type, e.g. animatedarchitecture
+
+        This is used to avoid conflicts between different types with the same name.
+
+        The namespace can contain letters, numbers, dashes, and underscores.
+        -->
+        <namespace>animatedarchitecture</namespace>
+
+        <!--
         The name of the type, e.g. BigDoor
         This is used for the name of the jar file
 
@@ -115,6 +124,7 @@
                                 <manifestSection>
                                     <name>StructureTypeMetadata</name>
                                     <manifestEntries>
+                                        <Namespace>${namespace}</Namespace>
                                         <TypeName>${typeName}</TypeName>
                                         <Version>${version}</Version>
                                         <SupportedApiVersions>${supportedApiVersions}</SupportedApiVersions>


### PR DESCRIPTION
# Description:

This pull request changes how structure jars are distributed and loaded. The structure jars are now embedded within the main Spigot jar and extracted at runtime.

# Key Benefits:

1) Simplified user experience: Users no longer need to manually install and upgrade structure types.
2) Expanded platform compatibility: The plugin can now be published on platforms that only support single-jar distributions (e.g., Hangar and Modrinth).

# Technical Changes:

- Introduced a new `spigot-packager` module that embeds structure-type jars into the `spigot-core` jar, resulting in a single jar for the entire project.
- Removed GitHub action for publishing the Structure jars as a separate zip file, as they are now unnecessary for the Spigot platform (the only platform currently supported.)
- Added namespace definition requirement in structure type manifests to improve pre-load checks.
- Moved some file-related methods from LocalizationUtil to the new FileUtil class for improved code reusability.