### PR TITLE
Fix animation region for negative values

### DIFF
--- a/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimationRegion.java
+++ b/animatedarchitecture-core/src/main/java/nl/pim16aap2/animatedarchitecture/core/animation/AnimationRegion.java
@@ -100,9 +100,9 @@ public final class AnimationRegion
         double yMin = Double.MAX_VALUE;
         double zMin = Double.MAX_VALUE;
 
-        double xMax = Double.MIN_VALUE;
-        double yMax = Double.MIN_VALUE;
-        double zMax = Double.MIN_VALUE;
+        double xMax = -Double.MAX_VALUE;
+        double yMax = -Double.MAX_VALUE;
+        double zMax = -Double.MAX_VALUE;
 
         for (final IAnimatedBlock animatedBlock : blocks)
         {
@@ -113,17 +113,17 @@ public final class AnimationRegion
 
             if (x < xMin)
                 xMin = pos.x();
-            else if (x > xMax)
+            if (x > xMax)
                 xMax = pos.x();
 
             if (y < yMin)
                 yMin = pos.y();
-            else if (y > yMax)
+            if (y > yMax)
                 yMax = pos.y();
 
             if (z < zMin)
                 zMin = pos.z();
-            else if (z > zMax)
+            if (z > zMax)
                 zMax = pos.z();
         }
 


### PR DESCRIPTION
Fixes #1009 

Apparently, `Double.MIN_VALUE` returns the lowest possible _non-negative_ value, unlike `Integer.MIN_VALUE`, which returns the lowest possible value, which is negative.

We used the MIN_VALUE as a placeholder for the highest value in a region (as any value would be higher than that). As a result, the animation region could not be calculated correctly for negative values, which would set the maximum value to near zero for any negative input. Using `-Double.MAX_VALUE` instead fixes this issue.

All of this caused issues with the audio because we play the sounds at the center of the animation region.