### PR TITLE
Handle unloading of protection hooks

### DIFF
--- a/animatedarchitecture-spigot/protection-hooks/hook-griefdefender-2/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/griefdefender2/GriefDefender2ProtectionHook.java
+++ b/animatedarchitecture-spigot/protection-hooks/hook-griefdefender-2/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/griefdefender2/GriefDefender2ProtectionHook.java
@@ -88,10 +88,4 @@ public class GriefDefender2ProtectionHook implements IProtectionHookSpigot
                         return CompletableFuture.completedFuture(false);
         return CompletableFuture.completedFuture(true);
     }
-
-    @Override
-    public String getName()
-    {
-        return "GriefDefender";
-    }
 }

--- a/animatedarchitecture-spigot/protection-hooks/hook-griefprevention/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/griefprevention/GriefPreventionProtectionHook.java
+++ b/animatedarchitecture-spigot/protection-hooks/hook-griefprevention/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/griefprevention/GriefPreventionProtectionHook.java
@@ -79,10 +79,4 @@ public class GriefPreventionProtectionHook implements IProtectionHookSpigot
                         return CompletableFuture.completedFuture(false);
         return CompletableFuture.completedFuture(true);
     }
-
-    @Override
-    public String getName()
-    {
-        return "GriefPrevention";
-    }
 }

--- a/animatedarchitecture-spigot/protection-hooks/hook-lands/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/lands/LandsProtectionHook.java
+++ b/animatedarchitecture-spigot/protection-hooks/hook-lands/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/lands/LandsProtectionHook.java
@@ -32,7 +32,7 @@ public class LandsProtectionHook implements IProtectionHookSpigot
     public LandsProtectionHook(ProtectionHookContext context)
     {
         this.context = context;
-        landsAddon = LandsIntegration.of(context.getPlugin());
+        landsAddon = LandsIntegration.of(context.getAnimatedArchitecturePlugin());
     }
 
     private boolean canBreakBlock(@Nullable Area area, Player player, Location loc)
@@ -88,11 +88,5 @@ public class LandsProtectionHook implements IProtectionHookSpigot
             }
         }
         return CompletableFuture.completedFuture(true);
-    }
-
-    @Override
-    public String getName()
-    {
-        return context.getSpecification().getName();
     }
 }

--- a/animatedarchitecture-spigot/protection-hooks/hook-plotsquared-6/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/plotsquared6/PlotSquared6ProtectionHook.java
+++ b/animatedarchitecture-spigot/protection-hooks/hook-plotsquared-6/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/plotsquared6/PlotSquared6ProtectionHook.java
@@ -138,10 +138,4 @@ public class PlotSquared6ProtectionHook implements IProtectionHookSpigot
             }
         return CompletableFuture.completedFuture(true);
     }
-
-    @Override
-    public String getName()
-    {
-        return plotSquaredPlugin.getName();
-    }
 }

--- a/animatedarchitecture-spigot/protection-hooks/hook-plotsquared-7/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/plotsquared7/PlotSquared7ProtectionHook.java
+++ b/animatedarchitecture-spigot/protection-hooks/hook-plotsquared-7/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/plotsquared7/PlotSquared7ProtectionHook.java
@@ -220,10 +220,4 @@ public class PlotSquared7ProtectionHook implements IProtectionHookSpigot
         }
         return CompletableFuture.completedFuture(true);
     }
-
-    @Override
-    public String getName()
-    {
-        return plotSquaredPlugin.getName();
-    }
 }

--- a/animatedarchitecture-spigot/protection-hooks/hook-redprotect/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/redprotect/RedProtectProtectionHook.java
+++ b/animatedarchitecture-spigot/protection-hooks/hook-redprotect/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/redprotect/RedProtectProtectionHook.java
@@ -77,10 +77,4 @@ public class RedProtectProtectionHook implements IProtectionHookSpigot
                         return CompletableFuture.completedFuture(false);
         return CompletableFuture.completedFuture(true);
     }
-
-    @Override
-    public String getName()
-    {
-        return context.getSpecification().getName();
-    }
 }

--- a/animatedarchitecture-spigot/protection-hooks/hook-towny/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/towny/TownyProtectionHook.java
+++ b/animatedarchitecture-spigot/protection-hooks/hook-towny/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/towny/TownyProtectionHook.java
@@ -63,12 +63,6 @@ public class TownyProtectionHook implements IProtectionHookSpigot
                         return CompletableFuture.completedFuture(false);
         return CompletableFuture.completedFuture(true);
     }
-
-    @Override
-    public String getName()
-    {
-        return context.getSpecification().getName();
-    }
 }
 
 

--- a/animatedarchitecture-spigot/protection-hooks/hook-world-guard-7/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/worldguard7/WorldGuard7ProtectionHook.java
+++ b/animatedarchitecture-spigot/protection-hooks/hook-world-guard-7/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/hooks/worldguard7/WorldGuard7ProtectionHook.java
@@ -162,12 +162,6 @@ public class WorldGuard7ProtectionHook implements IProtectionHookSpigot
             return new BukkitPlayer(worldGuardPlugin, player);
     }
 
-    @Override
-    public String getName()
-    {
-        return worldGuardPlugin.getName();
-    }
-
     private RegionQuery query()
     {
         return worldGuard.getPlatform().getRegionContainer().createQuery();

--- a/animatedarchitecture-spigot/spigot-util/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/util/hooks/IProtectionHookSpigot.java
+++ b/animatedarchitecture-spigot/spigot-util/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/util/hooks/IProtectionHookSpigot.java
@@ -120,7 +120,10 @@ public interface IProtectionHookSpigot
      *
      * @return The name of the {@link JavaPlugin} that is being hooked into.
      */
-    String getName();
+    default String getName()
+    {
+        return getContext().getSpecification().getName();
+    }
 
     /**
      * Get the {@link ProtectionHookContext} that is being used.

--- a/animatedarchitecture-spigot/spigot-util/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/util/hooks/ProtectionHookContext.java
+++ b/animatedarchitecture-spigot/spigot-util/src/main/java/nl/pim16aap2/animatedarchitecture/spigot/util/hooks/ProtectionHookContext.java
@@ -11,18 +11,18 @@ import org.bukkit.plugin.java.JavaPlugin;
 @Getter
 public final class ProtectionHookContext
 {
-    private final JavaPlugin plugin;
+    private final JavaPlugin animatedArchitecturePlugin;
     private final IProtectionHookSpigotSpecification specification;
     private final IPermissionsManagerSpigot permissionsManager;
     private final IExecutor executor;
 
     public ProtectionHookContext(
-        JavaPlugin plugin,
+        JavaPlugin animatedArchitecturePlugin,
         IProtectionHookSpigotSpecification specification,
         IPermissionsManagerSpigot permissionsManager,
         IExecutor executor)
     {
-        this.plugin = plugin;
+        this.animatedArchitecturePlugin = animatedArchitecturePlugin;
         this.specification = specification;
         this.permissionsManager = permissionsManager;
         this.executor = executor;


### PR DESCRIPTION
- When a plugin that we have a protection hook for is disabled, we now unload the hook as well.
- Simplified returning the name of the plugin a protection hook is loaded for.