### PR TITLE
Allow compiling the project without git directory

### DIFF
--- a/animatedarchitecture-core/pom.xml
+++ b/animatedarchitecture-core/pom.xml
@@ -14,8 +14,15 @@
 
     <properties>
         <project.root-dir>${project.basedir}/..</project.root-dir>
+
         <actions.run.id>-1</actions.run.id>
         <actions.run.number>-1</actions.run.number>
+
+        <!-- Default build data values. These will be overwritten by git-commit-id-maven-plugin -->
+        <git.branch>unknown</git.branch>
+        <git.commit.id>unknown</git.commit.id>
+        <git.dirty>unknown</git.dirty>
+        <git.commit.time>unknown</git.commit.time>
     </properties>
 
     <dependencies>
@@ -72,6 +79,8 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
                     <dotGitDirectory>${project.root-dir}/.git</dotGitDirectory>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Previously, the `git-commit-id-maven-plugin` plugin would fail if there is no `.git` directory (with all the stuff it wants to read inside).
This was changed by simply ignoring any issues with accessing/reading the git directory and simply falling back to default values if needed.