### PR TITLE
Improve Locking Strategies

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/storage/sqlite/SQLiteJDBCDriverConnection.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/storage/sqlite/SQLiteJDBCDriverConnection.java
@@ -62,6 +62,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -77,6 +78,9 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      */
     @SuppressWarnings("unused")
     private static final String FAKE_UUID = "0000";
+
+    @SuppressWarnings("unused") // Use by lombok.
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
     /**
      * The database file.
@@ -325,7 +329,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Write
+    @Locked.Write("lock")
     public boolean deleteStructureType(StructureType structureType)
     {
         final boolean removed = executeTransaction(
@@ -341,7 +345,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
         return removed;
     }
 
-    @Locked.Write
+    @Locked.Write("lock")
     private Long insert(
         Connection conn,
         Structure structure,
@@ -403,7 +407,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Write
+    @Locked.Write("lock")
     public Optional<Structure> insert(Structure structure)
     {
         try
@@ -489,7 +493,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Write
+    @Locked.Write("lock")
     public boolean syncStructureData(IStructureConst structure)
     {
         final String serializedProperties = PropertyContainerSerializer.serialize(structure);
@@ -523,7 +527,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public List<DatabaseManager.StructureIdentifier> getPartialIdentifiers(
         String input,
         @Nullable IPlayer player,
@@ -559,7 +563,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
         return executeQuery(query, this::collectIdentifiers, Collections.emptyList());
     }
 
-    @Locked.Read
+    @Locked.Read("lock")
     private List<DatabaseManager.StructureIdentifier> collectIdentifiers(ResultSet resultSet)
         throws SQLException
     {
@@ -587,7 +591,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
         return ret;
     }
 
-    @Locked.Write
+    @Locked.Write("lock")
     private void insertOrIgnorePlayer(Connection conn, PlayerData playerData)
     {
         executeUpdate(
@@ -613,7 +617,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      *     The owner of the structure whose player ID to retrieve.
      * @return The database ID of the player.
      */
