### PR TITLE
Improve Extension Packaging

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/NamespacedKey.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/api/NamespacedKey.java
@@ -3,6 +3,7 @@ package nl.pim16aap2.animatedarchitecture.core.api;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import nl.pim16aap2.animatedarchitecture.core.exceptions.InvalidNameSpacedKeyException;
 import nl.pim16aap2.animatedarchitecture.core.util.Constants;
 
 import javax.annotation.Nullable;
@@ -58,6 +59,8 @@ public final class NamespacedKey
      *     The namespace of the key.
      * @param name
      *     The name of the key.
+     * @throws InvalidNameSpacedKeyException
+     *     If either the namespace or name is null or does not match the regex rule.
      */
     public NamespacedKey(String namespace, String name)
     {
@@ -79,6 +82,9 @@ public final class NamespacedKey
      * @param input
      *     The input to create the {@link NamespacedKey} from.
      * @return The created {@link NamespacedKey}.
+     *
+     * @throws InvalidNameSpacedKeyException
+     *     If either the namespace or name is null or does not match the regex rule.
      */
     public static NamespacedKey of(String input)
     {
@@ -100,17 +106,22 @@ public final class NamespacedKey
      *     The String to test.
      * @return The test String in lowercase if it is valid.
      *
-     * @throws IllegalArgumentException
+     * @throws InvalidNameSpacedKeyException
      *     If the test is null or does not match the regex rule.
      */
     static String verify(String title, @Nullable String test)
     {
         if (test == null)
-            throw new IllegalArgumentException(title + " cannot be null.");
+            throw new InvalidNameSpacedKeyException(title + " cannot be null.");
 
         final String testLower = test.toLowerCase(Locale.ROOT);
         if (!PATTERN.matcher(testLower).matches())
-            throw new IllegalArgumentException(title + " must match the regex rule: " + PATTERN + ". Found: " + test);
+            throw InvalidNameSpacedKeyException.format(
+                "%s must match the regex rule: %s. Found: %s",
+                title,
+                PATTERN,
+                test
+            );
         return testLower;
     }
 }

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/exceptions/InvalidNameSpacedKeyException.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/exceptions/InvalidNameSpacedKeyException.java
@@ -1,0 +1,49 @@
+package nl.pim16aap2.animatedarchitecture.core.exceptions;
+
+import nl.pim16aap2.animatedarchitecture.core.api.NamespacedKey;
+
+/**
+ * Thrown when a {@link NamespacedKey} is invalid.
+ */
+public class InvalidNameSpacedKeyException extends RuntimeException
+{
+    /**
+     * Creates a new {@link InvalidNameSpacedKeyException} with the given message.
+     *
+     * @param message
+     *     The message of the exception.
+     */
+    public InvalidNameSpacedKeyException(String message)
+    {
+        super(message);
+    }
+
+    /**
+     * Creates a new {@link InvalidNameSpacedKeyException} with the given message and cause.
+     *
+     * @param message
+     *     The message of the exception.
+     * @param cause
+     *     The cause of the exception.
+     */
+    public InvalidNameSpacedKeyException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    /**
+     * Formats the message with the given arguments.
+     * <p>
+     * This method is a shortcut for {@link String#format(String, Object...)}.
+     *
+     * @param message
+     *     The message to format.
+     * @param args
+     *     The arguments to format the message with.
+     * @return The formatted exception.
+     */
+    public static InvalidNameSpacedKeyException format(String message, Object... args)
+    {
+        return new InvalidNameSpacedKeyException(String.format(message, args));
+    }
+}

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/exceptions/package-info.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/exceptions/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Contains our custom exceptions.
+ */
+@NonNullByDefault
+package nl.pim16aap2.animatedarchitecture.core.exceptions;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfo.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfo.java
@@ -5,6 +5,7 @@ import lombok.ToString;
 import lombok.extern.flogger.Flogger;
 import nl.pim16aap2.animatedarchitecture.core.api.IKeyed;
 import nl.pim16aap2.animatedarchitecture.core.api.NamespacedKey;
+import nl.pim16aap2.animatedarchitecture.core.exceptions.InvalidNameSpacedKeyException;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
 import nl.pim16aap2.animatedarchitecture.core.util.MathUtil;
 import org.jetbrains.annotations.Nullable;
@@ -281,6 +282,8 @@ final class StructureTypeInfo implements IKeyed
          *     The maximum version of the dependency. Inclusive.
          *     <p>
          *     Must be larger than {@code minVersion}.
+         * @throws InvalidNameSpacedKeyException
+         *     If the key is invalid.
          */
         Dependency(String key, int minVersion, int maxVersion)
         {

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/api/NamespacedKeyTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/api/NamespacedKeyTest.java
@@ -1,5 +1,6 @@
 package nl.pim16aap2.animatedarchitecture.core.api;
 
+import nl.pim16aap2.animatedarchitecture.core.exceptions.InvalidNameSpacedKeyException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -41,8 +42,8 @@ class NamespacedKeyTest
     @Test
     public void testNullNamespace()
     {
-        final IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
+        final InvalidNameSpacedKeyException exception = assertThrows(
+            InvalidNameSpacedKeyException.class,
             () -> new NamespacedKey(null, "name")
         );
         assertEquals("Namespace cannot be null.", exception.getMessage());
@@ -51,8 +52,8 @@ class NamespacedKeyTest
     @Test
     public void testNullName()
     {
-        final IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
+        final InvalidNameSpacedKeyException exception = assertThrows(
+            InvalidNameSpacedKeyException.class,
             () -> new NamespacedKey("owner", null)
         );
         assertEquals("Name cannot be null.", exception.getMessage());
@@ -61,8 +62,8 @@ class NamespacedKeyTest
     @Test
     public void testInvalidCharactersInNamespace()
     {
-        final IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
+        final InvalidNameSpacedKeyException exception = assertThrows(
+            InvalidNameSpacedKeyException.class,
             () -> new NamespacedKey("Owner!", "name")
         );
         assertEquals("Namespace must match the regex rule: ^[a-z0-9_-]+$. Found: Owner!", exception.getMessage());
@@ -71,8 +72,8 @@ class NamespacedKeyTest
     @Test
     public void testInvalidCharactersInName()
     {
-        final IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
+        final InvalidNameSpacedKeyException exception = assertThrows(
+            InvalidNameSpacedKeyException.class,
             () -> new NamespacedKey("owner", "Name!")
         );
         assertEquals("Name must match the regex rule: ^[a-z0-9_-]+$. Found: Name!", exception.getMessage());

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfoTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeInfoTest.java
@@ -1,6 +1,7 @@
 package nl.pim16aap2.animatedarchitecture.core.extensions;
 
 import nl.pim16aap2.animatedarchitecture.core.api.NamespacedKey;
+import nl.pim16aap2.animatedarchitecture.core.exceptions.InvalidNameSpacedKeyException;
 import nl.pim16aap2.animatedarchitecture.core.structures.StructureType;
 import nl.pim16aap2.animatedarchitecture.core.util.Constants;
 import org.jetbrains.annotations.Nullable;
@@ -188,8 +189,8 @@ class StructureTypeInfoTest
     @Test
     void testInvalidNameDependencyConstructor()
     {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Dependency("", 1, 1));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Dependency(" ", 1, 1));
+        Assertions.assertThrows(InvalidNameSpacedKeyException.class, () -> new Dependency("", 1, 1));
+        Assertions.assertThrows(InvalidNameSpacedKeyException.class, () -> new Dependency(" ", 1, 1));
     }
 
     @Test

--- a/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoaderTest.java
+++ b/animatedarchitecture-core/src/test/java/nl/pim16aap2/animatedarchitecture/core/extensions/StructureTypeLoaderTest.java
@@ -136,9 +136,9 @@ class StructureTypeLoaderTest
         final var file = Paths.get("/does/not/exist.jar");
         final var structureTypeInfoOpt = StructureTypeLoader.getStructureTypeInfo("EntryTitle", file, manifest);
 
-        Assertions.assertTrue(structureTypeInfoOpt.isPresent());
-
-        final var structureTypeInfo = structureTypeInfoOpt.get();
+        Assertions.assertTrue(structureTypeInfoOpt.isSuccessful());
+        final var structureTypeInfo = structureTypeInfoOpt.structureTypeInfo();
+        Assertions.assertNotNull(structureTypeInfo);
 
         Assertions.assertEquals(key, structureTypeInfo.getNamespacedKey());
         Assertions.assertEquals(1, structureTypeInfo.getVersion());
@@ -150,9 +150,9 @@ class StructureTypeLoaderTest
             structureTypeInfo.getDependencies()
         );
 
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> StructureTypeLoader.getStructureTypeInfo("EntryTitle", file, new Manifest())
+        Assertions.assertEquals(
+            StructureTypeLoader.StructureTypeInfoParseResult.NO_ATTRIBUTES,
+            StructureTypeLoader.getStructureTypeInfo("EntryTitle", file, new Manifest()).parseResult()
         );
     }
 }


### PR DESCRIPTION
- We improved logging around invalid extensions a bit. Instead of dumping stacktraces, we log the reason + context.
- We automatically remove the old legacy extension jars. The automatically-extracted ones use a new naming scheme, so extracting them from the jar doesn't automatically overwrite them. Leaving the old ones around is only going to be confusing for admins updating from an older version.