### PR TITLE
Fix incorrect workflow build command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         run: mvn --batch-mode -P=errorprone clean test install checkstyle:checkstyle pmd:check -Dactions.run.id=$GITHUB_RUN_ID -Dactions.run.number=$GITHUB_RUN_NUMBER
 
       - name: Build the javadocs
-        run: mvn --batch-mode -P=docs -Dmaven.test.skip -DskipTests install antrun:run lombok:delombok javadoc:javadoc javadoc:aggregate
+        run: mvn --batch-mode -P=docs -DskipTests install antrun:run lombok:delombok javadoc:javadoc javadoc:aggregate
         if: github.event_name == 'push' && github.ref == 'refs/heads/release'
 
       - name: Upload AnimatedArchitecture-Spigot


### PR DESCRIPTION
- The Maven command for building the docs included `-Dmaven.test.skip`. Using this flag means the test jars will not be compiled, which will result in compilation failure if they haven't been compiled in a previous run. While this is not necessarily an issue for our CI pipeline right now, it is technically wrong and may give people looking at the ci commands the wrong idea.