-    @Locked.Write
+    @Locked.Write("lock")
     private long getPlayerID(Connection conn, StructureOwner structureOwner)
     {
         insertOrIgnorePlayer(conn, structureOwner.playerData());
@@ -638,7 +642,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      *     "StructureOwnerPlayer" table.
      * @return An instance of a subclass of {@link Structure} if it could be created.
      */
-    @Locked.Read
+    @Locked.Read("lock")
     private Optional<Structure> getStructure(ResultSet structureRS)
         throws Exception
     {
@@ -676,7 +680,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public Optional<Structure> getStructure(long structureUID)
     {
         return executeQuery(
@@ -689,7 +693,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public Optional<Structure> getStructure(UUID playerUUID, long structureUID)
     {
         return executeQuery(
@@ -703,7 +707,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Write
+    @Locked.Write("lock")
     public boolean removeStructure(long structureUID)
     {
         return executeUpdate(SQLStatement.DELETE_STRUCTURE
@@ -712,7 +716,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Write
+    @Locked.Write("lock")
     public boolean removeStructures(UUID playerUUID, String structureName)
     {
         return executeUpdate(SQLStatement.DELETE_NAMED_STRUCTURE_OF_PLAYER
@@ -722,7 +726,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public boolean isAnimatedArchitectureWorld(String worldName)
     {
         return executeQuery(
@@ -735,7 +739,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public int getStructureCountForPlayer(UUID playerUUID)
     {
         return executeQuery(
@@ -748,7 +752,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public int getStructureCountForPlayer(UUID playerUUID, String structureName)
     {
         return executeQuery(
@@ -762,7 +766,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public int getStructureCountByName(String structureName)
     {
         return executeQuery(
@@ -775,7 +779,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public int getOwnerCountOfStructure(long structureUID)
     {
         return executeQuery(
@@ -788,7 +792,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public List<Structure> getStructures(UUID playerUUID, String structureName, PermissionLevel maxPermission)
     {
         return executeQuery(
@@ -803,14 +807,14 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public List<Structure> getStructures(UUID playerUUID, String name)
     {
         return getStructures(playerUUID, name, PermissionLevel.CREATOR);
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public List<Structure> getStructures(String name)
     {
         return executeQuery(
@@ -823,7 +827,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public List<Structure> getStructures(UUID playerUUID, PermissionLevel maxPermission)
     {
         return executeQuery(
@@ -837,14 +841,14 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public List<Structure> getStructures(UUID playerUUID)
     {
         return getStructures(playerUUID, PermissionLevel.CREATOR);
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public List<Structure> getStructuresOfType(String typeName)
     {
         return executeQuery(
@@ -857,7 +861,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public List<Structure> getStructuresOfType(String typeName, int version)
     {
         return executeQuery(
@@ -871,7 +875,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Write
+    @Locked.Write("lock")
     public boolean updatePlayerData(PlayerData playerData)
     {
         return executeUpdate(SQLStatement.UPDATE_PLAYER_DATA
@@ -886,7 +890,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public Optional<PlayerData> getPlayerData(UUID uuid)
     {
         return executeQuery(
@@ -907,7 +911,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public List<PlayerData> getPlayerData(String playerName)
     {
 
@@ -936,7 +940,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public Int2ObjectMap<LongList> getPowerBlockData(long chunkId)
     {
         return executeQuery(
@@ -965,7 +969,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Read
+    @Locked.Read("lock")
     public List<Structure> getStructuresInChunk(long chunkId)
     {
         return executeQuery(
@@ -978,7 +982,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Write
+    @Locked.Write("lock")
     public boolean removeOwner(long structureUID, UUID playerUUID)
     {
         return executeUpdate(SQLStatement.REMOVE_STRUCTURE_OWNER
@@ -987,7 +991,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
             .setLong(2, structureUID)) > 0;
     }
 
-    @Locked.Read
+    @Locked.Read("lock")
     private Map<UUID, StructureOwner> getOwnersOfStructure(long structureUID)
     {
         return executeQuery(
@@ -1027,7 +1031,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
     }
 
     @Override
-    @Locked.Write
+    @Locked.Write("lock")
     public boolean addOwner(long structureUID, PlayerData player, PermissionLevel permission)
     {
         // permission level 0 is reserved for the creator, and negative values are not allowed.
@@ -1086,7 +1090,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      *     The {@link DelayedPreparedStatement}.
      * @return Either the number of rows modified by the update, or -1 if an error occurred.
      */
-    @Locked.Write
+    @Locked.Write("lock")
     private int executeUpdate(DelayedPreparedStatement delayedPreparedStatement)
     {
         try (@Nullable Connection conn = getConnection())
@@ -1115,8 +1119,8 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      *     The {@link DelayedPreparedStatement}.
      * @return Either the number of rows modified by the update, or -1 if an error occurred.
      */
-    @Locked.Write
-    private static int executeUpdate(Connection conn, DelayedPreparedStatement delayedPreparedStatement)
+    @Locked.Write("lock")
+    private int executeUpdate(Connection conn, DelayedPreparedStatement delayedPreparedStatement)
     {
         logStatement(delayedPreparedStatement);
         try (PreparedStatement ps = delayedPreparedStatement.construct(conn))
@@ -1143,7 +1147,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      *     The type of the result to return.
      * @return The {@link ResultSet} of the query, or null in case an error occurred.
      */
-    @Locked.Read
+    @Locked.Read("lock")
     @Contract(" _, _, !null -> !null;")
     private @Nullable <T> T executeQuery(
         DelayedPreparedStatement query,
@@ -1180,7 +1184,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      *     The type of the result to return.
      * @return The {@link ResultSet} of the query, or null in case an error occurred.
      */
-    @Locked.Read
+    @Locked.Read("lock")
     @SuppressWarnings("unused")
     @Contract(" _, _, !null -> !null;")
     private @Nullable <T> T executeBatchQuery(
@@ -1224,7 +1228,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      *     The type of the result to return.
      * @return The {@link ResultSet} of the query, or null in case an error occurred.
      */
-    @Locked.Read
+    @Locked.Read("lock")
     @Contract(" _, _, _, !null -> !null")
     private @Nullable <T> T executeQuery(
         Connection conn,
@@ -1257,7 +1261,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      *     The type of the result to return.
      * @return The result of the Function.
      */
-    @Locked.Read
+    @Locked.Read("lock")
     @SuppressWarnings("unused")
     @Contract(" _, !null  -> !null")
     private @Nullable <T> T execute(CheckedFunction<Connection, T, Exception> fun, @Nullable T fallback)
@@ -1278,7 +1282,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      *     The type of the result to return.
      * @return The result of the Function.
      */
-    @Locked.Read
+    @Locked.Read("lock")
     @Contract(" _, !null, _ -> !null")
     private @Nullable <T> T execute(
         CheckedFunction<Connection, T, Exception> fun,
@@ -1327,7 +1331,7 @@ public final class SQLiteJDBCDriverConnection implements IStorage, IDebuggable
      *     The type of the result to return.
      * @return The result of the Function.
      */
-    @Locked.Read
+    @Locked.Read("lock")
     @Contract(" _, !null -> !null")
     private @Nullable <T> T executeTransaction(CheckedFunction<Connection, T, Exception> fun, @Nullable T fallback)
     {

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/Structure.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/Structure.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.animatedarchitecture.core.structures;
 
+import com.google.common.flogger.LazyArgs;
 import com.google.common.flogger.StackSize;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import dagger.assisted.Assisted;
@@ -717,6 +718,15 @@ public final class Structure implements IStructureConst, IPropertyHolder
             }
             else
             {
+                FutureUtil.logPossibleDeadlockTimeout(
+                    LazyArgs.lazy(() -> String.format(
+                        "Timed out waiting for write lock for structure: %d",
+                        getUid())
+                    ),
+                    timeOutMs,
+                    isMainThread
+                );
+
                 throw new IllegalStateException("Timed out waiting for write lock for structure: " + getUid());
             }
         }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/Structure.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/Structure.java
@@ -15,6 +15,7 @@ import nl.pim16aap2.animatedarchitecture.core.animation.IAnimationComponent;
 import nl.pim16aap2.animatedarchitecture.core.animation.StructureActivityManager;
 import nl.pim16aap2.animatedarchitecture.core.api.IChunkLoader;
 import nl.pim16aap2.animatedarchitecture.core.api.IConfig;
+import nl.pim16aap2.animatedarchitecture.core.api.IExecutor;
 import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
 import nl.pim16aap2.animatedarchitecture.core.api.IRedstoneManager;
 import nl.pim16aap2.animatedarchitecture.core.api.IWorld;
@@ -50,6 +51,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -127,6 +129,9 @@ public final class Structure implements IStructureConst, IPropertyHolder
     private final IStructureComponent component;
 
     @EqualsAndHashCode.Exclude
+    private final IExecutor executor;
+
+    @EqualsAndHashCode.Exclude
     private final IRedstoneManager redstoneManager;
 
     @EqualsAndHashCode.Exclude
@@ -173,6 +178,7 @@ public final class Structure implements IStructureConst, IPropertyHolder
         @Assisted PropertyContainer propertyContainer,
         @Assisted StructureType type,
         @Assisted IStructureComponent component,
+        IExecutor executor,
         DatabaseManager databaseManager,
         StructureToggleHelper structureOpeningHelper,
         StructureAnimationRequestBuilder structureToggleRequestBuilder,
@@ -193,6 +199,7 @@ public final class Structure implements IStructureConst, IPropertyHolder
         this.openDirection = openDirection;
         this.primeOwner = primeOwner;
         this.propertyContainer = propertyContainer;
+        this.executor = executor;
         this.redstoneManager = redstoneManager;
         this.structureActivityManager = structureActivityManager;
         this.chunkLoader = chunkLoader;
@@ -366,7 +373,7 @@ public final class Structure implements IStructureConst, IPropertyHolder
     {
         lazyAnimationRange.reset();
         lazyAnimationCycleDistance.reset();
-        invalidateBasicData();
+        invalidateSnapshot();
     }
 
     /**
@@ -378,7 +385,7 @@ public final class Structure implements IStructureConst, IPropertyHolder
      * <p>
      * If the animation may be affected in any way, use {@link #invalidateAnimationData()} instead.
      */
-    private void invalidateBasicData()
+    private void invalidateSnapshot()
     {
         lazyStructureSnapshot.reset();
     }
@@ -676,15 +683,49 @@ public final class Structure implements IStructureConst, IPropertyHolder
     }
 
     /**
-     * Use {@link #withWriteLock(Supplier)} instead.
+     * @deprecated Use a {@code withWriteLock} method that does not end with {@code 0} instead.
      */
-    @Locked.Write("lock")
+    @Deprecated
     private <T> T withWriteLock0(boolean resetAnimationData, Supplier<T> supplier)
     {
-        final T result = supplier.get();
-        if (resetAnimationData)
-            invalidateAnimationData();
-        return result;
+        final boolean isMainThread = executor.isMainThread();
+
+        // We want to avoid blocking the main thread for too long, so we use a time out of 500ms.
+        // Note that hitting the time-out is not intended behavior and needs additional handling
+        // regardless of the thread. We're just more lenient when it's async.
+        final int timeOutMs = isMainThread ? 500 : 5_000;
+
+        try
+        {
+            // If we're on the main thread, we try to obtain the write lock in a manner
+            // that ignores fairness, as the main thread should always have priority.
+            // If that fails or if we're not on the main thread, we try to obtain the write
+            // lock with a timeout.
+            if ((isMainThread && this.lock.writeLock().tryLock()) ||
+                this.lock.writeLock().tryLock(timeOutMs, TimeUnit.MILLISECONDS))
+            {
+                try
+                {
+                    final T result = supplier.get();
+                    if (resetAnimationData)
+                        invalidateAnimationData();
+                    return result;
+                }
+                finally
+                {
+                    this.lock.writeLock().unlock();
+                }
+            }
+            else
+            {
+                throw new IllegalStateException("Timed out waiting for write lock for structure: " + getUid());
+            }
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while trying to obtain write lock for structure: " + getUid());
+        }
     }
 
     /**
@@ -703,24 +744,26 @@ public final class Structure implements IStructureConst, IPropertyHolder
     public <T> T withWriteLock(Supplier<T> supplier)
     {
         assertWriteLockable();
+        //noinspection deprecation
         return withWriteLock0(true, supplier);
     }
 
-    /**
-     * Use {@link #withWriteLock(Runnable)} instead.
-     */
-    @Locked.Write("lock")
-    private void withWriteLock0(boolean resetAnimationData, Runnable runnable)
+    public <T> T withWriteLock(boolean resetAnimationData, Supplier<T> supplier)
     {
-        runnable.run();
-        if (resetAnimationData)
-            invalidateAnimationData();
+        assertWriteLockable();
+        //noinspection deprecation
+        return withWriteLock0(resetAnimationData, supplier);
     }
 
     private void withWriteLock(boolean resetAnimationData, Runnable runnable)
     {
         assertWriteLockable();
-        withWriteLock0(resetAnimationData, runnable);
+        //noinspection deprecation
+        withWriteLock0(resetAnimationData, () ->
+        {
+            runnable.run();
+            return null;
+        });
     }
 
     /**
@@ -841,13 +884,6 @@ public final class Structure implements IStructureConst, IPropertyHolder
             });
     }
 
-    @Locked.Write("lock")
-    private void setPowerBlock0(Vector3Di pos)
-    {
-        invalidateBasicData();
-        powerBlock = pos;
-    }
-
     /**
      * Updates the position of the powerblock.
      *
@@ -856,10 +892,12 @@ public final class Structure implements IStructureConst, IPropertyHolder
      */
     public void setPowerBlock(Vector3Di pos)
     {
-        // TODO: Use nicer system than 0().
-        assertWriteLockable();
-        setPowerBlock0(pos);
-        verifyRedstoneState();
+        withWriteLock(false, () ->
+        {
+            invalidateSnapshot();
+            powerBlock = pos;
+            verifyRedstoneState();
+        });
     }
 
     /**
@@ -875,7 +913,7 @@ public final class Structure implements IStructureConst, IPropertyHolder
             () ->
             {
                 this.name = name;
-                invalidateBasicData();
+                invalidateSnapshot();
             });
     }
 
@@ -899,13 +937,6 @@ public final class Structure implements IStructureConst, IPropertyHolder
             });
     }
 
-    @Locked.Write("lock")
-    private void setLocked0(boolean locked)
-    {
-        isLocked = locked;
-        invalidateBasicData();
-    }
-
     /**
      * Changes the lock status of this structure. Locked structures cannot be opened.
      *
@@ -914,28 +945,16 @@ public final class Structure implements IStructureConst, IPropertyHolder
      */
     public void setLocked(boolean locked)
     {
-        assertWriteLockable();
-        setLocked0(locked);
-        verifyRedstoneState();
-    }
-
-    @Locked.Write("lock")
-    private @Nullable StructureOwner removeOwner0(UUID ownerUUID)
-    {
-        if (primeOwner.playerData().getUUID().equals(ownerUUID))
+        withWriteLock(false, () ->
         {
-            log.atSevere().withStackTrace(StackSize.FULL).log(
-                "Failed to remove owner: '%s' as owner from structure: '%d'" +
-                    " because removing an owner with a permission level of 0 is not allowed!",
-                primeOwner.playerData(),
-                this.getUid()
-            );
-            return null;
-        }
-        final @Nullable StructureOwner removed = owners.remove(ownerUUID);
-        if (removed != null)
-            invalidateBasicData();
-        return removed;
+            isLocked = locked;
+            invalidateSnapshot();
+
+            if (!locked)
+                // Now that we're unlocked, we should verify the redstone state.
+                // We schedule this to happen later to avoid running it under a write lock.
+                executor.runAsyncLater(this::verifyRedstoneState, 1);
+        });
     }
 
     /**
@@ -953,25 +972,23 @@ public final class Structure implements IStructureConst, IPropertyHolder
      */
     @Nullable StructureOwner removeOwner(UUID ownerUUID)
     {
-        assertWriteLockable();
-        return removeOwner0(ownerUUID);
-    }
-
-    @Locked.Write("lock")
-    private boolean addOwner0(StructureOwner structureOwner)
-    {
-        if (structureOwner.permission() == PermissionLevel.CREATOR)
+        return withWriteLock(false, () ->
         {
-            log.atSevere().withStackTrace(StackSize.FULL).log(
-                "Failed to add Owner '%s' as owner to structure: %d because a permission level of 0 is not allowed!",
-                structureOwner.playerData(),
-                this.getUid()
-            );
-            return false;
-        }
-        owners.put(structureOwner.playerData().getUUID(), structureOwner);
-        invalidateBasicData();
-        return true;
+            if (primeOwner.playerData().getUUID().equals(ownerUUID))
+            {
+                log.atSevere().withStackTrace(StackSize.FULL).log(
+                    "Failed to remove owner: '%s' as owner from structure: '%d'" +
+                        " because removing an owner with a permission level of 0 is not allowed!",
+                    primeOwner.playerData(),
+                    this.getUid()
+                );
+                return null;
+            }
+            final @Nullable StructureOwner removed = owners.remove(ownerUUID);
+            if (removed != null)
+                invalidateSnapshot();
+            return removed;
+        });
     }
 
     /**
@@ -991,8 +1008,21 @@ public final class Structure implements IStructureConst, IPropertyHolder
      */
     boolean addOwner(StructureOwner structureOwner)
     {
-        assertWriteLockable();
-        return addOwner0(structureOwner);
+        return withWriteLock(false, () ->
+        {
+            if (structureOwner.permission() == PermissionLevel.CREATOR)
+            {
+                log.atSevere().withStackTrace(StackSize.FULL).log(
+                    "Failed to add Owner '%s' as owner to structure: %d because a permission level of 0 is not allowed!",
+                    structureOwner.playerData(),
+                    this.getUid()
+                );
+                return false;
+            }
+            owners.put(structureOwner.playerData().getUUID(), structureOwner);
+            invalidateSnapshot();
+            return true;
+        });
     }
 
     /**
@@ -1042,12 +1072,14 @@ public final class Structure implements IStructureConst, IPropertyHolder
         return setPropertyValue0(property, value);
     }
 
-    @Locked.Write("lock")
     private <T> IPropertyValue<T> setPropertyValue0(Property<T> property, @Nullable T value)
     {
-        final var ret = propertyContainer.setPropertyValue(property, value);
-        handlePropertyChange(property);
-        return ret;
+        return withWriteLock(false, () ->
+        {
+            final var ret = propertyContainer.setPropertyValue(property, value);
+            handlePropertyChange(property);
+            return ret;
+        });
     }
 
     /**
@@ -1063,7 +1095,7 @@ public final class Structure implements IStructureConst, IPropertyHolder
     {
         lazyPropertyContainerSnapshot.reset();
         property.getPropertyScopes().forEach(this::handlePropertyScopeChange);
-        invalidateBasicData();
+        invalidateSnapshot();
     }
 
     /**

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/Structure.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/Structure.java
@@ -73,8 +73,7 @@ public final class Structure implements IStructureConst, IPropertyHolder
     private static final double DEFAULT_ANIMATION_SPEED = 1.5D;
 
     @EqualsAndHashCode.Exclude
-    @Getter(AccessLevel.PACKAGE)
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
     @Getter
     private final long uid;
@@ -721,10 +720,13 @@ public final class Structure implements IStructureConst, IPropertyHolder
                 throw new IllegalStateException("Timed out waiting for write lock for structure: " + getUid());
             }
         }
-        catch (InterruptedException e)
+        catch (InterruptedException ex)
         {
             Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted while trying to obtain write lock for structure: " + getUid());
+            throw new IllegalStateException(
+                "Interrupted while trying to obtain write lock for structure: " + getUid(),
+                ex
+            );
         }
     }
 
@@ -1013,7 +1015,8 @@ public final class Structure implements IStructureConst, IPropertyHolder
             if (structureOwner.permission() == PermissionLevel.CREATOR)
             {
                 log.atSevere().withStackTrace(StackSize.FULL).log(
-                    "Failed to add Owner '%s' as owner to structure: %d because a permission level of 0 is not allowed!",
+                    "Failed to add Owner '%s' as owner to structure: " +
+                        "%d because a permission level of 0 is not allowed!",
                     structureOwner.playerData(),
                     this.getUid()
                 );

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/retriever/StructureFinder.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/structures/retriever/StructureFinder.java
@@ -12,8 +12,8 @@ import nl.pim16aap2.animatedarchitecture.core.api.IPlayer;
 import nl.pim16aap2.animatedarchitecture.core.commands.ICommandSender;
 import nl.pim16aap2.animatedarchitecture.core.data.cache.RollingCache;
 import nl.pim16aap2.animatedarchitecture.core.managers.DatabaseManager;
-import nl.pim16aap2.animatedarchitecture.core.structures.Structure;
 import nl.pim16aap2.animatedarchitecture.core.structures.PermissionLevel;
+import nl.pim16aap2.animatedarchitecture.core.structures.Structure;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
 import nl.pim16aap2.animatedarchitecture.core.structures.properties.Property;
 import nl.pim16aap2.animatedarchitecture.core.util.CollectionsUtil;
@@ -85,7 +85,7 @@ public final class StructureFinder
     /**
      * The lock used to synchronize access to the cache and other fields.
      */
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
     /**
      * The factory used to create structure retrievers when converting the results of the search to structures.
@@ -404,8 +404,7 @@ public final class StructureFinder
     }
 
     /**
-     * Gets all structures that have been found using the given search parameters as a list of
-     * {@link Structure}s.
+     * Gets all structures that have been found using the given search parameters as a list of {@link Structure}s.
      *
      * @param fullMatch
      *     When true, only the entries that have a complete match are returned. E.g. for an input of "door", "door"

--- a/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/extensions/StructureTypeLoaderIntegrationTest.java
+++ b/animatedarchitecture-testing/animatedarchitecture-integration-test/src/test/java/nl/pim16aap2/animatedarchitecture/extensions/StructureTypeLoaderIntegrationTest.java
@@ -45,7 +45,11 @@ class StructureTypeLoaderIntegrationTest
         final int jarCount =
             Objects.requireNonNull(extensionsPath.toFile().list((dir, name) -> name.endsWith(".jar"))).length;
 
-        Assertions.assertEquals(9, jarCount);
+        Assertions.assertEquals(
+            9,
+            jarCount,
+            "Expected 9 jar files, but found " + jarCount + " in directory " + extensionsPath.toAbsolutePath()
+        );
 
         final var structureTypeLoader = new StructureTypeLoader(
             restartableHolder,


### PR DESCRIPTION
This PR aims to improve the locking strategies in several ways. The main focus was on the Structure class.

## Use Fair Locking
We changed the locking strategy from unfair to fair in the following classes:
- Structure
- SQLiteJDBCDriverConnection
- StructureFinder

This will reduce throughput somewhat, but I do not expect our classes to be under heavy enough use for that to matter.

This was changed to prevent writer starvation, where no write lock can be obtained due to the constant read locks.

## Prioritize Main Thread
When trying to obtain a write lock for a structure on the main thread, we try to bypass the fairness entirely and grab one immediately, if possible. This may cause starvation issues when hammering write locks on the main thread, but that would indicate other problems.

## Try to detect deadlocks and recover before taking down the entire server.
Obtaining a write lock when you shouldn't may result in a deadlock. Alternatively, it may simply take a long time to obtain one.

To avoid issues with this, we now try to detect such issues by obtaining a write lock using the `tryLock(long, TimeUnit)` method. We use a timeout of 500ms on the main thread, and 5s on other threads.
If we time out waiting for a lock, we dump all threads and their stacktraces to the log, so we can figure out what happened and how to make sure it won't happen again.


## Reduce time spent under locks.
We moved some locks around in the Structure class to spend less time under locks (read locks, mostly). This should help reduce time wasted waiting for locks to become available.